### PR TITLE
Correct usage of textAlign vs. align

### DIFF
--- a/packages/www/src/documentation/components/text/headings.mdx
+++ b/packages/www/src/documentation/components/text/headings.mdx
@@ -71,9 +71,9 @@ Another common pattern for headings is to control the font-weight and the text-t
 The `align` property allows you to adjust the `text-align` property of your `<Heading />` component. This is useful if you need to center or right align the text.
 
 ```jsx static
-<Heading align="left">◀️ Align left (Default) </Heading>
-<Heading align="center">◀️ Align Center ▶️</Heading>
-<Heading align="right">Align Right ▶️</Heading>
+<Heading textAlign="left">◀️ Align left (Default) </Heading>
+<Heading textAlign="center">◀️ Align Center ▶️</Heading>
+<Heading textAlign="right">Align Right ▶️</Heading>
 ```
 
 ---

--- a/packages/www/src/documentation/components/text/text.mdx
+++ b/packages/www/src/documentation/components/text/text.mdx
@@ -64,14 +64,14 @@ You can use the `align` property to change the alignment of the rendered text, b
 </Card>
 <Card>
   <CardContent>
-    <Paragraph align="center">
+    <Paragraph textAlign="center">
       This is how you can center align Paragraph text
     </Paragraph>
   </CardContent>
 </Card>
 <Card>
   <CardContent>
-    <Paragraph align="right">
+    <Paragraph textAlign="right">
       This is how you can right align Paragraph text
     </Paragraph>
   </CardContent>


### PR DESCRIPTION
### :sparkles: Changes

- Use `textAlign` instead of `align`

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
