### PR TITLE
[LENS-438] Make ModalSurface maxWidth overwrite-able

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- Adds responsive maxWidth prop support for `ModalSurface` and all consumers
 - `ConfirmationDialog` uses `ConfirmLayout` to render modal content
 - `ModalHeader` accepts a new headerIcon prop to render next to the title content
 - `ModalManager` children prop is now optional

--- a/packages/components/src/Modal/Dialog/Dialog.tsx
+++ b/packages/components/src/Modal/Dialog/Dialog.tsx
@@ -3,17 +3,17 @@
  MIT License
 
  Copyright (c) 2019 Looker Data Sciences, Inc.
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,6 +32,7 @@ export const Dialog: FC<ModalProps> = ({
   width,
   children,
   surfaceStyles,
+  maxWidth,
   ...props
 }) => {
   const surface = (animationState: string) => (
@@ -39,6 +40,7 @@ export const Dialog: FC<ModalProps> = ({
       style={surfaceStyles}
       className={animationState}
       width={width}
+      maxWidth={maxWidth}
     >
       {children}
     </DialogSurface>

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -27,6 +27,7 @@
 import React, { CSSProperties } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { CSSObject, FlattenSimpleInterpolation } from 'styled-components'
+import { ResponsiveValue } from 'styled-system'
 import { useFocusTrap, useScrollLock } from '../utils'
 import { ModalBackdrop } from './ModalBackdrop'
 import { ModalPortal } from './ModalPortal'
@@ -61,7 +62,8 @@ export interface ManagedModalProps {
    * You can also specify `auto` if you want the Surface to auto-size to its content.
    * @default auto
    */
-  width?: string | string[]
+  width?: ResponsiveValue<string>
+  maxWidth?: ResponsiveValue<string>
 }
 
 export interface ModalProps extends ManagedModalProps {

--- a/packages/components/src/Modal/ModalSurface.tsx
+++ b/packages/components/src/Modal/ModalSurface.tsx
@@ -139,5 +139,5 @@ Style.defaultProps = {
   boxShadow: 3,
   color: 'palette.charcoal900',
   maxHeight: '90vh',
-  maxWidth: '90vw',
+  maxWidth: ['90vw', '90vw', '600px'],
 }

--- a/packages/playground/src/Dialog/DialogMaxWidthDemo.tsx
+++ b/packages/playground/src/Dialog/DialogMaxWidthDemo.tsx
@@ -1,0 +1,119 @@
+/*
+ MIT License
+ Copyright (c) 2019 Looker Data Sciences, Inc.
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import React, { useState } from 'react'
+import {
+  Button,
+  ModalContent,
+  Dialog,
+  DialogManager,
+  Confirm,
+} from '@looker/components'
+
+const DialogFixedWidth = () => {
+  const [isOpen, setOpen] = useState(false)
+  const handleClick = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+  return (
+    <>
+      <Dialog isOpen={isOpen} onClose={handleClose} maxWidth="300px">
+        <ModalContent>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et eros
+          sed nisi pellentesque vulputate ac eu augue. Sed commodo sagittis
+          neque, vel vulputate massa. Sed a velit nec ligula maximus lacinia.
+          Morbi congue imperdiet sem, rhoncus convallis enim bibendum et. Class
+          aptent taciti sociosqu ad litora torquent per conubia nostra, per
+          inceptos himenaeos.
+        </ModalContent>
+      </Dialog>
+      <Button onClick={handleClick}>Open fixed max width dialog</Button>
+    </>
+  )
+}
+
+const DialogResponsiveWidth = () => {
+  const [isOpen, setOpen] = useState(false)
+  const handleClick = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+  return (
+    <>
+      <Dialog
+        isOpen={isOpen}
+        onClose={handleClose}
+        maxWidth={['90vw', '50vw', '500px']}
+      >
+        <ModalContent>
+          Sed a velit nec ligula maximus lacinia. Morbi congue imperdiet sem,
+          rhoncus convallis enim bibendum et. Class aptent taciti sociosqu ad
+          litora torquent per conubia nostra, per inceptos himenaeos.
+        </ModalContent>
+      </Dialog>
+      <Button onClick={handleClick}>Open dynamic max width dialog</Button>
+    </>
+  )
+}
+
+const DialogManagerWidth = () => {
+  return (
+    <DialogManager
+      content={
+        <ModalContent>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et eros
+          sed nisi pellentesque vulputate ac eu augue. Sed commodo sagittis
+          neque, vel vulputate massa.
+        </ModalContent>
+      }
+      maxWidth="200px"
+    >
+      {open => <Button onClick={open}>Open static width DialogManager</Button>}
+    </DialogManager>
+  )
+}
+
+const ConfirmWidth = () => {
+  return (
+    <Confirm
+      title="Confirm Something"
+      message="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+      onConfirm={close => {
+        alert('You did something')
+        close()
+      }}
+      maxWidth={['10rem', '20rem', '30rem', '40rem']}
+    >
+      {open => (
+        <Button onClick={open} mr="small">
+          Open responsive width Confirm dialog
+        </Button>
+      )}
+    </Confirm>
+  )
+}
+
+export const DialogMaxWidthDemo = () => {
+  return (
+    <>
+      <DialogFixedWidth />
+      <DialogResponsiveWidth />
+      <DialogManagerWidth />
+      <ConfirmWidth />
+    </>
+  )
+}

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { CanCloseDialogManagerDemo } from './Confirm/CanCloseDialogManagerDemo'
+import { DialogMaxWidthDemo } from './Dialog/DialogMaxWidthDemo'
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <>
         <GlobalStyle />
-        <CanCloseDialogManagerDemo />
+        <DialogMaxWidthDemo />
       </>
     </ThemeProvider>
   )

--- a/packages/playground/src/template.html
+++ b/packages/playground/src/template.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta name="viewport" content="width=device-width" />
     <title>welcome</title>
   </head>
   <body>

--- a/packages/www/src/documentation/components/modals/dialog.mdx
+++ b/packages/www/src/documentation/components/modals/dialog.mdx
@@ -14,7 +14,7 @@ import { Banner } from '@looker/components'
 
 Dialogs break out of the standard application flow and UI to present new information or required actions.
 
-# Standard Use
+## Standard Use
 
 `Dialog` requires that the developer manages state by assigning `true` or `false` to the `isOpen` prop.
 
@@ -35,7 +35,7 @@ Dialogs break out of the standard application flow and UI to present new informa
 }
 ```
 
-# DialogManager
+## DialogManager
 
 DialogManager gives an easy way to compose a Dialog without the need to manage open/close state.
 
@@ -52,7 +52,34 @@ DialogManager gives an easy way to compose a Dialog without the need to manage o
 </DialogManager>
 ```
 
-# Advanced Use: Protect Unsaved User Changes
+## Props: width and maxWidth
+
+All variants of Dialog allow you to override content `width` and `max-width` style to suit your content. We support responsive width arrays an well as static strings.
+
+```jsx
+<DialogManager
+  content={
+    <ModalContent>
+      <Heading>
+        Resize your browser to watch maxWidth adjust accordingly
+      </Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et eros
+        sed nisi pellentesque vulputate ac eu augue. Sed commodo sagittis neque,
+        vel vulputate massa.
+      </Paragraph>
+    </ModalContent>
+  }
+  /**
+   * Responsive array values are passed from smallest to largest breakpoints:
+   */
+  maxWidth={['90vw', '60vw', '500px', '800px']}
+>
+  {open => <Button onClick={open}>Open responsive width modal</Button>}
+</DialogManager>
+```
+
+## Advanced Use: Protect Unsaved User Changes
 
 If your dialog content includes form inputs it's entirely possible that the user could unintentionally close the dialog and lose their unsaved changes. With careful management of dialog and form state, you can add a second stage dialog to alert the user to unsaved changes and protect them from losing their work.
 

--- a/packages/www/src/documentation/components/modals/dialog.mdx
+++ b/packages/www/src/documentation/components/modals/dialog.mdx
@@ -54,7 +54,13 @@ DialogManager gives an easy way to compose a Dialog without the need to manage o
 
 ## Props: width and maxWidth
 
-All variants of Dialog allow you to override content `width` and `max-width` style to suit your content. We support responsive width arrays an well as static strings.
+All variants of Dialog allow you to override `width` and `max-width` styles to suit your content. By default, `width` is unassigned so that Dialog Surface will conform to the width of its content. At the same time, `maxWidth` constrains the Dialog surface's width to be no larger than the specified value.
+
+`maxWidth` defaults to one of three sizes depending on the responsive breakpoint of the page (`['90vw', '90vw', '600px']`).
+
+With those constraints in mind, if you want a variable-width Dialog that renders complex content you should use `maxWidth`. If your Dialog content must be a specific predefined width, assign values to both props (or else `maxWidth` [will take priority](https://css-tricks.com/tale-width-max-width/)).
+
+The props accept responsive width arrays an well as static strings.
 
 ```jsx
 <DialogManager


### PR DESCRIPTION
### :sparkles: Changes

-  Adds responsive maxWidth prop support for `ModalSurface` and all consumers

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
