### PR TITLE
fix FieldColor onChange

### DIFF
--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
@@ -71,3 +71,16 @@ test('FieldColor with a validation message', () => {
   const { queryByText } = renderWithTheme(<FieldColorValidationMessage />)
   expect(queryByText('Error!')).toBeInTheDocument()
 })
+
+test('FieldColor with an onChange', () => {
+  const onChangeMock = jest.fn()
+  const { getByLabelText } = renderWithTheme(
+    <FieldColor onChange={onChangeMock} label="Background Color" />
+  )
+  const input = getByLabelText('Background Color')
+  fireEvent.change(input, { target: { value: '#FFFF00' } })
+  expect(onChangeMock).toHaveBeenCalledWith({
+    currentTarget: { value: '#ffff00' },
+    target: { value: '#ffff00' },
+  })
+})

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
@@ -93,15 +93,15 @@ export const FieldColorComponent = forwardRef(
     const [color, setColor] = useState<SimpleHSV>(initialValue)
     const [inputTextValue, setInputTextValue] = useState(props.value || '')
 
-    const callOnChange = () => {
-      if (!props.onChange || !color) return
-      props.onChange(createEventWithHSVValue(color))
+    const callOnChange = (newColor: SimpleHSV) => {
+      if (!props.onChange || !newColor) return
+      props.onChange(createEventWithHSVValue(newColor))
     }
 
     const setColorState = (newColor: SimpleHSV) => {
       setColor(newColor)
       newColor && setInputTextValue(simpleHSVtoFormattedColorString(newColor))
-      callOnChange()
+      callOnChange(newColor)
     }
 
     const handleColorChange = (hs: HueSaturation) =>
@@ -118,9 +118,9 @@ export const FieldColorComponent = forwardRef(
       setInputTextValue(value)
 
       if (!value || !isValidColor(value)) return
-
-      setColor(str2simpleHsv(value))
-      callOnChange()
+      const newColor = str2simpleHsv(value)
+      setColor(newColor)
+      callOnChange(newColor)
     }
 
     const content = (


### PR DESCRIPTION
### :sparkles: Changes

- Added `newColor` as an argument to `callOnChange` since using the `color` state is unreliable (state is asynchronous)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [-] Link(s) to related Github issues

### :camera: Screenshots
