### PR TITLE
[LENS-470] Slider stacking and doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Default `theme.reset` is inactive by default now. If your use depends on the previous behavior you can reproduce it via the instructions in this gist: https://gist.github.com/lukelooker/29576e0db918914137638cf9d2649bea
 
+### Fixed
+
+- custom slider knobs now have proper stacking order so as not to appear over modals
+
 ## [0.7.8] - 2018-12-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - custom slider knobs now have proper stacking order so as not to appear over modals
+- fixed documentation crosslinking between Dialog and Confirm
 
 ## [0.7.8] - 2018-12-16
 

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -322,7 +322,9 @@ const SliderValue = styled.div<SliderValueProps>`
   }
 `
 
-const SliderValueContent = styled.span``
+const SliderValueContent = styled.span`
+  position: relative;
+`
 
 interface SliderValueWrapperProps {
   valueSpacing: string

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -111,23 +111,6 @@ const SliderInternal = forwardRef(
         onMouseDown={handleUnfocus}
         data-testid="container"
       >
-        <SliderInput
-          branded={branded}
-          disabled={disabled}
-          id={id}
-          isFocused={isFocused}
-          knobSize={knobSize}
-          max={max}
-          min={min}
-          name={name}
-          onChange={handleChange}
-          step={step}
-          type="range"
-          value={displayValue}
-          aria-labelledby={restProps['aria-labelledby']}
-          data-testid="slider-input"
-          ref={ref}
-        />
         <SliderTrack knobSize={knobSize} trackHeight={trackHeight}>
           <SliderFill
             offsetPercent={fillPercent}
@@ -148,6 +131,23 @@ const SliderInternal = forwardRef(
             </SliderValue>
           </SliderValueWrapper>
         </SliderTrack>
+        <SliderInput
+          branded={branded}
+          disabled={disabled}
+          id={id}
+          isFocused={isFocused}
+          knobSize={knobSize}
+          max={max}
+          min={min}
+          name={name}
+          onChange={handleChange}
+          step={step}
+          type="range"
+          value={displayValue}
+          aria-labelledby={restProps['aria-labelledby']}
+          data-testid="slider-input"
+          ref={ref}
+        />
       </div>
     )
   }
@@ -181,7 +181,6 @@ const SliderInput = styled.input.attrs({ type: 'range' })<SliderInputProps>`
   height: ${({ knobSize }) => knobSize + 6}px;
   position: relative;
   width: 100%;
-  z-index: 1;
   -webkit-appearance: none; /* stylelint-disable-line */
 
   &::-webkit-slider-thumb {
@@ -242,7 +241,6 @@ const SliderTrack = styled.div<SliderTrackProps>`
   top: 50%;
   left: ${({ knobSize }) => `${knobSize / 2}px`};
   margin-top: ${({ trackHeight }) => `-${trackHeight / 2}px`};
-  z-index: 0;
 `
 
 interface ControlProps {
@@ -303,14 +301,13 @@ const SliderValue = styled.div<SliderValueProps>`
     border-bottom: none;
     border-right: none;
     content: ' ';
-    display: block;
     height: 8px;
-    left: calc(50% - 4px);
-    transform: rotate(45deg);
+    left: 50%;
+    margin-left: -4px;
     position: absolute;
-    top: -5px;
+    transform: rotate(45deg);
+    top: -6px;
     width: 8px;
-    z-index: 0;
   }
   &::after {
     /* mask out border overshoot on "word bubble" stem */
@@ -322,14 +319,10 @@ const SliderValue = styled.div<SliderValueProps>`
     position: absolute;
     top: 0;
     width: 80%;
-    z-index: 0;
   }
 `
 
-const SliderValueContent = styled.span`
-  position: relative;
-  z-index: 1;
-`
+const SliderValueContent = styled.span``
 
 interface SliderValueWrapperProps {
   valueSpacing: string
@@ -340,7 +333,6 @@ const SliderValueWrapper = styled.div<SliderValueWrapperProps>`
   display: grid;
   justify-items: center;
   left: calc(${({ offsetPercent }) => offsetPercent}%);
-  overflow: visible;
   position: absolute;
   top: ${({ valueSpacing }) => valueSpacing};
 `

--- a/packages/components/src/Form/Inputs/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Slider/__snapshots__/Slider.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`renders focus styles on keypress 1`] = `
   height: 30px;
   position: relative;
   width: 100%;
-  z-index: 1;
   -webkit-appearance: none;
 }
 

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,11 +24,16 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
+import { SliderDemo } from './Slider/SliderDemo'
+import { ConfirmDemo } from './Confirm/ConfirmDemo'
+
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <>
         <GlobalStyle />
+        <SliderDemo />
+        <ConfirmDemo />
       </>
     </ThemeProvider>
   )

--- a/packages/www/src/documentation/components/modals/dialog.mdx
+++ b/packages/www/src/documentation/components/modals/dialog.mdx
@@ -8,8 +8,8 @@ import { Banner } from '@looker/components'
 
 <Banner intent="warning">
   Dialog provides a general purpose (empty) modal overlay. Most likely you'll
-  you'll find <a href="./confirm">Confirm</a> more useful to drive specific user
-  action.
+  find <a href="/components/modals/confirm">Confirm</a> more useful to drive
+  specific user action.
 </Banner>
 
 Dialogs inform users about a task and can contain critical information, require decisions, or involve multiple tasks.


### PR DESCRIPTION
### :sparkles: Changes

- Removes z-index and fixes element ordering so that slider knobs don't obscure modal content
- Fixes url linking between Dialog and Confirm documents

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [x] Link(s) to related Github issues

### :camera: Screenshots
![before-after](https://user-images.githubusercontent.com/238293/71216851-97ff6480-2270-11ea-9a0c-6675d5ff2cdd.png)
