### PR TITLE
Fix change history icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `ChangeHistory` icon fixed
 - Update theme object to use more vibrant colors by default.
 - Improved documentation around installation of NPM package
 

--- a/packages/icons/src/svg/ChangeHistory.svg
+++ b/packages/icons/src/svg/ChangeHistory.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 3.99586L21.2656 20H2.73445L12 3.99586Z" stroke="black" stroke-width="2"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M23 21L12 2L1 21H23ZM4.46889 19H19.5311L12 5.99173L4.46889 19Z" fill="#1C2125"/>
 </svg>


### PR DESCRIPTION
### :sparkles: Changes
Updates the `ChangeHistory` icon

**Before**
![image](https://user-images.githubusercontent.com/170681/69585790-8d192300-0f95-11ea-94d0-51a954a30fa6.png)

**After**
![image](https://user-images.githubusercontent.com/170681/69585798-94403100-0f95-11ea-8437-a4c86629f4d5.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots
