### PR TITLE
[LENS-502] Protect modal input changes from being accidentally discarded

### DIFF
--- a/packages/components/src/Modal/Dialog/Confirm.test.tsx
+++ b/packages/components/src/Modal/Dialog/Confirm.test.tsx
@@ -51,8 +51,8 @@ afterEach(() => {
   optionalProps.onCancel.mockClear()
 })
 
-test('<Confirm/> with defaults', () => {
-  const { getByText, queryByText } = renderWithTheme(
+test('<Confirm/> confirm button closes modal and calls onConfirm callback', () => {
+  const { getByText, queryByTestId } = renderWithTheme(
     <Confirm {...requiredProps}>
       {open => <Button onClick={open}>Do Something</Button>}
     </Confirm>
@@ -61,18 +61,25 @@ test('<Confirm/> with defaults', () => {
   const opener = getByText('Do Something')
   fireEvent.click(opener)
 
-  const button = getByText('Confirm')
+  const confirmButton = getByText('Confirm')
 
+  expect(queryByTestId('confirmation-dialog')).toBeVisible()
+  expect(queryByTestId('discard-changes-dialog')).not.toBeInTheDocument()
   expect(getByText(requiredProps.title)).toBeVisible()
   expect(getByText(requiredProps.message)).toBeVisible()
-  expect(button).toHaveStyle(`background: ${semanticColors.primary.main}`)
+  expect(confirmButton).toHaveStyle(
+    `background: ${semanticColors.primary.main}`
+  )
 
-  fireEvent.click(button)
+  fireEvent.click(confirmButton)
   expect(requiredProps.onConfirm).toHaveBeenCalledTimes(1)
-
-  fireEvent.click(getByText('Cancel'))
-  expect(queryByText(requiredProps.title)).toBeNull()
+  expect(queryByTestId('confirmation-dialog')).not.toBeInTheDocument()
+  expect(queryByTestId('discard-changes-dialog')).not.toBeInTheDocument()
 })
+
+test('<Confirm /> cancel button closes modal and calls onCancel callback by default', () => {})
+
+test('<Confirm /> cancel button renders "discard changes modal" when protectChanges is true', () => {})
 
 test('<Confirm/> with custom props', () => {
   const { getByText } = renderWithTheme(
@@ -87,9 +94,7 @@ test('<Confirm/> with custom props', () => {
   const button = getByText(optionalProps.confirmLabel || '')
   expect(button).toHaveStyle(`background: ${semanticColors.danger.main}`)
 
-  fireEvent.click(getByText(optionalProps.cancelLabel || ''))
   fireEvent.click(button)
 
   expect(requiredProps.onConfirm).toHaveBeenCalledTimes(1)
-  expect(optionalProps.onCancel).toHaveBeenCalledTimes(1)
 })

--- a/packages/components/src/Modal/Dialog/Confirm.tsx
+++ b/packages/components/src/Modal/Dialog/Confirm.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, ReactNode, useState, SyntheticEvent } from 'react'
+import React, { FC, ReactNode, useState } from 'react'
 import isFunction from 'lodash/isFunction'
 import { useToggle } from '../../utils/useToggle'
 import { ConfirmationDialog, ConfirmationProps } from './ConfirmationDialog'

--- a/packages/components/src/Modal/Dialog/Confirm.tsx
+++ b/packages/components/src/Modal/Dialog/Confirm.tsx
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,34 +24,111 @@
 
  */
 
-import React, { FC, ReactNode } from 'react'
+import React, { FC, ReactNode, useState } from 'react'
+import isFunction from 'lodash/isFunction'
 import { useToggle } from '../../utils/useToggle'
 import { ConfirmationDialog, ConfirmationProps } from './ConfirmationDialog'
+import { DiscardChangesDialog } from './DiscardChangesDialog'
 
-export interface ConfirmProps extends ConfirmationProps {
+export interface ConfirmProps extends Omit<ConfirmationProps, 'onCancel'> {
   /**
    * Render prop is passed the confirmation opener
    */
   children: (open: () => void) => ReactNode
+  /**
+   * If true, watch for child input changes. Prompt user to confirm cancel action if there are unsaved changes.
+   * @default false
+   */
+  protectChanges?: boolean
+  /**
+   * Callback attached to any input elements within the modal.
+   */
+  onChange?: () => void
+  /**
+   * Callback fires if props.protectChanges === true and user closes modal without pressing confirm.
+   */
+  onCancel?: () => void
 }
 
-export function useConfirm(props: ConfirmationProps): [ReactNode, () => void] {
-  const { value, setOn, setOff } = useToggle()
+enum DialogStates {
+  default = 'DEFAULT',
+  unsaved = 'UNSAVED_CHANGES',
+  confirmClose = 'CONFIRM_CLOSE',
+}
 
-  const rendered = (
-    <ConfirmationDialog {...props} isOpen={value} close={setOff} />
+export function useConfirm({
+  protectChanges,
+  onCancel,
+  onConfirm,
+  onChange,
+  ...props
+}: Omit<ConfirmProps, 'children'>): [ReactNode, () => void] {
+  const [dialogState, setDialogState] = useState(DialogStates.default)
+  const { value: isOpen, setOn: setOpen, setOff: setClosed } = useToggle()
+
+  const resetDialog = () => {
+    setDialogState(DialogStates.default)
+  }
+
+  const openModal = () => {
+    resetDialog()
+    setOpen()
+  }
+
+  const handleCancel = () => {
+    if (protectChanges && dialogState === DialogStates.unsaved) {
+      // User attempted to close without saving changes.
+      // Update state to render Confirm Close message.
+      setDialogState(DialogStates.confirmClose)
+    } else {
+      if (isFunction(onCancel)) {
+        onCancel()
+      }
+      setClosed()
+    }
+  }
+
+  const handleConfirm = () => {
+    if (isFunction(onConfirm)) {
+      onConfirm()
+    }
+    setClosed()
+  }
+
+  const handleChange = () => {
+    setDialogState(DialogStates.unsaved)
+    if (isFunction(onChange)) {
+      onChange()
+    }
+  }
+
+  const renderedDialog = (
+    <>
+      <ConfirmationDialog
+        {...props}
+        onChange={handleChange}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+        isOpen={isOpen && dialogState !== DialogStates.confirmClose}
+      />
+      <DiscardChangesDialog
+        resetDialog={resetDialog}
+        closeDialog={handleCancel}
+        isOpen={isOpen && dialogState === DialogStates.confirmClose}
+      />
+    </>
   )
 
-  return [rendered, setOn]
+  return [renderedDialog, openModal]
 }
 
 export const Confirm: FC<ConfirmProps> = ({ children, ...props }) => {
-  const [confirmation, confirm] = useConfirm(props)
+  const [confirmationDialog, openModal] = useConfirm(props)
 
   return (
     <>
-      {children(confirm)}
-      {confirmation}
+      {children(openModal)}
+      {confirmationDialog}
     </>
   )
 }

--- a/packages/components/src/Modal/Dialog/Confirm.tsx
+++ b/packages/components/src/Modal/Dialog/Confirm.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, ReactNode, useState } from 'react'
+import React, { FC, ReactNode, useState, SyntheticEvent } from 'react'
 import isFunction from 'lodash/isFunction'
 import { useToggle } from '../../utils/useToggle'
 import { ConfirmationDialog, ConfirmationProps } from './ConfirmationDialog'
@@ -43,7 +43,7 @@ export interface ConfirmProps extends Omit<ConfirmationProps, 'onCancel'> {
   /**
    * Callback attached to any input elements within the modal.
    */
-  onChange?: () => void
+  onChange?: (e: Event) => void
   /**
    * Callback fires if props.protectChanges === true and user closes modal without pressing confirm.
    */
@@ -95,10 +95,10 @@ export function useConfirm({
     setClosed()
   }
 
-  const handleChange = () => {
+  const handleChange = (e: Event) => {
     setDialogState(DialogStates.unsaved)
     if (isFunction(onChange)) {
-      onChange()
+      onChange(e)
     }
   }
 

--- a/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
+++ b/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
@@ -24,7 +24,13 @@
 
  */
 
-import React, { FC, ReactElement, useEffect, useRef } from 'react'
+import React, {
+  FC,
+  ReactElement,
+  useEffect,
+  useRef,
+  SyntheticEvent,
+} from 'react'
 import { SemanticColors } from '@looker/design-tokens'
 import isFunction from 'lodash/isFunction'
 import { Button, ButtonTransparent } from '../../Button'
@@ -82,7 +88,7 @@ export interface ConfirmationDialogProps extends ConfirmationProps {
   /**
    * Callback to fire if any form input children change.
    */
-  onChange?: () => void
+  onChange?: (e: Event) => void
 }
 
 export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
@@ -104,9 +110,9 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
     /**
      * watch for changes to any input elements within the dialog content
      */
-    const changeListener = () => {
+    const changeListener: EventListener = (e: Event) => {
       if (isFunction(onChange)) {
-        onChange()
+        onChange(e)
       }
     }
 

--- a/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
+++ b/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
@@ -24,13 +24,7 @@
 
  */
 
-import React, {
-  FC,
-  ReactElement,
-  useEffect,
-  useRef,
-  SyntheticEvent,
-} from 'react'
+import React, { FC, ReactElement, useEffect, useRef } from 'react'
 import { SemanticColors } from '@looker/design-tokens'
 import isFunction from 'lodash/isFunction'
 import { Button, ButtonTransparent } from '../../Button'

--- a/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
+++ b/packages/components/src/Modal/Dialog/ConfirmationDialog.tsx
@@ -125,7 +125,13 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
   }, [onChange, ref])
 
   return (
-    <Dialog isOpen={isOpen} onClose={onCancel} ref={ref} {...props}>
+    <Dialog
+      isOpen={isOpen}
+      onClose={onCancel}
+      ref={ref}
+      {...props}
+      testId="confirmation-dialog"
+    >
       <ModalHeader>{title}</ModalHeader>
       <ModalContent innerProps={{ py: 'none' }}>
         {typeof message === 'string' ? (

--- a/packages/components/src/Modal/Dialog/Dialog.tsx
+++ b/packages/components/src/Modal/Dialog/Dialog.tsx
@@ -30,11 +30,12 @@ import { DialogSurface } from './DialogSurface'
 
 interface DialogProps extends ModalProps {
   children: ReactNode
+  testId?: string
 }
 
 export const Dialog = forwardRef(
   (
-    { width, children, surfaceStyles, ...props }: DialogProps,
+    { width, children, surfaceStyles, testId, ...props }: DialogProps,
     ref: Ref<HTMLDivElement>
   ) => {
     const surface = (animationState: string) => (
@@ -43,6 +44,7 @@ export const Dialog = forwardRef(
         className={animationState}
         width={width}
         ref={ref}
+        data-testid={testId}
       >
         {children}
       </DialogSurface>

--- a/packages/components/src/Modal/Dialog/Dialog.tsx
+++ b/packages/components/src/Modal/Dialog/Dialog.tsx
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,25 +24,32 @@
 
  */
 
-import React, { FC } from 'react'
+import React, { forwardRef, Ref, ReactNode } from 'react'
 import { Modal, ModalProps } from '../Modal'
 import { DialogSurface } from './DialogSurface'
 
-export const Dialog: FC<ModalProps> = ({
-  width,
-  children,
-  surfaceStyles,
-  ...props
-}) => {
-  const surface = (animationState: string) => (
-    <DialogSurface
-      style={surfaceStyles}
-      className={animationState}
-      width={width}
-    >
-      {children}
-    </DialogSurface>
-  )
-
-  return <Modal {...props} render={surface} />
+interface DialogProps extends ModalProps {
+  children: ReactNode
 }
+
+export const Dialog = forwardRef(
+  (
+    { width, children, surfaceStyles, ...props }: DialogProps,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    const surface = (animationState: string) => (
+      <DialogSurface
+        style={surfaceStyles}
+        className={animationState}
+        width={width}
+        ref={ref}
+      >
+        {children}
+      </DialogSurface>
+    )
+
+    return <Modal {...props} render={surface} />
+  }
+)
+
+Dialog.displayName = 'Dialog'

--- a/packages/components/src/Modal/Dialog/DiscardChangesDialog.tsx
+++ b/packages/components/src/Modal/Dialog/DiscardChangesDialog.tsx
@@ -1,0 +1,75 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2019 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, { FC } from 'react'
+import styled from 'styled-components'
+
+import { ButtonTransparent } from '../../Button'
+import { Paragraph } from '../../Text'
+import { ModalContent, ModalFooter, ModalHeader } from '../Layout'
+import { Dialog } from './Dialog'
+
+interface DiscardChangesProps {
+  closeDialog: () => void
+  resetDialog: () => void
+  isOpen: boolean
+}
+
+export const DiscardChangesDialog: FC<DiscardChangesProps> = ({
+  closeDialog,
+  resetDialog,
+  isOpen,
+}) => {
+  return (
+    <Dialog isOpen={isOpen} onClose={closeDialog} width={'30rem'}>
+      <ModalHeader headerIcon="Warning" headerIconColor="palette.red500">
+        Discard Changes?
+      </ModalHeader>
+      <ModalContent innerProps={{ py: 'none' }}>
+        <MessageGrid>
+          <Paragraph>
+            Are you sure you want to close the dialog? Unsaved changes will be
+            lost.
+          </Paragraph>
+        </MessageGrid>
+      </ModalContent>
+      <ModalFooter>
+        <ButtonTransparent onClick={closeDialog} color="danger">
+          Discard Changes
+        </ButtonTransparent>
+        <ButtonTransparent onClick={resetDialog} color="neutral">
+          Go Back
+        </ButtonTransparent>
+      </ModalFooter>
+    </Dialog>
+  )
+}
+
+const MessageGrid = styled.div`
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: auto 1fr;
+`

--- a/packages/components/src/Modal/Dialog/DiscardChangesDialog.tsx
+++ b/packages/components/src/Modal/Dialog/DiscardChangesDialog.tsx
@@ -54,12 +54,10 @@ export const DiscardChangesDialog: FC<DiscardChangesProps> = ({
         Discard Changes?
       </ModalHeader>
       <ModalContent innerProps={{ py: 'none' }}>
-        <MessageGrid>
-          <Paragraph>
-            Are you sure you want to close the dialog? Unsaved changes will be
-            lost.
-          </Paragraph>
-        </MessageGrid>
+        <Paragraph>
+          Are you sure you want to close the dialog? Unsaved changes will be
+          lost.
+        </Paragraph>
       </ModalContent>
       <ModalFooter>
         <ButtonTransparent onClick={closeDialog} color="danger">
@@ -72,9 +70,3 @@ export const DiscardChangesDialog: FC<DiscardChangesProps> = ({
     </Dialog>
   )
 }
-
-const MessageGrid = styled.div`
-  display: grid;
-  grid-gap: 1rem;
-  grid-template-columns: auto 1fr;
-`

--- a/packages/components/src/Modal/Dialog/DiscardChangesDialog.tsx
+++ b/packages/components/src/Modal/Dialog/DiscardChangesDialog.tsx
@@ -44,7 +44,12 @@ export const DiscardChangesDialog: FC<DiscardChangesProps> = ({
   isOpen,
 }) => {
   return (
-    <Dialog isOpen={isOpen} onClose={closeDialog} width={'30rem'}>
+    <Dialog
+      isOpen={isOpen}
+      onClose={closeDialog}
+      width={'30rem'}
+      testId="discard-changes-dialog"
+    >
       <ModalHeader headerIcon="Warning" headerIconColor="palette.red500">
         Discard Changes?
       </ModalHeader>

--- a/packages/components/src/Modal/Layout/ModalHeader.tsx
+++ b/packages/components/src/Modal/Layout/ModalHeader.tsx
@@ -35,43 +35,66 @@ import { IconNames } from '@looker/icons'
 import styled from 'styled-components'
 import React, { FC, useContext } from 'react'
 
+import { Icon } from '../../Icon'
 import { IconButton } from '../../Button'
-import { Flex } from '../../Layout'
 import { Heading } from '../../Text'
 import { ModalContext } from '../ModalContext'
 
 export interface ModalHeaderProps
   extends SpaceProps,
     CompatibleHTMLProps<HTMLElement> {
+  children: string
   /**
    * Specify an icon to be used for close. Defaults to `Close`
    */
   closeIcon?: IconNames
-  children: string
+  /**
+   * Render an icon next to the title text
+   */
+  headerIcon?: IconNames
+  /**
+   * Specify color of header icon
+   */
+  headerIconColor?: string
 }
 
 export const ModalHeader: FC<ModalHeaderProps> = ({
   children,
   closeIcon = 'Close',
+  headerIcon,
+  headerIconColor,
   ...props
 }) => {
   const { closeModal } = useContext(ModalContext)
 
   return (
     <Header {...props}>
-      <Flex justifyContent="space-between" alignItems="center">
-        <Heading as="h3" mr="xlarge" fontWeight="semiBold">
-          {children}
-        </Heading>
-        <IconButton
-          tabIndex={-1}
-          color="neutral"
-          size="small"
-          onClick={closeModal}
-          label="Close"
-          icon={closeIcon}
+      {headerIcon && (
+        <Icon
+          name={headerIcon}
+          color={headerIconColor}
+          size={22}
+          style={{ gridArea: 'icon' }}
+          mr="xsmall"
         />
-      </Flex>
+      )}
+      <Heading
+        as="h3"
+        mr="xlarge"
+        fontWeight="semiBold"
+        style={{ gridArea: 'text' }}
+      >
+        {children}
+      </Heading>
+      <IconButton
+        tabIndex={-1}
+        color="neutral"
+        size="small"
+        onClick={closeModal}
+        label="Close"
+        icon={closeIcon}
+        style={{ gridArea: 'close' }}
+      />
     </Header>
   )
 }
@@ -79,6 +102,9 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
 const Header = styled.header<SpaceProps>`
   ${reset}
   ${space}
+  display: grid;
+  grid-template-columns: [icon] auto [text] 1fr [close] auto;
+  align-items: center;
 `
 
 Header.defaultProps = {

--- a/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
+++ b/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ModalHeader 1`] = `
-.c7 {
+.c6 {
   width: 22px;
   height: 22px;
   -webkit-align-items: center;
@@ -14,7 +14,7 @@ exports[`ModalHeader 1`] = `
   display: inline-flex;
 }
 
-.c3 {
+.c2 {
   width: 28px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -44,56 +44,41 @@ exports[`ModalHeader 1`] = `
   padding: 0rem;
 }
 
-.c3[disabled] {
+.c2[disabled] {
   cursor: default;
   -webkit-filter: grayscale(0.3);
   filter: grayscale(0.3);
   opacity: 0.25;
 }
 
-.c1 {
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c4 {
+.c3 {
   background: transparent;
   border: 1px solid transparent;
   color: #939BA5;
 }
 
-.c4:active,
-.c4.active {
+.c3:active,
+.c3.active {
   background: #F5F6F7;
   border-color: #F5F6F7;
   color: #4C535B;
 }
 
-.c4:hover,
-.c4:focus,
-.c4.hover {
+.c3:hover,
+.c3:focus,
+.c3.hover {
   background: #FBFBFC;
   border-color: #FBFBFC;
   color: #4C535B;
 }
 
-.c4[disabled]:hover,
-.c4[disabled]:active,
-.c4[disabled]:focus {
+.c3[disabled]:hover,
+.c3[disabled]:active,
+.c3[disabled]:focus {
   color: #939BA5;
 }
 
-.c2 {
+.c1 {
   font-weight: 600;
   line-height: 1.75rem;
   font-size: 1.125rem;
@@ -101,7 +86,7 @@ exports[`ModalHeader 1`] = `
   color: #262D33;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   height: 1px;
   width: 1px;
@@ -110,7 +95,7 @@ exports[`ModalHeader 1`] = `
   clip: rect(1px,1px,1px,1px);
 }
 
-.c5 svg {
+.c4 svg {
   pointer-events: none;
 }
 
@@ -118,59 +103,71 @@ exports[`ModalHeader 1`] = `
   padding: 1.25rem;
   padding-right: 2rem;
   padding-left: 2rem;
+  display: grid;
+  grid-template-columns: [icon] auto [text] 1fr [close] auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <header
   className="c0"
 >
-  <div
+  <h3
     className="c1"
+    fontSize="large"
+    fontWeight="semiBold"
+    style={
+      Object {
+        "gridArea": "text",
+      }
+    }
   >
-    <h3
-      className="c2"
-      fontSize="large"
-      fontWeight="semiBold"
+    The Heading for a Dialog
+  </h3>
+  <button
+    className="c2 c3 c4"
+    color="neutral"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyUp={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    size="small"
+    style={
+      Object {
+        "gridArea": "close",
+      }
+    }
+    tabIndex={-1}
+    width={28}
+  >
+    <div
+      className="c5"
     >
-      The Heading for a Dialog
-    </h3>
-    <button
-      className="c3 c4 c5"
-      color="neutral"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onKeyUp={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      size="small"
-      tabIndex={-1}
-      width={28}
+      Close
+    </div>
+    <div
+      aria-hidden={true}
+      className="c6 "
+      size={22}
     >
-      <div
-        className="c6"
+      <svg
+        fill="currentColor"
+        height="100%"
+        viewBox="0 0 24 24"
+        width="100%"
       >
-        Close
-      </div>
-      <div
-        aria-hidden={true}
-        className="c7 "
-        size={22}
-      >
-        <svg
+        <title>
+          Close
+        </title>
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
           fill="currentColor"
-          height="100%"
-          viewBox="0 0 24 24"
-          width="100%"
-        >
-          <title>
-            Close
-          </title>
-          <path
-            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
-            fill="currentColor"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
+        />
+      </svg>
+    </div>
+  </button>
 </header>
 `;

--- a/packages/components/src/Modal/ModalSurface.tsx
+++ b/packages/components/src/Modal/ModalSurface.tsx
@@ -25,7 +25,7 @@
  */
 
 import { CompatibleHTMLProps, reset, theme } from '@looker/design-tokens'
-import React, { FC, useContext, useEffect } from 'react'
+import React, { Ref, useContext, useEffect, forwardRef } from 'react'
 import { HotKeys } from 'react-hotkeys'
 import styled, { CSSObject, css } from 'styled-components'
 import {
@@ -51,62 +51,65 @@ export interface ModalSurfaceProps
   animationState?: string
 }
 
-export const ModalSurface: FC<ModalSurfaceProps> = ({
-  anchor,
-  style,
-  className,
-  ...props
-}) => {
-  const { closeModal, enableFocusTrap, enableScrollLock } = useContext(
-    ModalContext
-  )
+export const ModalSurface = forwardRef(
+  (
+    { anchor, style, className, ...props }: ModalSurfaceProps,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    const { closeModal, enableFocusTrap, enableScrollLock } = useContext(
+      ModalContext
+    )
 
-  useEffect(() => {
-    enableScrollLock && enableScrollLock()
-    const t = window.setTimeout(() => {
-      enableFocusTrap && enableFocusTrap()
-    }, theme.transitions.durationModerate)
-    return () => {
-      window.clearTimeout(t)
-    }
-  }, [enableFocusTrap, enableScrollLock])
+    useEffect(() => {
+      enableScrollLock && enableScrollLock()
+      const t = window.setTimeout(() => {
+        enableFocusTrap && enableFocusTrap()
+      }, theme.transitions.durationModerate)
+      return () => {
+        window.clearTimeout(t)
+      }
+    }, [enableFocusTrap, enableScrollLock])
 
-  return (
-    <HotKeys
-      keyMap={{
-        CLOSE_MODAL: {
-          action: 'keyup',
-          name: 'Close Modal',
-          sequence: 'esc',
-        },
-      }}
-      handlers={{
-        CLOSE_MODAL: () => {
-          closeModal && closeModal()
-        },
-      }}
-      style={{
-        alignItems: 'center',
-        display: 'flex',
-        height: '100%',
-        justifyContent: anchor === 'right' ? 'flex-end' : 'center',
-        width: '100%',
-      }}
-      // NOTE: Styling is required because react-hotkeys injects a DOM element (`div` by default) that
-      // breaks the flex inheritance. Eventually they will offer a React Hook that should allow removal
-      // of this workaround.
-      //
-      // display: contents would be another workaround when it gains broader (corrected) support
-    >
-      <Style
-        className={`surface-overflow ${className}`}
-        tabIndex={-1}
-        surfaceStyle={style as CSSObject}
-        {...props}
-      />
-    </HotKeys>
-  )
-}
+    return (
+      <HotKeys
+        keyMap={{
+          CLOSE_MODAL: {
+            action: 'keyup',
+            name: 'Close Modal',
+            sequence: 'esc',
+          },
+        }}
+        handlers={{
+          CLOSE_MODAL: () => {
+            closeModal && closeModal()
+          },
+        }}
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          height: '100%',
+          justifyContent: anchor === 'right' ? 'flex-end' : 'center',
+          width: '100%',
+        }}
+        // NOTE: Styling is required because react-hotkeys injects a DOM element (`div` by default) that
+        // breaks the flex inheritance. Eventually they will offer a React Hook that should allow removal
+        // of this workaround.
+        //
+        // display: contents would be another workaround when it gains broader (corrected) support
+      >
+        <Style
+          className={`surface-overflow ${className}`}
+          tabIndex={-1}
+          surfaceStyle={style as CSSObject}
+          ref={ref}
+          {...props}
+        />
+      </HotKeys>
+    )
+  }
+)
+
+ModalSurface.displayName = 'ModalSurface'
 
 const surfaceTransition = () => css`
   ${props =>

--- a/packages/playground/src/Confirm/ConfirmDemo.tsx
+++ b/packages/playground/src/Confirm/ConfirmDemo.tsx
@@ -33,9 +33,8 @@ const StaticConfirm: React.FC = () => {
     <Confirm
       title="Confirm Something"
       message="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
-      onConfirm={close => {
+      onConfirm={() => {
         alert('You did something')
-        close()
       }}
       width={['10rem', '20rem', '30rem', '40rem']}
     >
@@ -53,9 +52,8 @@ const RichConfirm: React.FC = () => {
     <Confirm
       title="Did you know?"
       message={<RichMessage />}
-      onConfirm={close => {
+      onConfirm={() => {
         alert('Now you know.')
-        close()
       }}
       width={['10rem', '20rem', '30rem', '40rem']}
     >

--- a/packages/playground/src/Confirm/ProtectedModalDemo.tsx
+++ b/packages/playground/src/Confirm/ProtectedModalDemo.tsx
@@ -31,19 +31,31 @@ import {
   FieldCheckbox,
   FieldText,
   Heading,
+  DialogManager,
 } from '@looker/components'
 
 export const ProtectedModalDemo: React.FC = () => {
   return (
-    <Confirm
-      title="Please enter your information"
-      message={<UserForm />}
-      onConfirm={() => alert('Saved')}
-      width="500px"
-      protectChanges
-    >
-      {open => <Button onClick={open}>Open modal form</Button>}
-    </Confirm>
+    <>
+      <Confirm
+        title="Please enter your information"
+        message={<UserForm />}
+        onConfirm={() => alert('Saved')}
+        width="500px"
+        protectChanges
+      >
+        {open => <Button onClick={open}>Open Confirm form</Button>}
+      </Confirm>
+      <DialogManager
+        title="Please enter your information"
+        content={<UserForm />}
+        onConfirm={() => alert('Saved')}
+        width="500px"
+        protectChanges
+      >
+        {open => <Button onClick={open}>Open DialogManager form</Button>}
+      </DialogManager>
+    </>
   )
 }
 

--- a/packages/playground/src/Confirm/ProtectedModalDemo.tsx
+++ b/packages/playground/src/Confirm/ProtectedModalDemo.tsx
@@ -31,7 +31,6 @@ import {
   FieldCheckbox,
   FieldText,
   Heading,
-  DialogManager,
 } from '@looker/components'
 
 export const ProtectedModalDemo: React.FC = () => {
@@ -46,15 +45,6 @@ export const ProtectedModalDemo: React.FC = () => {
       >
         {open => <Button onClick={open}>Open Confirm form</Button>}
       </Confirm>
-      <DialogManager
-        title="Please enter your information"
-        content={<UserForm />}
-        onConfirm={() => alert('Saved')}
-        width="500px"
-        protectChanges
-      >
-        {open => <Button onClick={open}>Open DialogManager form</Button>}
-      </DialogManager>
     </>
   )
 }

--- a/packages/playground/src/Confirm/ProtectedModalDemo.tsx
+++ b/packages/playground/src/Confirm/ProtectedModalDemo.tsx
@@ -24,28 +24,39 @@
 
  */
 
-import React, { forwardRef, Ref } from 'react'
-import styled from 'styled-components'
+import React from 'react'
+import {
+  Button,
+  Confirm,
+  FieldCheckbox,
+  FieldText,
+  Heading,
+} from '@looker/components'
 
-import { ModalSurface, ModalSurfaceProps } from '../ModalSurface'
-
-export const DialogSurface = forwardRef(
-  (props: ModalSurfaceProps, ref: Ref<HTMLDivElement>) => (
-    <StyledDialogSurface {...props} ref={ref} />
+export const ProtectedModalDemo: React.FC = () => {
+  return (
+    <Confirm
+      title="Please enter your information"
+      message={<UserForm />}
+      onConfirm={() => alert('Saved')}
+      width="500px"
+      protectChanges
+    >
+      {open => <Button onClick={open}>Open modal form</Button>}
+    </Confirm>
   )
+}
+
+const UserForm: React.FC = () => (
+  <form>
+    <Heading as="h3" mb="small">
+      Who are you?
+    </Heading>
+    <FieldText name="name" label="Full Name" />
+    <Heading as="h3" mb="small">
+      Cookie Preference??
+    </Heading>
+    <FieldCheckbox name="chocolate-chip" label="Chocolate Chip" />
+    <FieldCheckbox name="peanut-butter" label="Peanut Butter" />
+  </form>
 )
-
-DialogSurface.displayName = 'DialogSurface'
-
-const StyledDialogSurface = styled(ModalSurface)<ModalSurfaceProps>`
-  &.entering,
-  &.exiting {
-    opacity: 0.01;
-    transform: translateY(100%);
-  }
-
-  &.exited {
-    opacity: 1;
-    transform: translateY(0%);
-  }
-`

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,14 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { ConfirmDemo } from './Confirm/ConfirmDemo'
+import { ProtectedModalDemo } from './Confirm/ProtectedModalDemo'
+
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <>
         <GlobalStyle />
-        <ConfirmDemo />
+        <ProtectedModalDemo />
       </>
     </ThemeProvider>
   )

--- a/packages/playground/src/template.html
+++ b/packages/playground/src/template.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta name="viewport" content="width=device-width" />
     <title>welcome</title>
   </head>
   <body>


### PR DESCRIPTION
### :sparkles: Changes

- Remove generic `close` callback in favor of more specific `onChange` and `onCancel` callbacks. We need to be more specific about which action is closing the modal in order to know whether to render the confirmation dialog.
- Update Confirm to update state based on change events
- Create a new DiscardChangesDialog to render as fallback if changes are about to be lost
- Update modal title to allow an icon to be rendered along with title text ]

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots
![confirm-close-dialog](https://user-images.githubusercontent.com/238293/72181151-89066080-339d-11ea-8d7c-6cbfb5155170.gif)
