### PR TITLE
Remove es2015 package generation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,8 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build:all": "yarn clean && yarn run build:es2015 && yarn run build:esm && yarn run build:cjs",
-    "build:es2015": "ttsc --project tsconfig.build.json --module es2015 --target es2015 --outDir dist/es2015",
+    "build:all": "yarn clean && yarn run build:esm && yarn run build:cjs",
     "build:esm": "ttsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
     "build:cjs": "ttsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "clean": "rm -Rf ./dist",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -17,8 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build:all": "yarn clean && yarn run build:es2015 && yarn run build:esm && yarn run build:cjs",
-    "build:es2015": "ttsc --project tsconfig.build.json --module es2015 --target es2015 --outDir dist/es2015",
+    "build:all": "yarn clean && yarn run build:esm && yarn run build:cjs",
     "build:esm": "ttsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
     "build:cjs": "ttsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "clean": "rm -Rf ./dist",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -17,8 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build:all": "yarn clean && yarn build:icons && yarn run build:es2015 && yarn run build:esm && yarn run build:cjs",
-    "build:es2015": "ttsc --project tsconfig.build.json --module es2015 --target es2015 --outDir dist/es2015",
+    "build:all": "yarn clean && yarn build:icons && yarn run build:esm && yarn run build:cjs",
     "build:esm": "ttsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
     "build:cjs": "ttsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:icons": "node bin/build.js",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -17,8 +17,7 @@
     "access": "public"
   },
   "scripts": {
-    "build:all": "yarn clean && yarn run build:es2015 && yarn run build:esm && yarn run build:cjs",
-    "build:es2015": "ttsc --project tsconfig.build.json --module es2015 --target es2015 --outDir dist/es2015",
+    "build:all": "yarn clean && yarn run build:esm && yarn run build:cjs",
     "build:esm": "ttsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
     "build:cjs": "ttsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "clean": "rm -Rf ./dist",


### PR DESCRIPTION
### :sparkles: Changes

- The es2015 target wasn't actually in use (esm instead) so removing that to accelerate builds

### :white_check_mark: Requirements

- [ ] Build and tests are passing
- [x] PR is ideally < 400LOC