### PR TITLE
Simplify ModalSurface maxWidth (& remove minWidth)

### DIFF
--- a/packages/components/src/Modal/ModalSurface.tsx
+++ b/packages/components/src/Modal/ModalSurface.tsx
@@ -139,6 +139,5 @@ Style.defaultProps = {
   boxShadow: 3,
   color: 'palette.charcoal900',
   maxHeight: '90vh',
-  maxWidth: ['90vw', '90vw', '700px'],
-  minWidth: ['80vw', '400px'],
+  maxWidth: '90vw',
 }


### PR DESCRIPTION
### :sparkles: Changes

- Rolling back `Style.defaultProps.maxWidth` for now since it can't be overwritten (without the use of `!important`) by `surfaceStyles` – the latter can't match the former's media query values.
- In the future, `surfaceStyles` could be updated to support responsive values.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots
