### PR TITLE
Tooltip Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Fixed
+
+- `Tooltip`
+  - Respects `width` property as expected
+  - Removed confusing `maxWidth` property
+  - `Link` color within `Tooltip` is set to `blue200` to ensure readability.
+
 ## [0.7.6] - 2019-11-18
 
 ### Changed

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -48,6 +48,7 @@ export const Link = styled.a<LinkProps>`
   ${typography}
   ${textDecoration}
 
+  &:focus,
   &:hover {
     text-decoration: underline;
   }

--- a/packages/components/src/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`A Link with an id 1`] = `
   text-decoration: none;
 }
 
+.c0:focus,
 .c0:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -44,6 +45,7 @@ exports[`A default Link 1`] = `
   text-decoration: none;
 }
 
+.c0:focus,
 .c0:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -73,6 +75,7 @@ exports[`A external Link 1`] = `
   text-decoration: none;
 }
 
+.c0:focus,
 .c0:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -36,8 +36,8 @@ import { Box } from '../Layout/Box'
 import { Button } from '../Button'
 import { OverlaySurface } from '../Overlay/OverlaySurface'
 import { Popover } from '../Popover'
-import { Paragraph } from '../Text'
 import { Tooltip } from './Tooltip'
+import { TooltipContent } from './TooltipContent'
 import { mouseEventSimulator } from './tooltip.test.helpers'
 
 describe('Tooltip', () => {
@@ -146,7 +146,7 @@ describe('Tooltip', () => {
 
   test('supports styling props', () => {
     const tooltip = mountWithTheme(
-      <Tooltip content="Hello world" maxWidth="20rem" textAlign="right">
+      <Tooltip content="Hello world" width="20rem" textAlign="right">
         {(eventHandlers, ref) => (
           <Button ref={ref} {...eventHandlers}>
             Test
@@ -162,9 +162,9 @@ describe('Tooltip', () => {
     const surface = tooltip.find(OverlaySurface)
     expect(surface.exists()).toBeTruthy()
 
-    const paragraph = surface.find(Paragraph)
-    expect(paragraph.props().maxWidth).toEqual('20rem')
-    expect(paragraph.props().textAlign).toEqual('right')
+    const content = surface.find(TooltipContent)
+    expect(content.props().width).toEqual('20rem')
+    expect(content.props().textAlign).toEqual('right')
   })
 
   test('tooltip can exceed bounds of containing overlay', () => {

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -31,7 +31,7 @@ import React, { useRef, useState, RefObject, FC, ReactNode } from 'react'
 import { Popper } from 'react-popper'
 import { ModalContext } from '../Modal'
 import { OverlaySurface, SurfaceStyleProps } from '../Overlay/OverlaySurface'
-import { Paragraph } from '../Text'
+import { TooltipContent } from './TooltipContent'
 
 interface EventHandlers {
   onBlur: () => void
@@ -66,12 +66,6 @@ export interface UseTooltipProps {
    * Content to display inside the tooltip. Can be a string or JSX.
    */
   content?: ReactNode
-
-  /**
-   * Specify the maximum width before wrapping text.
-   * @default 16rem
-   */
-  maxWidth?: string
   /**
    * Specify a fixed content width.
    * @default auto
@@ -114,9 +108,8 @@ export function useTooltip({
   canClose,
   content,
   isOpen: initializeOpen = false,
-  maxWidth = '16rem',
-  width = 'auto',
-  textAlign = 'center',
+  width,
+  textAlign,
   disabled,
   surfaceStyles,
   ...props
@@ -170,20 +163,6 @@ export function useTooltip({
   const referenceElement =
     triggerRef && triggerRef.current ? triggerRef.current : undefined
 
-  const contentFormatted = (
-    <Paragraph
-      style={{ hyphens: 'auto', overflowWrap: 'anywhere' }}
-      fontSize="xsmall"
-      maxWidth={maxWidth}
-      width={width}
-      p="xsmall"
-      m="none"
-      textAlign={textAlign}
-    >
-      {content}
-    </Paragraph>
-  )
-
   const popper =
     isOpen && content && !disabled ? (
       <ModalContext.Provider value={{ closeModal: handleClose }}>
@@ -219,7 +198,9 @@ export function useTooltip({
               color="palette.charcoal000"
               {...surfaceStyles}
             >
-              {contentFormatted}
+              <TooltipContent width={width} textAlign={textAlign}>
+                {content}
+              </TooltipContent>
             </OverlaySurface>
           )}
         </Popper>

--- a/packages/components/src/Tooltip/TooltipContent.tsx
+++ b/packages/components/src/Tooltip/TooltipContent.tsx
@@ -17,6 +17,12 @@ export const TooltipContent = styled(Paragraph).attrs(
 
   ${Link} {
     color: ${props => props.theme.colors.palette.blue200};
+    text-decoration: underline;
+
+    &:focus,
+    &:hover {
+      color: ${props => props.theme.colors.palette.blue100};
+    }
   }
 `
 

--- a/packages/components/src/Tooltip/TooltipContent.tsx
+++ b/packages/components/src/Tooltip/TooltipContent.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+import { Link } from '../Link'
+import { Paragraph } from '../Text'
+import { TooltipProps } from './Tooltip'
+export const TooltipContent = styled(Paragraph).attrs(
+  (props: TooltipProps) => ({
+    fontSize: 'xsmall',
+    lineHeight: 'xsmall',
+    m: 'none',
+    maxWidth: props.width,
+    p: 'xsmall',
+    width: 'auto',
+  })
+)`
+  hyphens: auto;
+  overflow-wrap: anywhere;
+
+  ${Link} {
+    color: ${props => props.theme.colors.palette.blue200};
+  }
+`
+
+TooltipContent.defaultProps = { textAlign: 'center', width: '16rem' }

--- a/packages/www/src/documentation/components/overlays/tooltip.mdx
+++ b/packages/www/src/documentation/components/overlays/tooltip.mdx
@@ -22,14 +22,21 @@ A simple Tooltip component with out of the box styles and behavior.
 
 ```jsx
 <Tooltip
+  width="20rem"
+  placement="right"
+  textAlign="left"
   content={
-    'Lorem ipsum dolor amet artisan meditation four loko poutine pinterest meh cold-pressed flexitarian vaporware umami kale chips selvage salvia waistcoat occupy. Jianbing jean shorts VHS austin bushwick.'
+    <>
+      This is a tooltip with quite a bit of text. It's probably not ideal to
+      have this much text in a Tooltip. Perhaps you should link to
+      <Link href="#">another document &rarr;</Link>
+    </>
   }
 >
   {(eventHandlers, ref) => (
-    <Button ref={ref} {...eventHandlers}>
-      Hover me! (with lots of text)
-    </Button>
+    <ButtonOutline {...eventHandlers} ref={ref}>
+      Tooltip with lots of text
+    </ButtonOutline>
   )}
 </Tooltip>
 ```


### PR DESCRIPTION
### :sparkles: Changes

- Update color of `Link` within `Tooltip` to `blue200` to ensure visibility
- Fix issue where `width` property isn't respected
- Remove `maxWidth` property
- Update examples to show use of width, placement and `Link`

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [x] Includes CHANGELOG update

### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/34253496/69196048-38cbfa00-0ae2-11ea-9115-b13d764b7740.png)

#### After

![image](https://user-images.githubusercontent.com/34253496/69195646-1ab1ca00-0ae1-11ea-8d6c-0b0ee990a3f9.png)

