### PR TITLE
Fix: Banner children display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
 - `Button` now has a `fullWidth` prop that will set the button's width to 100%, filling its parent container.
 - New modal component: `ConfirmLayout` for laying out standard user confirmation dialog content
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModalManager` children prop is now optional
 - Updated `ModalSurface` prop from `surfaceStyle` to `surfaceStyles` in order to make the modal and DialogManager apis consistent
 - Edited modal documentation for clarity
+- `Banner` children are now wrapped in `<Box display="auto">` so they will expand to the full available width.
 
 ## [07.13] - 2020-01-16
 

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -31,6 +31,7 @@ import {
 } from '@looker/design-tokens'
 import React, { forwardRef, Ref } from 'react'
 import { IconButton } from '../Button'
+import { Box } from '../Layout/Box'
 import { Icon } from '../Icon'
 import { Flex } from '../Layout/Flex'
 import { VisuallyHidden } from '../VisuallyHidden'
@@ -60,7 +61,7 @@ const getBannerIntentStyling = (intent: BannerIntent) => {
   const iconProps = {
     mr: 'small',
     size: 20,
-    style: { flexBasis: '20px' },
+    style: { flexBasis: '20px', flexShrink: 0 },
   }
 
   switch (intent) {
@@ -125,7 +126,7 @@ export const Banner = forwardRef(
       >
         {icon}
         <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
-        <Flex flex="auto">{children}</Flex>
+        <Box flex="auto">{children}</Box>
         {dismissable && (
           <IconButton
             ml="auto"

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -5,10 +5,6 @@ exports[`Confirmation banner 1`] = `
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .c0 {
@@ -128,10 +124,6 @@ exports[`Dismissable banner 1`] = `
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .c0 {
@@ -215,6 +207,7 @@ exports[`Dismissable banner 1`] = `
     style={
       Object {
         "flexBasis": "20px",
+        "flexShrink": 0,
       }
     }
   >
@@ -310,10 +303,6 @@ exports[`Error banner 1`] = `
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .c0 {
@@ -358,6 +347,7 @@ exports[`Error banner 1`] = `
     style={
       Object {
         "flexBasis": "20px",
+        "flexShrink": 0,
       }
     }
   >
@@ -409,10 +399,6 @@ exports[`Info banner 1`] = `
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
 }
 
 .c0 {
@@ -457,6 +443,7 @@ exports[`Info banner 1`] = `
     style={
       Object {
         "flexBasis": "20px",
+        "flexShrink": 0,
       }
     }
   >
@@ -504,6 +491,12 @@ exports[`Warning banner 1`] = `
   display: inline-flex;
 }
 
+.c3 {
+  -webkit-flex: auto;
+  -ms-flex: auto;
+  flex: auto;
+}
+
 .c0 {
   border-radius: 0.25rem;
   background-color: #FFEBC4;
@@ -519,16 +512,6 @@ exports[`Warning banner 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c3 {
-  -webkit-flex: auto;
-  -ms-flex: auto;
-  flex: auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -556,6 +539,7 @@ exports[`Warning banner 1`] = `
     style={
       Object {
         "flexBasis": "20px",
+        "flexShrink": 0,
       }
     }
   >


### PR DESCRIPTION
### :sparkles: Changes

- Use `Box` instead of `Flex` for  `Banner` children so they still get the full available width but don't unintentionally render as a row of columns.
- Add `flexShrink: 0` to the intent icon so it stays at a fixed size.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
