### PR TITLE
Set default toggle size

### DIFF
--- a/packages/www/src/Layout/SidebarToggle/SidebarToggle.tsx
+++ b/packages/www/src/Layout/SidebarToggle/SidebarToggle.tsx
@@ -39,7 +39,7 @@ const SidebarToggle: FC<SidebarToggleProps> = ({
   onClick,
   headerHeight,
 }) => {
-  const [buttonWidth, setButtonWidth] = useState(0)
+  const [buttonWidth, setButtonWidth] = useState(28)
   const iconName: IconNames = isOpen ? 'CaretLeft' : 'CaretRight'
 
   const measuredRef = useCallback(node => {


### PR DESCRIPTION
Sets a sane toggle button default size to prevent this unfortunate position jump that happens on load in production:
![toggle-jump](https://user-images.githubusercontent.com/238293/68256563-68a8d700-ffe5-11e9-96c3-5a615b3ef84a.gif)
