### PR TITLE
Fix Gatsby build error with Popover

### DIFF
--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -200,11 +200,13 @@ function useVerticalSpace(
   // Set height to the larger, popper will take care of flipping as needed
   const max = Math.max(spaceTop, spaceBottom)
 
+  const windowHeight = typeof window !== `undefined` ? window.innerHeight : 50
+
   // If the height of the overlay will be 50px or less,
   // it's too small to scroll
   // Popper will awkwardly move the overlay to try to fit in the window
   // but that's better than squishing it so small.
-  return max > 50 ? max : window.innerHeight
+  return max > 50 ? max : windowHeight
 }
 
 function useOpenWithoutElement(isOpen: boolean, element: HTMLElement | null) {


### PR DESCRIPTION
### :sparkles: Changes

Popover uses `window` object without first verifying that it exists. When Gatsby does its build it loads components without a real browser and therefore throws an exeception when trying to run this code.

Added a check to verify that window object exists before attempting to get its innerHeight

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
