### PR TITLE
Refactor z-index out of menu components

### DIFF
--- a/packages/components/src/Menu/MenuGroupLabel.tsx
+++ b/packages/components/src/Menu/MenuGroupLabel.tsx
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,7 +34,6 @@ export const MenuGroupLabel = styled.div<MenuGroupLabelProps>`
   box-shadow: ${props => props.boxShadow};
   position: sticky;
   top: -1px;
-  z-index: 2;
 `
 
 MenuGroupLabel.defaultProps = {

--- a/packages/components/src/Menu/MenuGroupLabel.tsx
+++ b/packages/components/src/Menu/MenuGroupLabel.tsx
@@ -34,6 +34,7 @@ export const MenuGroupLabel = styled.div<MenuGroupLabelProps>`
   box-shadow: ${props => props.boxShadow};
   position: sticky;
   top: -1px;
+  margin-bottom: ${({ theme }) => theme.space.xxsmall};
 `
 
 MenuGroupLabel.defaultProps = {

--- a/packages/components/src/Menu/MenuItem/MenuItem.test.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItem.test.tsx
@@ -51,7 +51,7 @@ test('MenuItem - current', () => {
 
 test('MenuItem - current + marker', () => {
   assertSnapshot(
-    <MenuItem current currentMarker icon="Home">
+    <MenuItem current icon="Home">
       who!
     </MenuItem>
   )
@@ -83,7 +83,7 @@ test('MenuItem - with customizations', () => {
     }
 
   assertSnapshot(
-    <MenuItem current currentMarker customizationProps={menuCustomizations}>
+    <MenuItem current customizationProps={menuCustomizations}>
       who!
     </MenuItem>
   )
@@ -95,7 +95,7 @@ test('MenuItem - with single customization', () => {
   }
 
   assertSnapshot(
-    <MenuItem current currentMarker customizationProps={menuCustomizations}>
+    <MenuItem current customizationProps={menuCustomizations}>
       who!
     </MenuItem>
   )

--- a/packages/components/src/Menu/MenuItem/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItem.tsx
@@ -117,10 +117,6 @@ export interface MenuItemProps
    */
   current?: boolean
   /**
-   * Display a marker next to the MenuItem if it is current
-   */
-  currentMarker?: boolean
-  /**
    * Sets the correct accessible role for the MenuItem:
    * - Use **'link'** for items that navigation to another page
    * - Use **'button'** for items that trigger in page interactions, like displaying a modal
@@ -133,7 +129,6 @@ export interface MenuItemProps
 export const MenuItem: FC<MenuItemProps> = props => {
   const {
     current,
-    currentMarker,
     children,
     detail,
     icon,
@@ -165,7 +160,6 @@ export const MenuItem: FC<MenuItemProps> = props => {
   return (
     <MenuItemListItem
       current={current}
-      currentMarker={currentMarker}
       itemStyle={style}
       aria-current={current && 'page'}
       onClick={onClick}

--- a/packages/components/src/Menu/MenuItem/MenuItemButton.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItemButton.tsx
@@ -48,7 +48,6 @@ export const MenuItemButton = styled.button<MenuItemButtonProps>`
   font-size: inherit;
   flex: 1;
   outline: none;
-  padding-left: ${({ theme }) => theme.space.small};
   text-align: left;
   text-decoration: none;
 `

--- a/packages/components/src/Menu/MenuItem/MenuItemButton.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItemButton.tsx
@@ -48,6 +48,7 @@ export const MenuItemButton = styled.button<MenuItemButtonProps>`
   font-size: inherit;
   flex: 1;
   outline: none;
+  padding-left: ${({ theme }) => theme.space.small};
   text-align: left;
   text-decoration: none;
 `

--- a/packages/components/src/Menu/MenuItem/MenuItemListItem.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItemListItem.tsx
@@ -92,6 +92,8 @@ export const MenuItemListItem = styled(Li)<MenuListItemProps>`
     border-left-style: solid;
     border-left-color: ${({ itemStyle, current }) =>
       current ? itemStyle.marker.color : 'transparent'};
+    padding-left: calc(${({ theme, itemStyle }) =>
+      `${theme.space.medium} - ${itemStyle.marker.size}px`});
   }
 
   &:focus-within button,

--- a/packages/components/src/Menu/MenuItem/MenuItemListItem.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItemListItem.tsx
@@ -85,15 +85,21 @@ export const MenuItemListItem = styled(Li)<MenuListItemProps>`
   transition: ${props =>
     `background ${props.theme.transitions.durationQuick} ${props.theme.easings.ease},
     color ${props.theme.transitions.durationQuick} ${props.theme.easings.ease}`};
-  margin: 3px 0;
-  &:focus-within {
-    box-shadow: ${props => `0 0 3px 1px ${props.theme.colors.palette.blue400}`};
+
+  button,
+  a {
+    border-left-width: ${({ itemStyle }) => itemStyle.marker.size}px;
+    border-left-style: solid;
+    border-left-color: ${({ itemStyle, current }) =>
+      current ? itemStyle.marker.color : 'transparent'};
   }
 
-  border-left-width: ${({ itemStyle }) => itemStyle.marker.size}px;
-  border-left-style: solid;
-  border-left-color: ${({ itemStyle, current }) =>
-    current ? itemStyle.marker.color : 'transparent'};
+  &:focus-within button,
+  &:focus-within a {
+    box-shadow:  ${props =>
+      `0 0 3px 1px ${props.theme.colors.palette.blue400}`};
+  }
+
   ${hoverStyles};
 
   ${Icon} {

--- a/packages/components/src/Menu/MenuItem/MenuItemListItem.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItemListItem.tsx
@@ -38,25 +38,7 @@ import { MenuItemStyle } from './menuItemStyle'
 
 export interface MenuListItemProps extends CompatibleHTMLProps<HTMLLIElement> {
   current?: boolean
-  currentMarker?: boolean
   itemStyle: MenuItemStyle
-}
-
-const currentBorder = (props: MenuListItemProps) => {
-  if (!props.current || !props.currentMarker) return false
-
-  return css`
-    ::before {
-      content: '';
-      display: block;
-      height: 100%;
-      position: absolute;
-      left: 0;
-      top: 0;
-      background: ${props.itemStyle.marker.color};
-      width: ${props.itemStyle.marker.size}px;
-    }
-  `
 }
 
 const hoverStyles = (props: MenuListItemProps) => {
@@ -86,7 +68,7 @@ const iconColor = (props: MenuListItemProps) =>
  * used when styled extends a base type. E.g. (styled.li has `color` prop)
  */
 const Li = forwardRef((props: MenuListItemProps, ref: Ref<HTMLLIElement>) => {
-  const domProps = omit(props, 'current', 'currentMarker', 'itemStyle')
+  const domProps = omit(props, 'current', 'itemStyle')
   return <li {...domProps} ref={ref} />
 })
 
@@ -96,22 +78,22 @@ export const MenuItemListItem = styled(Li)<MenuListItemProps>`
   ${color}
   ${space}
   ${typography}
-
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  position: relative;
   text-decoration: none;
   transition: ${props =>
     `background ${props.theme.transitions.durationQuick} ${props.theme.easings.ease},
     color ${props.theme.transitions.durationQuick} ${props.theme.easings.ease}`};
-
+  margin: 3px 0;
   &:focus-within {
     box-shadow: ${props => `0 0 3px 1px ${props.theme.colors.palette.blue400}`};
-    z-index: 1;
   }
 
-  ${currentBorder};
+  border-left-width: ${({ itemStyle }) => itemStyle.marker.size}px;
+  border-left-style: solid;
+  border-left-color: ${({ itemStyle, current }) =>
+    current ? itemStyle.marker.color : 'transparent'};
   ${hoverStyles};
 
   ${Icon} {

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -87,13 +87,17 @@ exports[`MenuItem - current + marker 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: #262D33;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -227,13 +231,17 @@ exports[`MenuItem - current 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: #262D33;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -350,13 +358,17 @@ exports[`MenuItem - detail 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -477,13 +489,17 @@ exports[`MenuItem - icon 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -609,13 +625,17 @@ exports[`MenuItem - with customizations 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 10px;
   border-left-style: solid;
   border-left-color: #1E1047;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -697,13 +717,17 @@ exports[`MenuItem - with single customization 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: #262D33;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -785,13 +809,17 @@ exports[`MenuItem 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c0 button,
+.c0 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c0:focus-within {
+.c0:focus-within button,
+.c0:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`MenuItem - current + marker 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -94,6 +93,7 @@ exports[`MenuItem - current + marker 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: #262D33;
+  padding-left: calc(1rem - 4px);
 }
 
 .c0:focus-within button,
@@ -195,7 +195,6 @@ exports[`MenuItem - current 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -238,6 +237,7 @@ exports[`MenuItem - current 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: #262D33;
+  padding-left: calc(1rem - 4px);
 }
 
 .c0:focus-within button,
@@ -317,7 +317,6 @@ exports[`MenuItem - detail 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -365,6 +364,7 @@ exports[`MenuItem - detail 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c0:focus-within button,
@@ -463,7 +463,6 @@ exports[`MenuItem - icon 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -496,6 +495,7 @@ exports[`MenuItem - icon 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c0:focus-within button,
@@ -599,7 +599,6 @@ exports[`MenuItem - with customizations 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -632,6 +631,7 @@ exports[`MenuItem - with customizations 1`] = `
   border-left-width: 10px;
   border-left-style: solid;
   border-left-color: #1E1047;
+  padding-left: calc(1rem - 10px);
 }
 
 .c0:focus-within button,
@@ -691,7 +691,6 @@ exports[`MenuItem - with single customization 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -724,6 +723,7 @@ exports[`MenuItem - with single customization 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: #262D33;
+  padding-left: calc(1rem - 4px);
 }
 
 .c0:focus-within button,
@@ -783,7 +783,6 @@ exports[`MenuItem 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -816,6 +815,7 @@ exports[`MenuItem 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c0:focus-within button,

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`MenuItem - current + marker 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -62,12 +63,6 @@ exports[`MenuItem - current + marker 1`] = `
 
 .c4 .c3 {
   color: #C1C6CC;
-  -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
-  transition: color 150ms cubic-bezier(0.86,0,0.07,1);
-}
-
-.c5 .c3 {
-  color: #262D33;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -88,27 +83,18 @@ exports[`MenuItem - current + marker 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: #262D33;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
-}
-
-.c0::before {
-  content: '';
-  display: block;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  background: #262D33;
-  width: 4px;
 }
 
 .c0 .c3 {
@@ -205,6 +191,7 @@ exports[`MenuItem - current 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -236,16 +223,18 @@ exports[`MenuItem - current 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: #262D33;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c0 .c3 {
@@ -320,6 +309,7 @@ exports[`MenuItem - detail 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -356,16 +346,18 @@ exports[`MenuItem - detail 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c0:hover {
@@ -459,6 +451,7 @@ exports[`MenuItem - icon 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -480,16 +473,18 @@ exports[`MenuItem - icon 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c0:hover {
@@ -588,6 +583,7 @@ exports[`MenuItem - with customizations 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -609,27 +605,18 @@ exports[`MenuItem - with customizations 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 10px;
+  border-left-style: solid;
+  border-left-color: #1E1047;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
-}
-
-.c0::before {
-  content: '';
-  display: block;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  background: #1E1047;
-  width: 10px;
 }
 
 .c0 .c2 {
@@ -684,6 +671,7 @@ exports[`MenuItem - with single customization 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -705,27 +693,18 @@ exports[`MenuItem - with single customization 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: #262D33;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
-}
-
-.c0::before {
-  content: '';
-  display: block;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  background: #262D33;
-  width: 4px;
 }
 
 .c0 .c2 {
@@ -780,6 +759,7 @@ exports[`MenuItem 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -801,16 +781,18 @@ exports[`MenuItem 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c0:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c0:hover {

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -37,6 +37,12 @@ import React, {
 import { HotKeys } from 'react-hotkeys'
 import styled, { css } from 'styled-components'
 import {
+  MaxHeightProps,
+  MinHeightProps,
+  HeightProps,
+  height,
+  minHeight,
+  maxHeight,
   width,
   WidthProps,
   MaxWidthProps,
@@ -53,6 +59,9 @@ import { moveFocus } from './moveFocus'
 
 export interface MenuListProps
   extends CompatibleHTMLProps<HTMLUListElement>,
+    MaxHeightProps,
+    MinHeightProps,
+    HeightProps,
     MaxWidthProps,
     MinWidthProps,
     WidthProps,
@@ -157,9 +166,16 @@ const dividersStyle = css`
 
 export const MenuList = styled(MenuListInternal)`
   ${reset}
+
+  ${minHeight}
+  ${maxHeight}
+  ${height}
+
   ${minWidth}
   ${maxWidth}
   ${width}
+
+  overflow: auto;
 
   list-style: none;
   outline: none;
@@ -167,4 +183,4 @@ export const MenuList = styled(MenuListInternal)`
   ${props => props.groupDividers !== false && dividersStyle};
 `
 
-MenuList.defaultProps = { minWidth: '10rem' }
+MenuList.defaultProps = { minWidth: '12rem' }

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -46,7 +46,6 @@ exports[`MenuGroup - JSX label 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: -1px;
-  z-index: 2;
 }
 
 .c0 {
@@ -89,6 +88,7 @@ exports[`MenuGroup - JSX label 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -110,16 +110,18 @@ exports[`MenuGroup - JSX label 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c5:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c5:hover {
@@ -255,7 +257,6 @@ exports[`MenuGroup - label 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: -1px;
-  z-index: 2;
 }
 
 .c0 {
@@ -298,6 +299,7 @@ exports[`MenuGroup - label 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -319,16 +321,18 @@ exports[`MenuGroup - label 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c4:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c4:hover {
@@ -460,7 +464,6 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: -1px;
-  z-index: 2;
 }
 
 .c0 {
@@ -503,6 +506,7 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -524,16 +528,18 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c4:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c4:hover {
@@ -705,6 +711,7 @@ exports[`MenuGroup - menu customization 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -736,16 +743,18 @@ exports[`MenuGroup - menu customization 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 10px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c2:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c2:hover {
@@ -952,6 +961,7 @@ exports[`MenuGroup 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
+  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -973,16 +983,18 @@ exports[`MenuGroup 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
+  margin: 3px 0;
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
 }
 
 .c2:focus-within {
   box-shadow: 0 0 3px 1px #49a9f2;
-  z-index: 1;
 }
 
 .c2:hover {

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -114,13 +114,17 @@ exports[`MenuGroup - JSX label 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c5 button,
+.c5 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c5:focus-within {
+.c5:focus-within button,
+.c5:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -325,13 +329,17 @@ exports[`MenuGroup - label 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c4 button,
+.c4 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c4:focus-within {
+.c4:focus-within button,
+.c4:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -532,13 +540,17 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c4 button,
+.c4 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c4:focus-within {
+.c4:focus-within button,
+.c4:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -747,13 +759,17 @@ exports[`MenuGroup - menu customization 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c2 button,
+.c2 a {
   border-left-width: 10px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c2:focus-within {
+.c2:focus-within button,
+.c2:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 
@@ -987,13 +1003,17 @@ exports[`MenuGroup 1`] = `
   text-decoration: none;
   -webkit-transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: background 150ms cubic-bezier(0.86,0,0.07,1), color 150ms cubic-bezier(0.86,0,0.07,1);
-  margin: 3px 0;
+}
+
+.c2 button,
+.c2 a {
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
 }
 
-.c2:focus-within {
+.c2:focus-within button,
+.c2:focus-within a {
   box-shadow: 0 0 3px 1px #49a9f2;
 }
 

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`MenuGroup - JSX label 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: -1px;
+  margin-bottom: 0.25rem;
 }
 
 .c0 {
@@ -88,7 +89,6 @@ exports[`MenuGroup - JSX label 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -121,6 +121,7 @@ exports[`MenuGroup - JSX label 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c5:focus-within button,
@@ -261,6 +262,7 @@ exports[`MenuGroup - label 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: -1px;
+  margin-bottom: 0.25rem;
 }
 
 .c0 {
@@ -303,7 +305,6 @@ exports[`MenuGroup - label 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -336,6 +337,7 @@ exports[`MenuGroup - label 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c4:focus-within button,
@@ -472,6 +474,7 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   position: -webkit-sticky;
   position: sticky;
   top: -1px;
+  margin-bottom: 0.25rem;
 }
 
 .c0 {
@@ -514,7 +517,6 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -547,6 +549,7 @@ exports[`MenuGroup - labelProps & labelStyles 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c4:focus-within button,
@@ -723,7 +726,6 @@ exports[`MenuGroup - menu customization 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -766,6 +768,7 @@ exports[`MenuGroup - menu customization 1`] = `
   border-left-width: 10px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 10px);
 }
 
 .c2:focus-within button,
@@ -977,7 +980,6 @@ exports[`MenuGroup 1`] = `
   -ms-flex: 1;
   flex: 1;
   outline: none;
-  padding-left: 0.75rem;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1010,6 +1012,7 @@ exports[`MenuGroup 1`] = `
   border-left-width: 4px;
   border-left-style: solid;
   border-left-color: transparent;
+  padding-left: calc(1rem - 4px);
 }
 
 .c2:focus-within button,

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -26,40 +26,62 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { MenuGroup, MenuList, MenuItem, GlobalStyle } from '@looker/components'
+import {
+  Box,
+  ButtonOutline,
+  Menu,
+  MenuDisclosure,
+  MenuGroup,
+  MenuList,
+  MenuItem,
+  GlobalStyle,
+} from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
 const App: React.FC = () => {
+  const contents = (
+    <>
+      <MenuGroup label="Cheeses">
+        <MenuItem icon="FavoriteOutline">Cheddar</MenuItem>
+        <MenuItem icon="FavoriteOutline">Mozerella</MenuItem>
+        <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
+      </MenuGroup>
+      <MenuGroup label="Meats">
+        <MenuItem icon="FavoriteOutline">Sausage</MenuItem>
+        <MenuItem icon="FavoriteOutline">Pepperoni</MenuItem>
+        <MenuItem icon="FavoriteOutline">Salami</MenuItem>
+      </MenuGroup>
+      <MenuGroup label="Vegetables">
+        <MenuItem icon="FavoriteOutline">Onion</MenuItem>
+        <MenuItem icon="FavoriteOutline">Mushroom</MenuItem>
+        <MenuItem icon="FavoriteOutline">Peppers</MenuItem>
+      </MenuGroup>
+    </>
+  )
+
   return (
     <ThemeProvider theme={theme}>
-      <>
+      <Box m="xxxlarge">
         <GlobalStyle />
-        <MenuList>
-          <MenuGroup label="Links">
-            <MenuItem icon="LogoRings" current>
-              Looker
-            </MenuItem>
-            <MenuItem icon="Validate">Validate</MenuItem>
-            <MenuItem icon="ChartPie">Pizza!</MenuItem>
-          </MenuGroup>
-          <MenuGroup label="Cheeses">
-            <MenuItem icon="FavoriteOutline">Cheddar</MenuItem>
-            <MenuItem icon="FavoriteOutline">Mozerella</MenuItem>
-            <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
-          </MenuGroup>
-          <MenuGroup label="Meats">
-            <MenuItem icon="FavoriteOutline">Sausage</MenuItem>
-            <MenuItem icon="FavoriteOutline">Pepperoni</MenuItem>
-            <MenuItem icon="FavoriteOutline">Salami</MenuItem>
-          </MenuGroup>
-          <MenuGroup label="Vegetables">
-            <MenuItem icon="FavoriteOutline">Onion</MenuItem>
-            <MenuItem icon="FavoriteOutline">Mushroom</MenuItem>
-            <MenuItem icon="FavoriteOutline">Peppers</MenuItem>
-          </MenuGroup>
-        </MenuList>
-      </>
+        <Menu>
+          <MenuDisclosure>
+            <ButtonOutline mr="xlarge">
+              Pizza Menu Selection.... (Scroll)
+            </ButtonOutline>
+          </MenuDisclosure>
+          <MenuList height="20rem" minWidth="18rem">
+            {contents}
+          </MenuList>
+        </Menu>
+
+        <Menu>
+          <MenuDisclosure>
+            <ButtonOutline>Pizza Menu Selection....</ButtonOutline>
+          </MenuDisclosure>
+          <MenuList minWidth="18rem">{contents}</MenuList>
+        </Menu>
+      </Box>
     </ThemeProvider>
   )
 }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -26,48 +26,39 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import {
-  Button,
-  Popover,
-  PopoverContent,
-  GlobalStyle,
-  InputText,
-} from '@looker/components'
+import { MenuGroup, MenuList, MenuItem, GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
 const App: React.FC = () => {
-  const [value, setValue] = React.useState('')
-  function handleChange(e: React.FormEvent<HTMLInputElement>) {
-    setValue(e.currentTarget.value)
-  }
   return (
     <ThemeProvider theme={theme}>
       <>
         <GlobalStyle />
-        <Popover
-          content={
-            <PopoverContent p="large">
-              <InputText
-                onChange={handleChange}
-                value={value}
-                placeholder="Type in me"
-              />
-            </PopoverContent>
-          }
-        >
-          {(onClick, ref, className) => (
-            <Button
-              aria-haspopup="true"
-              onClick={onClick}
-              ref={ref}
-              className={className}
-              m="small"
-            >
-              Reproduces Helltool Modal/Popover Bug
-            </Button>
-          )}
-        </Popover>
+        <MenuList>
+          <MenuGroup label="Links">
+            <MenuItem icon="LogoRings" current>
+              Looker
+            </MenuItem>
+            <MenuItem icon="Validate">Validate</MenuItem>
+            <MenuItem icon="ChartPie">Pizza!</MenuItem>
+          </MenuGroup>
+          <MenuGroup label="Cheeses">
+            <MenuItem icon="FavoriteOutline">Cheddar</MenuItem>
+            <MenuItem icon="FavoriteOutline">Mozerella</MenuItem>
+            <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
+          </MenuGroup>
+          <MenuGroup label="Meats">
+            <MenuItem icon="FavoriteOutline">Sausage</MenuItem>
+            <MenuItem icon="FavoriteOutline">Pepperoni</MenuItem>
+            <MenuItem icon="FavoriteOutline">Salami</MenuItem>
+          </MenuGroup>
+          <MenuGroup label="Vegetables">
+            <MenuItem icon="FavoriteOutline">Onion</MenuItem>
+            <MenuItem icon="FavoriteOutline">Mushroom</MenuItem>
+            <MenuItem icon="FavoriteOutline">Peppers</MenuItem>
+          </MenuGroup>
+        </MenuList>
       </>
     </ThemeProvider>
   )

--- a/packages/www/src/documentation/components/overlays/menu.mdx
+++ b/packages/www/src/documentation/components/overlays/menu.mdx
@@ -102,7 +102,6 @@ When a `MenuList` is focused the `up` and `down` arrow keys will move focus thro
       itemRole="link"
       icon="FavoriteOutline"
       current
-      currentMarker
       detail="Is often orange"
     >
       Cheddar


### PR DESCRIPTION
### :sparkles: Changes

- Removes use of z-index to enforce menu component stacking order. This is primarily accomplished through working around any need for `position` settings on MenuItem, so it no longer competes with the MenuGroupLabel `position: sticky;` behavior. 

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots

![sticky-header](https://user-images.githubusercontent.com/238293/68617236-b311d400-047b-11ea-9a54-52568bc854ed.gif)

