### PR TITLE
Fix focus trap issues

### DIFF
--- a/packages/components/src/Modal/ModalSurface.tsx
+++ b/packages/components/src/Modal/ModalSurface.tsx
@@ -24,8 +24,8 @@
 
  */
 
-import { CompatibleHTMLProps, reset } from '@looker/design-tokens'
-import React, { FC, useContext } from 'react'
+import { CompatibleHTMLProps, reset, theme } from '@looker/design-tokens'
+import React, { FC, useContext, useEffect, useState } from 'react'
 import { HotKeys } from 'react-hotkeys'
 import styled, { CSSObject, css } from 'styled-components'
 import {
@@ -38,7 +38,7 @@ import {
   LayoutProps,
   layout,
 } from 'styled-system'
-import { useFocusTrap } from '../Overlay/useFocusTrap.hook'
+import { useFocusTrap } from '../utils'
 import { ModalContext } from './ModalContext'
 
 export interface ModalSurfaceProps
@@ -59,7 +59,14 @@ export const ModalSurface: FC<ModalSurfaceProps> = ({
   ...props
 }) => {
   const { closeModal } = useContext(ModalContext)
-  const focusRef = useFocusTrap()
+  const [focusTrapEnabled, setFocusTrapEnabled] = useState(false)
+  const focusRef = useFocusTrap(focusTrapEnabled)
+
+  useEffect(() => {
+    window.setTimeout(() => {
+      setFocusTrapEnabled(true)
+    }, theme.transitions.durationModerate)
+  }, [])
 
   return (
     <HotKeys

--- a/packages/components/src/Overlay/OverlaySurface.tsx
+++ b/packages/components/src/Overlay/OverlaySurface.tsx
@@ -47,7 +47,6 @@ import { PopperArrowProps } from 'react-popper'
 import styled from 'styled-components'
 import { ModalContext } from '../Modal'
 import { OverlaySurfaceArrow } from './OverlaySurfaceArrow'
-import { useFocusTrap } from './useFocusTrap.hook'
 
 export interface SurfaceStyleProps extends BorderProps, BoxShadowProps {
   color?: string
@@ -79,7 +78,6 @@ export const OverlaySurface = forwardRef(
       ...innerProps
     } = props
     const { closeModal } = useContext(ModalContext)
-    const focusRef = useFocusTrap()
     // workaround for react-popper -caused error:
     // `NaN` is an invalid value for the `left` css style property
     if (Number.isNaN(arrowProps.style.left as number)) {
@@ -90,7 +88,13 @@ export const OverlaySurface = forwardRef(
     }
 
     return (
-      <Outer ref={ref} zIndex={zIndex} style={style} {...eventHandlers}>
+      <Outer
+        ref={ref}
+        zIndex={zIndex}
+        style={style}
+        {...eventHandlers}
+        tabIndex={-1}
+      >
         <HotKeys
           keyMap={{
             CLOSE_MODAL: {
@@ -105,7 +109,7 @@ export const OverlaySurface = forwardRef(
             },
           }}
         >
-          <Inner {...innerProps} tabIndex={-1} ref={focusRef}>
+          <Inner {...innerProps}>
             {children}
             {arrow !== false && (
               <OverlaySurfaceArrow

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,7 +38,7 @@ import { Box } from '../Layout'
 import { ModalContext } from '../Modal'
 import { ModalPortal } from '../Modal/ModalPortal'
 import { OverlaySurface } from '../Overlay/OverlaySurface'
-import { useControlWarn } from '../utils'
+import { useControlWarn, useFocusTrap } from '../utils'
 
 export interface UsePopoverProps {
   /**
@@ -271,6 +271,7 @@ export function usePopover({
 }: UsePopoverProps) {
   const portalRef = useRef<HTMLDivElement | null>(null)
   const newTriggerRef = useRef<HTMLElement>(null)
+  const focusRef = useFocusTrap()
 
   const triggerRef = props.triggerRef || newTriggerRef
 
@@ -358,7 +359,10 @@ export function usePopover({
               arrow={arrow}
               arrowProps={arrowProps}
               placement={placement}
-              ref={ref}
+              ref={node => {
+                ref(node)
+                focusRef(node)
+              }}
               style={style}
               backgroundColor="palette.white"
               border="1px solid"

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,4 +26,5 @@
 
 export * from './GlobalStyle'
 export * from './useControlWarn'
+export * from './useFocusTrap'
 export * from './useToggle'

--- a/packages/components/src/utils/useFocusTrap.ts
+++ b/packages/components/src/utils/useFocusTrap.ts
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,7 @@ export interface UseFocusOptions {
 }
 
 export function useFocusTrap(
+  enabled = true,
   escapeDeactivates = false,
   clickOutsideDeactivates = true
 ) {
@@ -40,9 +41,9 @@ export function useFocusTrap(
 
   return useCallback(
     node => {
-      if (!node) {
+      if (!node || !enabled) {
         trap.current && trap.current.deactivate()
-      } else {
+      } else if (node && enabled) {
         const autoFocusElement = node.querySelector(
           '[data-autofocus="true"]'
         ) as HTMLElement
@@ -56,6 +57,6 @@ export function useFocusTrap(
         trap.current.activate()
       }
     },
-    [escapeDeactivates, clickOutsideDeactivates]
+    [enabled, escapeDeactivates, clickOutsideDeactivates]
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- `Toolitp` renders `OverlaySurface` but should not engage a focus-trap. In fact it causes a browser-crashing bug when `Tooltip`, `Popover` and another focus-trapping element such as a `Dialog` are in play, causing the blur/focus events get stuck in a loop. So I moved `useFocusTrap` to `Popover` instead.
- No elements are visible when `ModalSurface` mounts so `focus-trap`/`tabbable` can't find anything to focus on. A delay before enabling `useFocusTrap` fixes this.

### :white_check_mark: Requirements

- [-] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [-] Link(s) to related Github issues

### :camera: Screenshots
