### PR TITLE
Fix focus trap issue with Select and Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - create Chip component with test coverage
 
+### Fixed
+
+- A `Select` used inside of a `Dialog` would intermittently lose focus and fail to update when clicking on an option.
+
 ## [0.7.12] - 2010-01-13
 
 ### Fixed

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -95,11 +95,14 @@ export function Modal({
     callbackRef: focusRef,
     disable: disableFocusTrap,
     enable: enableFocusTrap,
+    isEnabled: focusTrapEnabled,
+    trapRef: focusTrapRef,
   } = useFocusTrap(isOpen)
   const {
     callbackRef: scrollRef,
     disable: disableScrollLock,
     enable: enableScrollLock,
+    isEnabled: scrollLockEnabled,
   } = useScrollLock(isOpen, false)
 
   return (
@@ -110,6 +113,9 @@ export function Modal({
         disableScrollLock,
         enableFocusTrap,
         enableScrollLock,
+        focusTrapEnabled,
+        focusTrapRef,
+        scrollLockEnabled,
       }}
     >
       <CSSTransition

--- a/packages/components/src/Modal/ModalContext.ts
+++ b/packages/components/src/Modal/ModalContext.ts
@@ -24,7 +24,8 @@
 
  */
 
-import { createContext } from 'react'
+import { createContext, MutableRefObject } from 'react'
+import { FocusTrap } from 'focus-trap'
 
 export interface ModalContextProps {
   closeModal?: () => void
@@ -33,6 +34,7 @@ export interface ModalContextProps {
   enableFocusTrap?: () => void
   disableFocusTrap?: () => void
   focusTrapEnabled?: boolean
+  focusTrapRef?: MutableRefObject<FocusTrap | undefined>
   scrollLockEnabled?: boolean
 }
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -347,7 +347,10 @@ export function usePopover({
     enable: enableFocusTrap,
     isEnabled: focusTrapEnabled,
     disable: disableFocusTrap,
+    trapRef: focusTrapRef,
   } = useFocusTrap(controlledIsOpen && focusTrap)
+
+  const { focusTrapRef: parentFocusTrapRef } = React.useContext(ModalContext)
 
   const [newTriggerElement, callbackRef] = useCallbackRef()
   // If the triggerElement is passed in props, use that instead of the new element
@@ -368,10 +371,23 @@ export function usePopover({
   const verticalSpace = useVerticalSpace(element, pin, propsPlacement, isOpen)
   const openWithoutElem = useOpenWithoutElement(isOpen, element)
 
+  useEffect(() => {
+    if (isOpen) {
+      if (focusTrap) {
+        // this will disable any parent focus trap
+        enableFocusTrap()
+      } else {
+        // need to manually disable any parent focus trap
+        parentFocusTrapRef &&
+          parentFocusTrapRef.current &&
+          parentFocusTrapRef.current.deactivate({ returnFocus: false })
+      }
+    }
+  }, [focusTrap, parentFocusTrapRef, isOpen, enableFocusTrap])
+
   function handleOpen(event: SyntheticEvent) {
     setOpen(true)
     enableScrollLock()
-    enableFocusTrap()
     event.stopPropagation()
     event.preventDefault()
   }
@@ -391,6 +407,7 @@ export function usePopover({
         enableFocusTrap,
         enableScrollLock,
         focusTrapEnabled,
+        focusTrapRef,
         scrollLockEnabled,
       }}
     >

--- a/packages/playground/src/Select/SelectDemo.tsx
+++ b/packages/playground/src/Select/SelectDemo.tsx
@@ -18,8 +18,16 @@
  SOFTWARE.
  */
 
-import React, { MouseEvent } from 'react'
-import { Button, Divider, Box, Select, FieldSelect } from '@looker/components'
+import React, { MouseEvent, useState } from 'react'
+import {
+  Button,
+  Divider,
+  Box,
+  Select,
+  FieldSelect,
+  ModalContent,
+  Dialog,
+} from '@looker/components'
 
 const options = [
   { label: 'Apples', value: '1' },
@@ -29,7 +37,7 @@ const options = [
   { label: 'Kiwis', value: '5' },
 ]
 
-export function SelectDemo() {
+function SelectContent() {
   const [value, setValue] = React.useState()
   const [searchTerm, setSearchTerm] = React.useState('')
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
@@ -100,5 +108,27 @@ export function SelectDemo() {
         validationMessage={{ message: 'An error message', type: 'error' }}
       />
     </Box>
+  )
+}
+
+const ModalInner = () => {
+  return (
+    <ModalContent>
+      <SelectContent />
+    </ModalContent>
+  )
+}
+
+export const SelectDemo = () => {
+  const [isOpen, setOpen] = useState(false)
+  const handleClick = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+  return (
+    <>
+      <Dialog isOpen={isOpen} onClose={handleClose}>
+        <ModalInner />
+      </Dialog>
+      <Button onClick={handleClick}>Open</Button>
+    </>
   )
 }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { ConfirmDemo } from './Confirm/ConfirmDemo'
+import { SelectDemo } from './Select/SelectDemo'
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <>
         <GlobalStyle />
-        <ConfirmDemo />
+        <SelectDemo />
       </>
     </ThemeProvider>
   )


### PR DESCRIPTION
### :sparkles: Changes

- Fixes an issue where clicking on an option of a `Select` inside a `Dialog` breaks the `Dialog`'s focus trap and blurs the `Select`'s, which prevents the click from registering a change.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
