### PR TITLE
Fix text transform examples

### DIFF
--- a/packages/www/src/documentation/components/text/headings.mdx
+++ b/packages/www/src/documentation/components/text/headings.mdx
@@ -59,7 +59,7 @@ Another common pattern for headings is to control the font-weight and the text-t
 <Heading fontWeight="semiBold" textTransform="upper">
   Semi-bold and upper
 </Heading>
-<Heading fontWeight="bold" textTransform="caps">
+<Heading fontWeight="bold" textTransform="capitalize">
   Bold and caps
 </Heading>
 ```

--- a/packages/www/src/documentation/components/text/text.mdx
+++ b/packages/www/src/documentation/components/text/text.mdx
@@ -34,7 +34,7 @@ Common patterns for text is to adjust the font weight and transform the text. Be
     <Text fontSize="xxxxlarge" fontWeight="light">
       This is a great headline
     </Text>
-    <Text fontSize="small" textTransform="caps">
+    <Text fontSize="small" textTransform="capitalize">
       Some metadata about this story
     </Text>
 ```

--- a/packages/www/src/documentation/getting-started/index.mdx
+++ b/packages/www/src/documentation/getting-started/index.mdx
@@ -24,7 +24,7 @@ Which renders the following:
 ```jsx
 <Card raised>
   <CardContent>
-    <Heading fontWeight="semiBold" textTransform="caps">
+    <Heading fontWeight="semiBold" textTransform="capitalize">
       Welcome to Looker Components
     </Heading>
     <Text>Looker's component library</Text>


### PR DESCRIPTION
converts all instances of `textTransform="caps"` to `textTransform="capitalize"`

<img width="848" alt="Screen Shot 2019-11-05 at 3 48 07 PM" src="https://user-images.githubusercontent.com/238293/68256053-d81dc700-ffe3-11e9-8f77-e5067783474f.png">
