### PR TITLE
Update theme colors, and copy old values to legacy variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update theme object to use more vibrant colors by default.
+- creates new legacyTheme export for users who don't like the colors changing
 - Improved documentation around installation of NPM package
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update theme object to use more vibrant colors by default.
-- creates new classicTheme export for users who don't like the colors changing
 - Improved documentation around installation of NPM package
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update theme object to use more vibrant colors by default.
-- creates new legacyTheme export for users who don't like the colors changing
+- creates new classicTheme export for users who don't like the colors changing
 - Improved documentation around installation of NPM package
 
 ### Fixed

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -94,12 +94,8 @@ test('Button Focus split - on tab not on click', () => {
   )
 
   fireEvent.click(getByText('button'))
-  expect(getByText('focus')).not.toHaveStyle(
-    `box-shadow: 0 0 0 0.15rem rgba(100,81,138,0.25)`
-  )
+  expect(getByText('focus')).toMatchSnapshot()
 
   fireEvent.keyUp(getByText('focus'), { charCode: 9, code: 9, key: 'Tab' })
-  expect(getByText('focus')).toHaveStyle(
-    `box-shadow: 0 0 0 0.15rem rgba(100,81,138,0.25)`
-  )
+  expect(getByText('focus')).toMatchSnapshot()
 })

--- a/packages/components/src/Button/ButtonOutline.test.tsx
+++ b/packages/components/src/Button/ButtonOutline.test.tsx
@@ -58,12 +58,8 @@ test('ButtonOutline Focus split - on tab not on click', () => {
   )
 
   fireEvent.click(getByText('ButtonOutline'))
-  expect(getByText('focus')).not.toHaveStyle(
-    `box-shadow: 0 0 0 0.15rem rgba(100,81,138,0.25)`
-  )
+  expect(getByText('focus')).toMatchSnapshot()
 
   fireEvent.keyUp(getByText('focus'), { charCode: 9, code: 9, key: 'Tab' })
-  expect(getByText('focus')).toHaveStyle(
-    `box-shadow: 0 0 0 0.15rem rgba(100,81,138,0.25)`
-  )
+  expect(getByText('focus')).toMatchSnapshot()
 })

--- a/packages/components/src/Button/ButtonTransparent.test.tsx
+++ b/packages/components/src/Button/ButtonTransparent.test.tsx
@@ -58,12 +58,8 @@ test('ButtonTransparent Focus split - on tab not on click', () => {
   )
 
   fireEvent.click(getByText('ButtonTransparent'))
-  expect(getByText('focus')).not.toHaveStyle(
-    `box-shadow: 0 0 0 0.15rem rgba(100,81,138,0.25)`
-  )
+  expect(getByText('focus')).toMatchSnapshot()
 
   fireEvent.keyUp(getByText('focus'), { charCode: 9, code: 9, key: 'Tab' })
-  expect(getByText('focus')).toHaveStyle(
-    `box-shadow: 0 0 0 0.15rem rgba(100,81,138,0.25)`
-  )
+  expect(getByText('focus')).toMatchSnapshot()
 })

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button Focus split - on tab not on click 1`] = `
+.c0 {
+  border: 0;
+  box-sizing: border-box;
+  font: inherit;
+  font-size: 100%;
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 1rem;
+  height: 34px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c1 {
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
+  color: #FFFFFF;
+}
+
+.c1:active,
+.c1.active {
+  background: #412399;
+  border-color: #412399;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  background: #4F2ABA;
+  border-color: #4F2ABA;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  background-color: #6C43E0;
+  border-color: #C1C6CC;
+}
+
+<button
+  class="c0 c1"
+>
+  focus
+</button>
+`;
+
+exports[`Button Focus split - on tab not on click 2`] = `
+<button
+  class="sc-bxivhb cwuduv sc-ifAKCX sc-EHOje kAurnO"
+>
+  focus
+</button>
+`;
+
 exports[`Button disable 1`] = `
 .c0 {
   border: 0;
@@ -43,28 +126,28 @@ exports[`Button disable 1`] = `
 }
 
 .c1 {
-  background: #64518A;
-  border: 1px solid #64518A;
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
   color: #FFFFFF;
 }
 
 .c1:active,
 .c1.active {
-  background: #2A1B60;
-  border-color: #2A1B60;
+  background: #412399;
+  border-color: #412399;
 }
 
 .c1:hover,
 .c1:focus,
 .c1.hover {
-  background: #473764;
-  border-color: #473764;
+  background: #4F2ABA;
+  border-color: #4F2ABA;
 }
 
 .c1[disabled]:hover,
 .c1[disabled]:active,
 .c1[disabled]:focus {
-  background-color: #64518A;
+  background-color: #6C43E0;
   border-color: #C1C6CC;
 }
 
@@ -121,28 +204,28 @@ exports[`Button validates all sizes 1`] = `
 }
 
 .c1 {
-  background: #64518A;
-  border: 1px solid #64518A;
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
   color: #FFFFFF;
 }
 
 .c1:active,
 .c1.active {
-  background: #2A1B60;
-  border-color: #2A1B60;
+  background: #412399;
+  border-color: #412399;
 }
 
 .c1:hover,
 .c1:focus,
 .c1.hover {
-  background: #473764;
-  border-color: #473764;
+  background: #4F2ABA;
+  border-color: #4F2ABA;
 }
 
 .c1[disabled]:hover,
 .c1[disabled]:active,
 .c1[disabled]:focus {
-  background-color: #64518A;
+  background-color: #6C43E0;
   border-color: #C1C6CC;
 }
 
@@ -196,28 +279,28 @@ exports[`Button validates all sizes 2`] = `
 }
 
 .c1 {
-  background: #64518A;
-  border: 1px solid #64518A;
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
   color: #FFFFFF;
 }
 
 .c1:active,
 .c1.active {
-  background: #2A1B60;
-  border-color: #2A1B60;
+  background: #412399;
+  border-color: #412399;
 }
 
 .c1:hover,
 .c1:focus,
 .c1.hover {
-  background: #473764;
-  border-color: #473764;
+  background: #4F2ABA;
+  border-color: #4F2ABA;
 }
 
 .c1[disabled]:hover,
 .c1[disabled]:active,
 .c1[disabled]:focus {
-  background-color: #64518A;
+  background-color: #6C43E0;
   border-color: #C1C6CC;
 }
 
@@ -271,28 +354,28 @@ exports[`Button validates all sizes 3`] = `
 }
 
 .c1 {
-  background: #64518A;
-  border: 1px solid #64518A;
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
   color: #FFFFFF;
 }
 
 .c1:active,
 .c1.active {
-  background: #2A1B60;
-  border-color: #2A1B60;
+  background: #412399;
+  border-color: #412399;
 }
 
 .c1:hover,
 .c1:focus,
 .c1.hover {
-  background: #473764;
-  border-color: #473764;
+  background: #4F2ABA;
+  border-color: #4F2ABA;
 }
 
 .c1[disabled]:hover,
 .c1[disabled]:active,
 .c1[disabled]:focus {
-  background-color: #64518A;
+  background-color: #6C43E0;
   border-color: #C1C6CC;
 }
 
@@ -346,28 +429,28 @@ exports[`Button validates all sizes 4`] = `
 }
 
 .c1 {
-  background: #64518A;
-  border: 1px solid #64518A;
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
   color: #FFFFFF;
 }
 
 .c1:active,
 .c1.active {
-  background: #2A1B60;
-  border-color: #2A1B60;
+  background: #412399;
+  border-color: #412399;
 }
 
 .c1:hover,
 .c1:focus,
 .c1.hover {
-  background: #473764;
-  border-color: #473764;
+  background: #4F2ABA;
+  border-color: #4F2ABA;
 }
 
 .c1[disabled]:hover,
 .c1[disabled]:active,
 .c1[disabled]:focus {
-  background-color: #64518A;
+  background-color: #6C43E0;
   border-color: #C1C6CC;
 }
 

--- a/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ButtonOutline Focus split - on tab not on click 1`] = `
+.c0 {
+  border: 0;
+  box-sizing: border-box;
+  font: inherit;
+  font-size: 100%;
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 1rem;
+  height: 34px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c1 {
+  border: 1px solid #C1C6CC;
+  color: #6C43E0;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  border-color: #6C43E0;
+  color: #412399;
+}
+
+.c1:active,
+.c1.active {
+  background: #6C43E0;
+  border-color: #6C43E0;
+  color: #FFFFFF;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  border-color: #C1C6CC;
+  color: #6C43E0;
+}
+
+<button
+  class="c0 c1"
+>
+  focus
+</button>
+`;
+
+exports[`ButtonOutline Focus split - on tab not on click 2`] = `
+<button
+  class="sc-bxivhb cwuduv sc-ifAKCX sc-EHOje dFdbyE"
+>
+  focus
+</button>
+`;
+
 exports[`ButtonOutline has the correct style 1`] = `
 .c0 {
   border: 0;
@@ -44,20 +127,20 @@ exports[`ButtonOutline has the correct style 1`] = `
 
 .c1 {
   border: 1px solid #C1C6CC;
-  color: #64518A;
+  color: #6C43E0;
 }
 
 .c1:hover,
 .c1:focus,
 .c1.hover {
-  border-color: #64518A;
-  color: #2A1B60;
+  border-color: #6C43E0;
+  color: #412399;
 }
 
 .c1:active,
 .c1.active {
-  background: #64518A;
-  border-color: #64518A;
+  background: #6C43E0;
+  border-color: #6C43E0;
   color: #FFFFFF;
 }
 
@@ -65,7 +148,7 @@ exports[`ButtonOutline has the correct style 1`] = `
 .c1[disabled]:active,
 .c1[disabled]:focus {
   border-color: #C1C6CC;
-  color: #64518A;
+  color: #6C43E0;
 }
 
 <button

--- a/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
@@ -1,5 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ButtonTransparent Focus split - on tab not on click 1`] = `
+.c0 {
+  border: 0;
+  box-sizing: border-box;
+  font: inherit;
+  font-size: 100%;
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 1rem;
+  height: 34px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c1 {
+  background: transparent;
+  border: 1px solid transparent;
+  color: #6C43E0;
+}
+
+.c1:active,
+.c1.active {
+  background: #E8E5FF;
+  border-color: #E8E5FF;
+  color: #6C43E0;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  background: #F3F2FF;
+  border-color: #F3F2FF;
+  color: #6C43E0;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  color: #6C43E0;
+}
+
+<button
+  class="c0 c1"
+>
+  focus
+</button>
+`;
+
+exports[`ButtonTransparent Focus split - on tab not on click 2`] = `
+<button
+  class="sc-bxivhb cwuduv sc-ifAKCX sc-EHOje ewBWhA"
+>
+  focus
+</button>
+`;
+
 exports[`ButtonTransparent has the correct style 1`] = `
 .c0 {
   border: 0;
@@ -45,7 +129,7 @@ exports[`ButtonTransparent has the correct style 1`] = `
 .c1 {
   background: transparent;
   border: 1px solid transparent;
-  color: #64518A;
+  color: #6C43E0;
 }
 
 .c1:active,
@@ -66,7 +150,7 @@ exports[`ButtonTransparent has the correct style 1`] = `
 .c1[disabled]:hover,
 .c1[disabled]:active,
 .c1[disabled]:focus {
-  color: #64518A;
+  color: #6C43E0;
 }
 
 <button

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -1139,12 +1139,12 @@ exports[`IconButton outline 1`] = `
 .c2:hover,
 .c2:focus,
 .c2.hover {
-  border-color: #64518A;
+  border-color: #6C43E0;
 }
 
 .c2:active,
 .c2.active {
-  border-color: #64518A;
+  border-color: #6C43E0;
 }
 
 .c2[disabled]:hover,

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`A FieldToggleSwitch 1`] = `
 }
 
 .c8:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c7 {
@@ -66,7 +66,7 @@ exports[`A FieldToggleSwitch 1`] = `
 }
 
 .c6 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 .c5 {
@@ -222,7 +222,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
 }
 
 .c8:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c7 {
@@ -255,7 +255,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
 }
 
 .c6 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 .c5 {
@@ -415,7 +415,7 @@ exports[`A FieldToggleSwitch with label aligned left 1`] = `
 }
 
 .c8:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c7 {
@@ -448,7 +448,7 @@ exports[`A FieldToggleSwitch with label aligned left 1`] = `
 }
 
 .c6 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 .c5 {

--- a/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Big ToggleSwitch 1`] = `
 }
 
 .c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c1 {
@@ -66,7 +66,7 @@ exports[`Big ToggleSwitch 1`] = `
 }
 
 .c0 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 <div
@@ -120,7 +120,7 @@ exports[`ToggleSwitch default 1`] = `
 }
 
 .c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c1 {
@@ -153,7 +153,7 @@ exports[`ToggleSwitch default 1`] = `
 }
 
 .c0 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 <div
@@ -207,7 +207,7 @@ exports[`ToggleSwitch on set to false 1`] = `
 }
 
 .c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c1 {
@@ -240,7 +240,7 @@ exports[`ToggleSwitch on set to false 1`] = `
 }
 
 .c0 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 <div
@@ -299,7 +299,7 @@ exports[`ToggleSwitch on set to true 1`] = `
 }
 
 .c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(100,81,138,0.5);
+  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
 }
 
 .c1 {
@@ -332,7 +332,7 @@ exports[`ToggleSwitch on set to true 1`] = `
 }
 
 .c0 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 <div
@@ -434,7 +434,7 @@ exports[`ToggleSwitch that is disabled 1`] = `
 }
 
 .c0 input:focus + div {
-  box-shadow: 0 0 0 0.2rem rgba(100,81,138,0.4);
+  box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
 
 <div

--- a/packages/components/src/Layout/Box/__snapshots__/Box.test.tsx.snap
+++ b/packages/components/src/Layout/Box/__snapshots__/Box.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Box Box supports background-color 1`] = `
   margin: 0;
   padding: 0;
   vertical-align: baseline;
-  background-color: #64518A;
+  background-color: #6C43E0;
 }
 
 <div

