### PR TITLE
Require allowScrollWithin ref on useScrollLock

### DIFF
--- a/packages/components/src/Modal/ModalPortal.tsx
+++ b/packages/components/src/Modal/ModalPortal.tsx
@@ -37,7 +37,10 @@ export interface ModalPortalProps {
 
 export const ModalPortal: FC<ModalPortalProps> = ({ portalRef, children }) => {
   const el = useRef(document.createElement('div'))
-  useScrollLock(false, portalRef)
+  const ref = useRef<HTMLDivElement>(null)
+  const refToUse = portalRef || ref
+
+  useScrollLock(refToUse)
 
   useEffect(() => {
     const modalRoot = getModalRoot()
@@ -52,7 +55,7 @@ export const ModalPortal: FC<ModalPortalProps> = ({ portalRef, children }) => {
   }, [el])
 
   const content = (
-    <InvisiBox ref={portalRef} zIndex={CustomizableModalAttributes.zIndex}>
+    <InvisiBox ref={refToUse} zIndex={CustomizableModalAttributes.zIndex}>
       {children}
     </InvisiBox>
   )

--- a/packages/components/src/utils/useScrollLock.ts
+++ b/packages/components/src/utils/useScrollLock.ts
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,8 +27,8 @@
 import { RefObject, useEffect } from 'react'
 
 export function useScrollLock(
-  disabled?: boolean,
-  allowScrollWithin?: RefObject<HTMLElement | null>
+  allowScrollWithin: RefObject<HTMLElement | null>,
+  disabled = false
 ) {
   useEffect(() => {
     let scrollTop = window.scrollY


### PR DESCRIPTION
### :sparkles: Changes

- Fixes an issue where the long contents of `Dialog` cannot be scrolled.
- Made the `allowScrollWithin` argument (a `RefObject`) required in `useScrollLock` – the downsides of not providing this when it's intended are bigger than the possibility of ever wanting to use it without.
- Created a fallback ref in `ModalPortal` to pass to `useScrollLock` if the optional `portalRef` prop is not present.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues
