### PR TITLE
Remove aria-labelledby on MenuList used without Menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASE]
+
+### Added
+
+### Changes
+
+### Fixed
+
+- Bad `aria-labelledby` attribute on `MenuList` when used without `Menu`.
+
 ## [0.7.11] - 2020-01-09
 
 ### Added

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -115,7 +115,7 @@ export const MenuListInternal = forwardRef(
             tabIndex={-1}
             role="menu"
             id={id}
-            aria-labelledby={`button-${id}`}
+            aria-labelledby={id && `button-${id}`}
             {...props}
           >
             {children}


### PR DESCRIPTION
### :sparkles: Changes

- Don't add `aria-labelledby` on `MenuList` if `id` is not found on `MenuContext` (i.e. `MenuList` is used without `Menu`)

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC