### PR TITLE
[LENS-498] Responsive Dialog Widths

### DIFF
--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -61,7 +61,7 @@ export interface ManagedModalProps {
    * You can also specify `auto` if you want the Surface to auto-size to its content.
    * @default auto
    */
-  width?: string
+  width?: string | string[]
 }
 
 export interface ModalProps extends ManagedModalProps {

--- a/packages/playground/src/Confirm/ConfirmDemo.tsx
+++ b/packages/playground/src/Confirm/ConfirmDemo.tsx
@@ -37,6 +37,7 @@ const StaticConfirm: React.FC = () => {
         alert('You did something')
         close()
       }}
+      width={['10rem', '20rem', '30rem']}
     >
       {open => (
         <Button onClick={open} mr="small">

--- a/packages/playground/src/Confirm/ConfirmDemo.tsx
+++ b/packages/playground/src/Confirm/ConfirmDemo.tsx
@@ -37,7 +37,7 @@ const StaticConfirm: React.FC = () => {
         alert('You did something')
         close()
       }}
-      width={['10rem', '20rem', '30rem']}
+      width={['10rem', '20rem', '30rem', '40rem']}
     >
       {open => (
         <Button onClick={open} mr="small">
@@ -57,6 +57,7 @@ const RichConfirm: React.FC = () => {
         alert('Now you know.')
         close()
       }}
+      width={['10rem', '20rem', '30rem', '40rem']}
     >
       {open => <Button onClick={open}>Do something fancy</Button>}
     </Confirm>

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { MenuDemo } from './Menu/MenuDemo'
+import { ConfirmDemo } from './Confirm/ConfirmDemo'
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <>
         <GlobalStyle />
-        <MenuDemo />
+        <ConfirmDemo />
       </>
     </ThemeProvider>
   )


### PR DESCRIPTION
### :sparkles: Changes

- add support for a styled system array of widths in the modal typescript definitions

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots

![confirm-widths](https://user-images.githubusercontent.com/238293/72093513-6276f580-32c9-11ea-84cb-2cbb5c63f670.gif)
