### PR TITLE
Add `onClose` callback for ModalManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Changes
+
+- `ModalManager` (and it's derived `DialogManager` & `DrawerManager`) now support a `onClose` callback that will be called when the modal is closed.
+
 ## [0.7.7] - 2019-12-19
 
 ### Added

--- a/packages/components/src/Modal/ModalManager.tsx
+++ b/packages/components/src/Modal/ModalManager.tsx
@@ -48,6 +48,10 @@ export interface ModalManagerProps extends ManagedModalProps {
    */
   canClose?: () => boolean
   /**
+   * Specify a callback to be called each time this Modal is closed
+   */
+  onClose?: () => void
+  /**
    * Can be one of: top, bottom, left, right, auto, with the modifiers: start,
    * end. This value comes directly from popper.js. See
    * https://popper.js.org/popper-documentation.html#Popper.placements for more
@@ -117,6 +121,7 @@ export abstract class ModalManager extends Component<
 
   public close() {
     if (this.props.canClose && !this.props.canClose()) return
+    this.props.onClose && this.props.onClose()
     this.setState({ isOpen: false })
   }
 


### PR DESCRIPTION
### :sparkles: Changes

- Add `onClose` callback for ModalManager

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC