### PR TITLE
Fix: InputText autoComplete 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASE]
+## [UNRELEASED]
 
 ### Added
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bad `aria-labelledby` attribute on `MenuList` when used without `Menu`.
+- `autoComplete` not being passed down to `input` in `InputText`.
 
 ## [0.7.11] - 2020-01-09
 

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.test.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.test.tsx
@@ -80,6 +80,7 @@ test('Should trigger onChange handler', () => {
         id="thumbs-up"
         value="foobar"
         onChange={handleChange}
+        options={[{ label: 'Foobar', value: 'foobar' }]}
       />
     </ThemeProvider>
   )

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`A FieldSelect 1`] = `
         width="100%"
       >
         <div
-          aria-autocomplete="both"
+          aria-autoComplete="both"
           className="c3 c4 c5"
           onClick={[Function]}
           width="100%"
@@ -311,7 +311,7 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
         width="100%"
       >
         <div
-          aria-autocomplete="both"
+          aria-autoComplete="both"
           className="c4 c5 c6"
           onClick={[Function]}
           width="100%"
@@ -504,7 +504,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
         width="100%"
       >
         <div
-          aria-autocomplete="both"
+          aria-autoComplete="both"
           className="c4 c5 c6"
           onClick={[Function]}
           width="100%"
@@ -645,7 +645,7 @@ exports[`A required FieldSelect 1`] = `
       aria-hidden="true"
       className="c2"
     >
-       
+
       *
     </span>
   </label>
@@ -668,7 +668,7 @@ exports[`A required FieldSelect 1`] = `
         width="100%"
       >
         <div
-          aria-autocomplete="both"
+          aria-autoComplete="both"
           className="c4 c5 c6"
           onClick={[Function]}
           width="100%"
@@ -813,7 +813,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
         width="100%"
       >
         <div
-          aria-autocomplete="both"
+          aria-autoComplete="both"
           className="c3 c4 c5"
           onClick={[Function]}
           width="100%"

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -122,12 +122,13 @@ exports[`A FieldSelect 1`] = `
         width="100%"
       >
         <div
-          aria-autoComplete="both"
           className="c3 c4 c5"
           onClick={[Function]}
           width="100%"
         >
           <input
+            aria-autocomplete="both"
+            autoComplete="off"
             className="c6 c7"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -311,12 +312,13 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
         width="100%"
       >
         <div
-          aria-autoComplete="both"
           className="c4 c5 c6"
           onClick={[Function]}
           width="100%"
         >
           <input
+            aria-autocomplete="both"
+            autoComplete="off"
             className="c7 c8"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -504,12 +506,13 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
         width="100%"
       >
         <div
-          aria-autoComplete="both"
           className="c4 c5 c6"
           onClick={[Function]}
           width="100%"
         >
           <input
+            aria-autocomplete="both"
+            autoComplete="off"
             className="c7 c8"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -645,7 +648,7 @@ exports[`A required FieldSelect 1`] = `
       aria-hidden="true"
       className="c2"
     >
-
+       
       *
     </span>
   </label>
@@ -668,12 +671,13 @@ exports[`A required FieldSelect 1`] = `
         width="100%"
       >
         <div
-          aria-autoComplete="both"
           className="c4 c5 c6"
           onClick={[Function]}
           width="100%"
         >
           <input
+            aria-autocomplete="both"
+            autoComplete="off"
             className="c7 c8"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -813,12 +817,13 @@ exports[`FieldSelect supports labelWeight 1`] = `
         width="100%"
       >
         <div
-          aria-autoComplete="both"
           className="c3 c4 c5"
           onClick={[Function]}
           width="100%"
         >
           <input
+            aria-autocomplete="both"
+            autoComplete="off"
             className="c6 c7"
             id="listbox-thumbs-up"
             onBlur={[Function]}

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.test.tsx
@@ -143,7 +143,7 @@ describe('Keyboard navigation', () => {
     expect(queryByRole('listbox')).not.toBeInTheDocument()
   })
 
-  test('arrows and enter with autocomplete = false', () => {
+  test('arrows and enter with autoComplete = false', () => {
     const {
       getAllByRole,
       getByRole,
@@ -151,7 +151,7 @@ describe('Keyboard navigation', () => {
       getByTestId,
     } = renderWithTheme(
       <Combobox id="with-options" openOnFocus>
-        <ComboboxInput data-testid="select-input" autocomplete={false} />
+        <ComboboxInput data-testid="select-input" autoComplete={false} />
         <ComboboxList>
           <ComboboxOption label="Foo" value="101" />
           <ComboboxOption label="Bar" value="102" />

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.tsx
@@ -141,13 +141,13 @@ export const ComboboxInternal = forwardRef(function Combobox(
 
   const buttonRef = useRef<HTMLButtonElement>(null)
 
-  // When <ComboboxInput autocomplete={false} /> we don't want cycle back to
+  // When <ComboboxInput autoComplete={false} /> we don't want cycle back to
   // the user's value while navigating (because it's always the user's value),
   // but we need to know this in useKeyDown which is far away from the prop
   // here, so we do something sneaky and write it to this ref on context so we
   // can use it anywhere else 😛. Another new trick for me and I'm excited
   // about this one too!
-  const autocompletePropRef = useRef(true)
+  const autoCompletePropRef = useRef(true)
   const readOnlyPropRef = useRef(false)
 
   const persistSelectionRef = useRef(false)
@@ -188,7 +188,7 @@ export const ComboboxInternal = forwardRef(function Combobox(
   }, [isVisible, isVisibleRef, onOpen, onClose, option])
 
   const context = {
-    autocompletePropRef,
+    autoCompletePropRef,
     buttonRef,
     data,
     inputCallbackRef,

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
@@ -39,7 +39,7 @@ export interface ComboboxContextProps {
   state?: ComboboxState
   transition?: ComboboxTransition
   listboxId?: string
-  autocompletePropRef?: MutableRefObject<boolean>
+  autoCompletePropRef?: MutableRefObject<boolean>
   persistSelectionRef?: MutableRefObject<boolean>
   readOnlyPropRef?: MutableRefObject<boolean>
   isVisible?: boolean

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxInput.tsx
@@ -244,7 +244,7 @@ export const ComboboxInputInternal = forwardRef(function ComboboxInput(
       onKeyDown={wrappedOnKeyDown}
       id={listboxId}
       autoComplete="off"
-      aria-autoComplete="both"
+      aria-autocomplete="both"
       aria-activedescendant={
         navigationOption
           ? String(makeHash(navigationOption ? navigationOption.value : ''))

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxInput.tsx
@@ -45,7 +45,8 @@ import { ComboboxContext } from './ComboboxContext'
 import { getComboboxText } from './ComboboxOption'
 import { ComboboxActionType, ComboboxState } from './state'
 
-export interface ComboboxInputProps extends InputSearchProps {
+export interface ComboboxInputProps
+  extends Omit<InputSearchProps, 'autoComplete'> {
   /**
    * If true, when the user clicks inside the text box the current value will
    * be selected. Use this if the user is likely to delete all the text anyway
@@ -66,7 +67,7 @@ export interface ComboboxInputProps extends InputSearchProps {
    * But if your input is more like a normal `<input type="text"/>`, then leave
    * the `true` default.
    */
-  autocomplete?: boolean
+  autoComplete?: boolean
 }
 
 export const ComboboxInputInternal = forwardRef(function ComboboxInput(
@@ -75,7 +76,7 @@ export const ComboboxInputInternal = forwardRef(function ComboboxInput(
     selectOnClick = false,
 
     // updates the value in the input when navigating w/ the keyboard
-    autocomplete = true,
+    autoComplete = true,
     readOnly = false,
 
     // wrapped events
@@ -105,7 +106,7 @@ export const ComboboxInputInternal = forwardRef(function ComboboxInput(
     state,
     transition,
     listboxId,
-    autocompletePropRef,
+    autoCompletePropRef,
     persistSelectionRef,
     readOnlyPropRef,
     openOnFocus,
@@ -128,10 +129,10 @@ export const ComboboxInputInternal = forwardRef(function ComboboxInput(
   const isInputting = useRef(false)
 
   useLayoutEffect(() => {
-    if (autocompletePropRef) autocompletePropRef.current = autocomplete
+    if (autoCompletePropRef) autoCompletePropRef.current = autoComplete
     if (readOnlyPropRef) readOnlyPropRef.current = readOnly
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autocomplete, readOnly])
+  }, [autoComplete, readOnly])
 
   function handleClear() {
     contextOnChange && contextOnChange()
@@ -212,7 +213,7 @@ export const ComboboxInputInternal = forwardRef(function ComboboxInput(
   let inputOption = contextInputValue !== undefined ? contextInputValue : option
 
   if (
-    autocomplete &&
+    autoComplete &&
     (state === ComboboxState.NAVIGATING || state === ComboboxState.INTERACTING)
   ) {
     // When idle, we don't have a navigationOption on ArrowUp/Down
@@ -242,7 +243,8 @@ export const ComboboxInputInternal = forwardRef(function ComboboxInput(
       onChange={wrappedOnChange}
       onKeyDown={wrappedOnKeyDown}
       id={listboxId}
-      aria-autocomplete="both"
+      autoComplete="off"
+      aria-autoComplete="both"
       aria-activedescendant={
         navigationOption
           ? String(makeHash(navigationOption ? navigationOption.value : ''))

--- a/packages/components/src/Form/Inputs/Combobox/helpers.ts
+++ b/packages/components/src/Form/Inputs/Combobox/helpers.ts
@@ -63,7 +63,7 @@ export function useKeyDown() {
     optionsRef,
     state,
     transition,
-    autocompletePropRef,
+    autoCompletePropRef,
     persistSelectionRef,
     readOnlyPropRef,
   } = useContext(ComboboxContext)
@@ -96,7 +96,7 @@ export function useKeyDown() {
             : -1
           const atBottom = index === options.length - 1
           if (atBottom) {
-            if (autocompletePropRef && autocompletePropRef.current) {
+            if (autoCompletePropRef && autoCompletePropRef.current) {
               // Go back to the value the user has typed because we are
               // auto-completing and they need to be able to get back to what
               // they had typed w/o having to backspace out.
@@ -136,7 +136,7 @@ export function useKeyDown() {
             ? findIndex(options, navigationOption)
             : -1
           if (index === 0) {
-            if (autocompletePropRef && autocompletePropRef.current) {
+            if (autoCompletePropRef && autoCompletePropRef.current) {
               // Go back to the value the user has typed because we are
               // auto-completing and they need to be able to get back to what
               // they had typed w/o having to backspace out.

--- a/packages/components/src/Form/Inputs/InputProps.ts
+++ b/packages/components/src/Form/Inputs/InputProps.ts
@@ -33,8 +33,8 @@ export interface InputProps extends CompatibleHTMLProps<HTMLInputElement> {
 
 export const inputPropKeys = [
   'accept',
-  'autofocus',
-  'autocomplete',
+  'autoFocus',
+  'autoComplete',
   'checked',
   'data-autofocus',
   'data-testid',

--- a/packages/components/src/Form/Inputs/InputProps.ts
+++ b/packages/components/src/Form/Inputs/InputProps.ts
@@ -67,6 +67,7 @@ export const inputPropKeys = [
   'pattern',
   'step',
   'value',
+  'aria-autocomplete',
   'aria-label',
   'aria-describedby',
   'aria-labelledby',

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -64,7 +64,19 @@ export interface InputTextProps
    *
    * @default 'text'
    */
-  type?: 'number' | 'password' | 'text' | 'search'
+  type?:
+    | 'date'
+    | 'datetime-local'
+    | 'email'
+    | 'month'
+    | 'number'
+    | 'password'
+    | 'search'
+    | 'tel'
+    | 'text'
+    | 'time'
+    | 'url'
+    | 'week'
 }
 
 const InputComponent = forwardRef(

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -27,6 +27,7 @@
 import React, { forwardRef, Ref, FormEvent } from 'react'
 import styled from 'styled-components'
 import { CustomizableAttributes } from '@looker/design-tokens'
+import { ListItem } from '../../../List'
 import { ValidationType } from '../../ValidationMessage'
 import {
   Combobox,
@@ -119,7 +120,8 @@ const SelectComponent = forwardRef(
     ref: Ref<HTMLInputElement>
   ) => {
     const optionValue = getOption(value, options)
-    const defaultOptionValue = getOption(defaultValue, options)
+    const defaultOptionValue =
+      getOption(defaultValue, options) || (options && options[0])
 
     function handleChange(option?: ComboboxOptionObject) {
       const newValue = option ? option.value : ''
@@ -158,7 +160,7 @@ const SelectComponent = forwardRef(
         <ComboboxInput
           {...inputProps}
           {...ariaProps}
-          autocomplete={false}
+          autoComplete={false}
           readOnly={!isFilterable}
           onChange={handleInputChange}
           hideControls={!isClearable}
@@ -172,11 +174,9 @@ const SelectComponent = forwardRef(
                 <ComboboxOption {...option} key={index} />
               ))
             ) : (
-              <ComboboxOption
-                value=""
-                label="No options"
-                color="palette.charcoal400"
-              />
+              <ListItem fontSize="small" px="medium" py="xxsmall">
+                No options
+              </ListItem>
             )}
           </ComboboxList>
         )}


### PR DESCRIPTION
### :sparkles: Changes

- `autoComplete` wasn't getting passed down b/c we were incorrectly looking for all lowercase `autocomplete` 
- while testing I discovered and fixed a few related issues:
  - `autoFocus` had the same issue
  - "email" and other valid [HTML5 input types](http://html5doctor.com/html5-forms-input-types/) were not supported on `InputText` or one of our other input components, so I added the types that are similar in appearance to type="text"
  - the "no options" message on an empty `Select` was itself behaving like an option

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
