### PR TITLE
update cancel button color to neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- update button color to be neutral for useConfirm and Confirm components.
 - Button size map was updated with correct sizes
 - Test for Button got updates to reflect the correct sizes
 - `ModalManager` (and it's derived `DialogManager` & `DrawerManager`) now support a `onClose` callback that will be called when the modal is closed.

--- a/packages/components/src/Modal/Dialog/Confirm.test.tsx
+++ b/packages/components/src/Modal/Dialog/Confirm.test.tsx
@@ -39,7 +39,7 @@ const requiredProps = {
 }
 
 const optionalProps = {
-  cancelLabel: 'Dont Delete',
+  cancelLabel: "Don't Delete",
   confirmLabel: 'Delete',
   message: 'This is permanent',
   onCancel: jest.fn(),

--- a/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
+++ b/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
@@ -46,6 +46,11 @@ export interface ConfirmationProps extends ManagedModalProps {
    */
   buttonColor?: keyof SemanticColors
   /**
+   * Defines the color of the confirm button. Can be the string name of a color listed in the color theme, or a color object.
+   * @default "neutral"
+   */
+  cancelColor?: keyof SemanticColors
+  /**
    * Confirmation button text
    * @default 'Confirm'
    */
@@ -86,6 +91,7 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
   close,
   confirmLabel = 'Confirm',
   buttonColor = 'primary',
+  cancelColor = 'neutral',
   isOpen = false,
   message,
   onCancel,
@@ -119,7 +125,9 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
         <Button onClick={confirm} color={buttonColor}>
           {confirmLabel}
         </Button>
-        <ButtonTransparent onClick={cancel}>{cancelLabel}</ButtonTransparent>
+        <ButtonTransparent color={cancelColor} onClick={cancel}>
+          {cancelLabel}
+        </ButtonTransparent>
       </ModalFooter>
     </Dialog>
   )


### PR DESCRIPTION
✨ Changes

- updated cancel button color on UseConfirm and Confirm components

✅ Requirements
- [  ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [x] Link(s) to related Github issues

📷 Screenshots

<img width="235" alt="Screen Shot 2019-12-16 at 12 05 10 PM" src="https://user-images.githubusercontent.com/23616264/70941636-b4499a00-2001-11ea-8016-7b1aa9feb6c2.png">