--- a/packages/design-tokens/src/theme.ts
+++ b/packages/design-tokens/src/theme.ts
@@ -50,8 +50,6 @@ import {
   fontFamilies,
   fontSizes,
   fontWeights,
-  classicSemanticColors,
-  classicPalette,
   lineHeights,
   palette,
   radii,
@@ -93,9 +91,4 @@ export const theme: Theme = {
   shadows,
   space,
   transitions,
-}
-
-export const classicTheme: Theme = {
-  ...theme,
-  colors: { palette: classicPalette, semanticColors: classicSemanticColors },
 }

--- a/packages/design-tokens/src/theme.ts
+++ b/packages/design-tokens/src/theme.ts
@@ -50,6 +50,8 @@ import {
   fontFamilies,
   fontSizes,
   fontWeights,
+  legacySemanticColors,
+  legacyPalette,
   lineHeights,
   palette,
   radii,
@@ -81,6 +83,21 @@ export interface Theme {
 export const theme: Theme = {
   breakpoints,
   colors: { palette, semanticColors },
+  easings,
+  fontSizes,
+  fontWeights,
+  fonts: fontFamilies,
+  lineHeights,
+  radii,
+  reset: defaultReset,
+  shadows,
+  space,
+  transitions,
+}
+
+export const legacyTheme: Theme = {
+  breakpoints,
+  colors: { palette: legacyPalette, semanticColors: legacySemanticColors },
   easings,
   fontSizes,
   fontWeights,

--- a/packages/design-tokens/src/theme.ts
+++ b/packages/design-tokens/src/theme.ts
@@ -50,8 +50,8 @@ import {
   fontFamilies,
   fontSizes,
   fontWeights,
-  legacySemanticColors,
-  legacyPalette,
+  classicSemanticColors,
+  classicPalette,
   lineHeights,
   palette,
   radii,
@@ -95,17 +95,7 @@ export const theme: Theme = {
   transitions,
 }
 
-export const legacyTheme: Theme = {
-  breakpoints,
-  colors: { palette: legacyPalette, semanticColors: legacySemanticColors },
-  easings,
-  fontSizes,
-  fontWeights,
-  fonts: fontFamilies,
-  lineHeights,
-  radii,
-  reset: defaultReset,
-  shadows,
-  space,
-  transitions,
+export const classicTheme: Theme = {
+  ...theme,
+  colors: { palette: classicPalette, semanticColors: classicSemanticColors },
 }

--- a/packages/design-tokens/src/tokens/color/palette.ts
+++ b/packages/design-tokens/src/tokens/color/palette.ts
@@ -103,10 +103,3 @@ export const palette: Palette = {
   red800: '#730B0F',
   red900: '#52080B',
 }
-
-export const classicPalette: Palette = {
-  ...palette,
-  primary500: '#64518A',
-  primary600: '#473764',
-  primary700: '#2A1B60',
-}

--- a/packages/design-tokens/src/tokens/color/palette.ts
+++ b/packages/design-tokens/src/tokens/color/palette.ts
@@ -27,81 +27,6 @@
 import { Palette } from '../../system'
 
 /* eslint-disable sort-keys */
-export const palette: Palette = {
-  textInverted: '#FFFFFF',
-  transparent: 'transparent',
-  white: '#FFFFFF',
-
-  primary500: '#4F2ABA', // duplicate purple500
-  primary600: '#412399', // duplicate purple600
-  primary700: '#341C7A', // duplicate purple700
-
-  charcoal000: '#FBFBFC',
-  charcoal100: '#F5F6F7',
-  charcoal200: '#DEE1E5',
-  charcoal300: '#C1C6CC',
-  charcoal400: '#939BA5',
-  charcoal500: '#707781',
-  charcoal600: '#4C535B',
-  charcoal700: '#343C42',
-  charcoal800: '#262D33',
-  charcoal900: '#262D33',
-
-  purple000: '#F3F2FF',
-  purple100: '#E8E5FF',
-  purple200: '#BFB2FF',
-  purple300: '#9785F2',
-  purple400: '#6C43E0',
-  purple500: '#4F2ABA',
-  purple600: '#412399',
-  purple700: '#341C7A',
-  purple800: '#291661',
-  purple900: '#1E1047',
-
-  blue000: '#f7fcff',
-  blue100: '#e0f2ff',
-  blue200: '#bfe3ff',
-  blue300: '#6fbcf7',
-  blue400: '#49a9f2',
-  blue500: '#0087e1',
-  blue600: '#0059b2',
-  blue700: '#00418c',
-  blue800: '#0f2f66',
-  blue900: '#08284d',
-
-  green000: '#f2fff5',
-  green100: '#e0ffe7',
-  green200: '#b4fac2',
-  green300: '#67e591',
-  green400: '#33cc73',
-  green500: '#24b25f',
-  green600: '#0e8c42',
-  green700: '#0b6b38',
-  green800: '#08522d',
-  green900: '#06381f',
-
-  yellow000: '#FFF7E8',
-  yellow100: '#FFEBC4',
-  yellow200: '#FFDB96',
-  yellow300: '#FFCA62',
-  yellow400: '#FFB72B',
-  yellow500: '#FFA800',
-  yellow600: '#EF9E00',
-  yellow700: '#CC8600',
-  yellow800: '#A56D00',
-  yellow900: '#724B00',
-
-  red000: '#FFF2F4',
-  red100: '#FFE5E9',
-  red200: '#FFB8C1',
-  red300: '#FF667A',
-  red400: '#ED3B53',
-  red500: '#CC1F36',
-  red600: '#B2121F',
-  red700: '#990F14',
-  red800: '#730B0F',
-  red900: '#52080B',
-}
 
 export const classicPalette: Palette = {
   textInverted: '#FFFFFF',
@@ -177,4 +102,12 @@ export const classicPalette: Palette = {
   red700: '#990F14',
   red800: '#730B0F',
   red900: '#52080B',
+}
+
+export const palette: Palette = {
+  ...classicPalette,
+
+  primary500: '#4F2ABA', // duplicate purple500
+  primary600: '#412399', // duplicate purple600
+  primary700: '#341C7A', // duplicate purple700
 }

--- a/packages/design-tokens/src/tokens/color/palette.ts
+++ b/packages/design-tokens/src/tokens/color/palette.ts
@@ -28,14 +28,14 @@ import { Palette } from '../../system'
 
 /* eslint-disable sort-keys */
 
-export const classicPalette: Palette = {
+export const palette: Palette = {
   textInverted: '#FFFFFF',
   transparent: 'transparent',
   white: '#FFFFFF',
 
-  primary500: '#64518A',
-  primary600: '#473764',
-  primary700: '#2A1B60',
+  primary500: '#4F2ABA', // duplicate purple500
+  primary600: '#412399', // duplicate purple600
+  primary700: '#341C7A', // duplicate purple700
 
   charcoal000: '#FBFBFC',
   charcoal100: '#F5F6F7',
@@ -104,10 +104,9 @@ export const classicPalette: Palette = {
   red900: '#52080B',
 }
 
-export const palette: Palette = {
-  ...classicPalette,
-
-  primary500: '#4F2ABA', // duplicate purple500
-  primary600: '#412399', // duplicate purple600
-  primary700: '#341C7A', // duplicate purple700
+export const classicPalette: Palette = {
+  ...palette,
+  primary500: '#64518A',
+  primary600: '#473764',
+  primary700: '#2A1B60',
 }

--- a/packages/design-tokens/src/tokens/color/palette.ts
+++ b/packages/design-tokens/src/tokens/color/palette.ts
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,6 +35,82 @@ export const palette: Palette = {
   primary500: '#64518A',
   primary600: '#473764',
   primary700: '#2A1B60',
+
+  charcoal000: '#FBFBFC',
+  charcoal100: '#F5F6F7',
+  charcoal200: '#DEE1E5',
+  charcoal300: '#C1C6CC',
+  charcoal400: '#939BA5',
+  charcoal500: '#707781',
+  charcoal600: '#4C535B',
+  charcoal700: '#343C42',
+  charcoal800: '#262D33',
+  charcoal900: '#262D33',
+
+  purple000: '#F3F2FF',
+  purple100: '#E8E5FF',
+  purple200: '#BFB2FF',
+  purple300: '#9785F2',
+  purple400: '#6C43E0',
+  purple500: '#4F2ABA',
+  purple600: '#412399',
+  purple700: '#341C7A',
+  purple800: '#291661',
+  purple900: '#1E1047',
+
+  blue000: '#f7fcff',
+  blue100: '#e0f2ff',
+  blue200: '#bfe3ff',
+  blue300: '#6fbcf7',
+  blue400: '#49a9f2',
+  blue500: '#0087e1',
+  blue600: '#0059b2',
+  blue700: '#00418c',
+  blue800: '#0f2f66',
+  blue900: '#08284d',
+
+  green000: '#f2fff5',
+  green100: '#e0ffe7',
+  green200: '#b4fac2',
+  green300: '#67e591',
+  green400: '#33cc73',
+  green500: '#24b25f',
+  green600: '#0e8c42',
+  green700: '#0b6b38',
+  green800: '#08522d',
+  green900: '#06381f',
+
+  yellow000: '#FFF7E8',
+  yellow100: '#FFEBC4',
+  yellow200: '#FFDB96',
+  yellow300: '#FFCA62',
+  yellow400: '#FFB72B',
+  yellow500: '#FFA800',
+  yellow600: '#EF9E00',
+  yellow700: '#CC8600',
+  yellow800: '#A56D00',
+  yellow900: '#724B00',
+
+  red000: '#FFF2F4',
+  red100: '#FFE5E9',
+  red200: '#FFB8C1',
+  red300: '#FF667A',
+  red400: '#ED3B53',
+  red500: '#CC1F36',
+  red600: '#B2121F',
+  red700: '#990F14',
+  red800: '#730B0F',
+  red900: '#52080B',
+}
+
+export const legacyPalette: Palette = {
+  textInverted: '#FFFFFF',
+  transparent: 'transparent',
+  white: '#FFFFFF',
+
+  primary500: '#4F2ABA', // duplicate purple500
+  primary600: '#412399', // duplicate purple600
+  primary700: '#341C7A', // duplicate purple700
 
   charcoal000: '#FBFBFC',
   charcoal100: '#F5F6F7',

--- a/packages/design-tokens/src/tokens/color/palette.ts
+++ b/packages/design-tokens/src/tokens/color/palette.ts
@@ -32,9 +32,9 @@ export const palette: Palette = {
   transparent: 'transparent',
   white: '#FFFFFF',
 
-  primary500: '#64518A',
-  primary600: '#473764',
-  primary700: '#2A1B60',
+  primary500: '#4F2ABA', // duplicate purple500
+  primary600: '#412399', // duplicate purple600
+  primary700: '#341C7A', // duplicate purple700
 
   charcoal000: '#FBFBFC',
   charcoal100: '#F5F6F7',
@@ -108,9 +108,9 @@ export const legacyPalette: Palette = {
   transparent: 'transparent',
   white: '#FFFFFF',
 
-  primary500: '#4F2ABA', // duplicate purple500
-  primary600: '#412399', // duplicate purple600
-  primary700: '#341C7A', // duplicate purple700
+  primary500: '#64518A',
+  primary600: '#473764',
+  primary700: '#2A1B60',
 
   charcoal000: '#FBFBFC',
   charcoal100: '#F5F6F7',

--- a/packages/design-tokens/src/tokens/color/palette.ts
+++ b/packages/design-tokens/src/tokens/color/palette.ts
@@ -103,7 +103,7 @@ export const palette: Palette = {
   red900: '#52080B',
 }
 
-export const legacyPalette: Palette = {
+export const classicPalette: Palette = {
   textInverted: '#FFFFFF',
   transparent: 'transparent',
   white: '#FFFFFF',

--- a/packages/design-tokens/src/tokens/color/semantic_colors.ts
+++ b/packages/design-tokens/src/tokens/color/semantic_colors.ts
@@ -99,7 +99,7 @@ export const semanticColors: SemanticColors = {
   },
 }
 
-export const legacySemanticColors: SemanticColors = {
+export const classicSemanticColors: SemanticColors = {
   danger: {
     altText: red400,
     borderColor: charcoal300,

--- a/packages/design-tokens/src/tokens/color/semantic_colors.ts
+++ b/packages/design-tokens/src/tokens/color/semantic_colors.ts
@@ -52,53 +52,6 @@ const {
   white,
 } = palette
 
-export const semanticColors: SemanticColors = {
-  danger: {
-    altText: red400,
-    borderColor: charcoal300,
-    dark: red600,
-    darker: red700,
-    light: red100,
-    lighter: red000,
-    linkColor: blue500,
-    main: red500,
-    text: white,
-  },
-  neutral: {
-    altText: charcoal600,
-    borderColor: charcoal300,
-    dark: charcoal500,
-    darker: charcoal600,
-    light: charcoal100,
-    lighter: charcoal000,
-    linkColor: blue500,
-    main: charcoal400,
-    text: white,
-  },
-  primary: {
-    altText: purple400,
-    borderColor: charcoal300,
-    dark: purple500,
-    darker: purple600,
-    light: purple100,
-    lighter: purple000,
-    linkColor: blue500,
-    main: purple400,
-    text: white,
-  },
-  secondary: {
-    altText: purple400,
-    borderColor: charcoal300,
-    dark: primary600,
-    darker: primary700,
-    light: purple100,
-    lighter: purple000,
-    linkColor: blue500,
-    main: primary500,
-    text: white,
-  },
-}
-
 export const classicSemanticColors: SemanticColors = {
   danger: {
     altText: red400,
@@ -143,5 +96,15 @@ export const classicSemanticColors: SemanticColors = {
     linkColor: blue500,
     main: primary500,
     text: white,
+  },
+}
+
+export const semanticColors: SemanticColors = {
+  ...classicSemanticColors,
+  primary: {
+    ...classicSemanticColors.primary,
+    dark: purple500,
+    darker: purple600,
+    main: purple400,
   },
 }

--- a/packages/design-tokens/src/tokens/color/semantic_colors.ts
+++ b/packages/design-tokens/src/tokens/color/semantic_colors.ts
@@ -25,7 +25,7 @@
  */
 
 import { SemanticColors } from '../../system'
-import { palette, classicPalette } from './palette'
+import { palette } from './palette'
 
 const {
   blue500,
@@ -96,15 +96,5 @@ export const semanticColors: SemanticColors = {
     linkColor: blue500,
     main: primary500,
     text: white,
-  },
-}
-
-export const classicSemanticColors: SemanticColors = {
-  ...semanticColors,
-  primary: {
-    ...semanticColors.primary,
-    dark: classicPalette.primary600,
-    darker: classicPalette.primary700,
-    main: classicPalette.primary500,
   },
 }

--- a/packages/design-tokens/src/tokens/color/semantic_colors.ts
+++ b/packages/design-tokens/src/tokens/color/semantic_colors.ts
@@ -25,7 +25,7 @@
  */
 
 import { SemanticColors } from '../../system'
-import { palette } from './palette'
+import { palette, classicPalette } from './palette'
 
 const {
   blue500,
@@ -52,7 +52,7 @@ const {
   white,
 } = palette
 
-export const classicSemanticColors: SemanticColors = {
+export const semanticColors: SemanticColors = {
   danger: {
     altText: red400,
     borderColor: charcoal300,
@@ -78,12 +78,12 @@ export const classicSemanticColors: SemanticColors = {
   primary: {
     altText: purple400,
     borderColor: charcoal300,
-    dark: primary600,
-    darker: primary700,
+    dark: purple500,
+    darker: purple600,
     light: purple100,
     lighter: purple000,
     linkColor: blue500,
-    main: primary500,
+    main: purple400,
     text: white,
   },
   secondary: {
@@ -99,12 +99,12 @@ export const classicSemanticColors: SemanticColors = {
   },
 }
 
-export const semanticColors: SemanticColors = {
-  ...classicSemanticColors,
+export const classicSemanticColors: SemanticColors = {
+  ...semanticColors,
   primary: {
-    ...classicSemanticColors.primary,
-    dark: purple500,
-    darker: purple600,
-    main: purple400,
+    ...semanticColors.primary,
+    dark: classicPalette.primary600,
+    darker: classicPalette.primary700,
+    main: classicPalette.primary500,
   },
 }

--- a/packages/design-tokens/src/tokens/color/semantic_colors.ts
+++ b/packages/design-tokens/src/tokens/color/semantic_colors.ts
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,6 +41,8 @@ const {
   purple000,
   purple100,
   purple400,
+  purple500,
+  purple600,
   red000,
   red100,
   red400,
@@ -51,6 +53,53 @@ const {
 } = palette
 
 export const semanticColors: SemanticColors = {
+  danger: {
+    altText: red400,
+    borderColor: charcoal300,
+    dark: red600,
+    darker: red700,
+    light: red100,
+    lighter: red000,
+    linkColor: blue500,
+    main: red500,
+    text: white,
+  },
+  neutral: {
+    altText: charcoal600,
+    borderColor: charcoal300,
+    dark: charcoal500,
+    darker: charcoal600,
+    light: charcoal100,
+    lighter: charcoal000,
+    linkColor: blue500,
+    main: charcoal400,
+    text: white,
+  },
+  primary: {
+    altText: purple400,
+    borderColor: charcoal300,
+    dark: purple500,
+    darker: purple600,
+    light: purple100,
+    lighter: purple000,
+    linkColor: blue500,
+    main: purple400,
+    text: white,
+  },
+  secondary: {
+    altText: purple400,
+    borderColor: charcoal300,
+    dark: primary600,
+    darker: primary700,
+    light: purple100,
+    lighter: purple000,
+    linkColor: blue500,
+    main: primary500,
+    text: white,
+  },
+}
+
+export const legacySemanticColors: SemanticColors = {
   danger: {
     altText: red400,
     borderColor: charcoal300,


### PR DESCRIPTION
### :sparkles: Changes

- Implements the theme changes used in #91 
- Creates new `legacySemanticColors`, `legacyPalette`, and `legacyTheme` to provide the option of maintaining current color settings

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [x] Link(s) to related Github issues
