### PR TITLE
Fix on prop bleeding to dom in ToggleSwitch

### DIFF
--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -175,11 +175,9 @@ exports[`A FieldToggleSwitch 1`] = `
         />
         <div
           className="c8"
-          size={20}
         >
           <div
             className="c9"
-            size={20}
           />
         </div>
       </div>
@@ -373,13 +371,9 @@ exports[`A FieldToggleSwitch turned on 1`] = `
         />
         <div
           className="c8"
-          on={true}
-          size={20}
         >
           <div
             className="c9"
-            on={true}
-            size={20}
           />
         </div>
       </div>
@@ -564,11 +558,9 @@ exports[`A FieldToggleSwitch with label aligned left 1`] = `
         />
         <div
           className="c8"
-          size={20}
         >
           <div
             className="c9"
-            size={20}
           />
         </div>
       </div>

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
@@ -60,6 +60,10 @@ export interface KnobProps {
   on?: boolean
 }
 
+interface KnobContainerBaseProps extends KnobProps, PseudoProps {
+  children: ReactNode
+}
+
 export interface ToggleSwitchProps
   extends SpaceProps,
     Omit<InputProps, 'type'>,
@@ -99,14 +103,9 @@ const KnobContainer: FC<KnobProps> = ({ className, ...props }) => {
   )
 }
 
-const KnobContainerBase = styled(
-  ({
-    children,
-    className,
-  }: KnobProps & PseudoProps & { children: ReactNode }) => (
-    <div className={className}>{children}</div>
-  )
-)`
+const KnobContainerBase = styled(({ children, className }) => (
+  <div className={className}>{children}</div>
+))<KnobContainerBaseProps>`
   ${reset}
   ${pseudoClasses}
 

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
@@ -25,7 +25,7 @@
  */
 
 import { rem, rgba } from 'polished'
-import React, { forwardRef, Ref } from 'react'
+import React, { forwardRef, Ref, ReactNode, FC } from 'react'
 import styled from 'styled-components'
 import {
   CustomizableAttributes,
@@ -67,7 +67,7 @@ export interface ToggleSwitchProps
   size?: number
 }
 
-const Knob = styled.div<KnobProps>`
+const Knob = styled(({ className }) => <div className={className} />)`
   transform: ${props =>
     props.on ? `translateX(${rem(props.size * 0.75)})` : ''};
   transition: ${props => props.theme.transitions.durationModerate};
@@ -83,26 +83,30 @@ const Knob = styled.div<KnobProps>`
       : CustomizableToggleSwitchAttributes.knobOffColor};
 `
 
-const KnobContainer = forwardRef(
-  ({ className, ...props }: KnobProps, ref: Ref<HTMLDivElement>) => {
-    const hoverStyle = props.disabled
-      ? undefined
-      : { boxShadow: `0 0 .01rem 0.01rem ${rgba(palette.primary500, 0.5)}` }
-    return (
-      <KnobContainerBase
-        className={className}
-        hoverStyle={hoverStyle}
-        size={props.size}
-        on={props.on}
-        ref={ref}
-      >
-        <Knob {...props} />
-      </KnobContainerBase>
-    )
-  }
-)
+const KnobContainer: FC<KnobProps> = ({ className, ...props }) => {
+  const hoverStyle = props.disabled
+    ? undefined
+    : { boxShadow: `0 0 .01rem 0.01rem ${rgba(palette.primary500, 0.5)}` }
+  return (
+    <KnobContainerBase
+      className={className}
+      hoverStyle={hoverStyle}
+      size={props.size}
+      on={props.on}
+    >
+      <Knob {...props} />
+    </KnobContainerBase>
+  )
+}
 
-const KnobContainerBase = styled.div<KnobProps & PseudoProps>`
+const KnobContainerBase = styled(
+  ({
+    children,
+    className,
+  }: KnobProps & PseudoProps & { children: ReactNode }) => (
+    <div className={className}>{children}</div>
+  )
+)`
   ${reset}
   ${pseudoClasses}
 

--- a/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -79,11 +79,9 @@ exports[`Big ToggleSwitch 1`] = `
   />
   <div
     className="c2"
-    size={60}
   >
     <div
       className="c3"
-      size={60}
     />
   </div>
 </div>
@@ -168,11 +166,9 @@ exports[`ToggleSwitch default 1`] = `
   />
   <div
     className="c2"
-    size={20}
   >
     <div
       className="c3"
-      size={20}
     />
   </div>
 </div>
@@ -259,13 +255,9 @@ exports[`ToggleSwitch on set to false 1`] = `
   />
   <div
     className="c2"
-    on={false}
-    size={20}
   >
     <div
       className="c3"
-      on={false}
-      size={20}
     />
   </div>
 </div>
@@ -355,13 +347,9 @@ exports[`ToggleSwitch on set to true 1`] = `
   />
   <div
     className="c2"
-    on={true}
-    size={20}
   >
     <div
       className="c3"
-      on={true}
-      size={20}
     />
   </div>
 </div>
@@ -462,14 +450,9 @@ exports[`ToggleSwitch that is disabled 1`] = `
   />
   <div
     className="c2"
-    on={true}
-    size={20}
   >
     <div
       className="c3"
-      disabled={true}
-      on={true}
-      size={20}
     />
   </div>
   <div


### PR DESCRIPTION
`<div on={true}` causes a React warning. This solution isn't elegant but it works and I couldn't find any better inspiration in https://github.com/styled-components/styled-components/issues/135

The other props like `size` and `disabled` weren't causing breakage but I filtered those as well since they have no place on a `<div/>`.