### PR TITLE
Fix missing OverlaySurfaceArrow border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed confusing `maxWidth` property
   - `Link` color within `Tooltip` is set to `blue200` to ensure readability.
 - `useFocusTrap` and `useScrollLock` behavior when `Popover` is nested in a `Modal` or another `Popover`.
+- Added missing border on `OverlaySurfaceArrow`
 
 ## [0.7.6] - 2019-11-18
 

--- a/packages/components/src/Overlay/OverlaySurfaceArrow.tsx
+++ b/packages/components/src/Overlay/OverlaySurfaceArrow.tsx
@@ -24,16 +24,21 @@
 
  */
 
-import { color, ColorProps, CompatibleHTMLProps } from '@looker/design-tokens'
+import {
+  border,
+  BorderProps,
+  color,
+  ColorProps,
+  CompatibleHTMLProps,
+} from '@looker/design-tokens'
 import { PopperArrowProps } from 'react-popper'
 import styled from 'styled-components'
 
 interface OverlaySurfaceArrowProps
-  extends Omit<CompatibleHTMLProps<HTMLDivElement>, 'style'>,
+  extends BorderProps,
     ColorProps,
+    Omit<CompatibleHTMLProps<HTMLDivElement>, 'style'>,
     PopperArrowProps {
-  borderColor?: string
-  border?: string
   ['data-placement']: string
 }
 
@@ -52,9 +57,11 @@ export const OverlaySurfaceArrow = styled.div.attrs(
     height: 0.5rem;
 
     ${color}
-
-    border-bottom: ${props => props.border} ${props => props.borderColor};
-    border-right: ${props => props.border} ${props => props.borderColor};
+    ${border}
+    /* only want border-right and border-bottom from styled-system's border */
+    border-top: none;
+    border-left: none;
+    border-radius: 0;
   }
 
   &[data-placement*='top'] {


### PR DESCRIPTION
### :sparkles: Changes

- Fix missing border on `OverlaySurfaceArrow`

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/53451193/70360688-10f3ca80-1834-11ea-95f7-5abdccd28100.png)

![image](https://user-images.githubusercontent.com/53451193/70360635-ef92de80-1833-11ea-8cbe-cc3c93c9385d.png)
