### PR TITLE
Fix Select (& InputChips / InputSearch) width issues

### DIFF
--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -2,7 +2,19 @@
 
 exports[`A FieldSelect 1`] = `
 .c2 {
+  display: inline-block;
+}
+
+.c3 {
+  border-radius: 0.25rem;
+  border: solid 1px;
+  border-color: #DEE1E5;
   width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.25rem;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-size: 0.875rem;
 }
 
 .c7 {
@@ -41,18 +53,6 @@ exports[`A FieldSelect 1`] = `
   border-color: #DEE1E5;
 }
 
-.c3 {
-  border-radius: 0.25rem;
-  border: solid 1px;
-  border-color: #DEE1E5;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.25rem;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  font-size: 0.875rem;
-}
-
 .c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -86,6 +86,7 @@ exports[`A FieldSelect 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -156,7 +157,6 @@ exports[`A FieldSelect 1`] = `
         id="thumbs-up"
         name="thumbsUp"
         role="combobox"
-        width="100%"
       >
         <div
           className="c3 c4 c5"
@@ -187,7 +187,19 @@ exports[`A FieldSelect 1`] = `
 
 exports[`A FieldSelect with an error validation aligned to the left 1`] = `
 .c3 {
+  display: inline-block;
+}
+
+.c4 {
+  border-radius: 0.25rem;
+  border: solid 1px;
+  border-color: #DEE1E5;
   width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.25rem;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-size: 0.875rem;
 }
 
 .c8 {
@@ -226,18 +238,6 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
   border-color: #DEE1E5;
 }
 
-.c4 {
-  border-radius: 0.25rem;
-  border: solid 1px;
-  border-color: #DEE1E5;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.25rem;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  font-size: 0.875rem;
-}
-
 .c10 .c7 {
   border: none;
   -webkit-appearance: none;
@@ -248,6 +248,7 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -304,6 +305,7 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -400,7 +402,6 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
         id="thumbs-up"
         name="thumbsUp"
         role="combobox"
-        width="100%"
       >
         <div
           className="c4 c5 c6"
@@ -438,7 +439,19 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
 
 exports[`A FieldSelect with an error validation aligned to the right 1`] = `
 .c3 {
+  display: inline-block;
+}
+
+.c4 {
+  border-radius: 0.25rem;
+  border: solid 1px;
+  border-color: #DEE1E5;
   width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.25rem;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-size: 0.875rem;
 }
 
 .c8 {
@@ -477,18 +490,6 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
   border-color: #DEE1E5;
 }
 
-.c4 {
-  border-radius: 0.25rem;
-  border: solid 1px;
-  border-color: #DEE1E5;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.25rem;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  font-size: 0.875rem;
-}
-
 .c10 .c7 {
   border: none;
   -webkit-appearance: none;
@@ -499,6 +500,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -555,6 +557,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -648,7 +651,6 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
         id="thumbs-up"
         name="thumbsUp"
         role="combobox"
-        width="100%"
       >
         <div
           className="c4 c5 c6"
@@ -686,7 +688,19 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
 
 exports[`A required FieldSelect 1`] = `
 .c3 {
+  display: inline-block;
+}
+
+.c4 {
+  border-radius: 0.25rem;
+  border: solid 1px;
+  border-color: #DEE1E5;
   width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.25rem;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-size: 0.875rem;
 }
 
 .c8 {
@@ -725,18 +739,6 @@ exports[`A required FieldSelect 1`] = `
   border-color: #DEE1E5;
 }
 
-.c4 {
-  border-radius: 0.25rem;
-  border: solid 1px;
-  border-color: #DEE1E5;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.25rem;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  font-size: 0.875rem;
-}
-
 .c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -770,6 +772,7 @@ exports[`A required FieldSelect 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -852,7 +855,6 @@ exports[`A required FieldSelect 1`] = `
         name="thumbsUp"
         required={true}
         role="combobox"
-        width="100%"
       >
         <div
           className="c4 c5 c6"
@@ -883,7 +885,19 @@ exports[`A required FieldSelect 1`] = `
 
 exports[`FieldSelect supports labelWeight 1`] = `
 .c2 {
+  display: inline-block;
+}
+
+.c3 {
+  border-radius: 0.25rem;
+  border: solid 1px;
+  border-color: #DEE1E5;
   width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.25rem;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-size: 0.875rem;
 }
 
 .c7 {
@@ -922,18 +936,6 @@ exports[`FieldSelect supports labelWeight 1`] = `
   border-color: #DEE1E5;
 }
 
-.c3 {
-  border-radius: 0.25rem;
-  border: solid 1px;
-  border-color: #DEE1E5;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.25rem;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  font-size: 0.875rem;
-}
-
 .c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -967,6 +969,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 
@@ -1037,7 +1040,6 @@ exports[`FieldSelect supports labelWeight 1`] = `
         id="thumbs-up"
         name="thumbsUp"
         role="combobox"
-        width="100%"
       >
         <div
           className="c3 c4 c5"

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.tsx
@@ -40,6 +40,7 @@ import {
 import React, { forwardRef, useRef, useState, Ref, useEffect } from 'react'
 import styled from 'styled-components'
 import { useID, useCallbackRef, useForkedRef } from '../../../utils'
+import { Box } from '../../../Layout/Box'
 import { useFocusManagement } from './helpers'
 import { useReducerMachine, ComboboxActionType, ComboboxState } from './state'
 import { ComboboxContext, defaultData } from './ComboboxContext'
@@ -208,7 +209,7 @@ export const ComboboxInternal = forwardRef(function Combobox(
 
   return (
     <ComboboxContext.Provider value={context}>
-      <div
+      <Box
         display="inline-block"
         {...rest}
         ref={ref}
@@ -218,7 +219,7 @@ export const ComboboxInternal = forwardRef(function Combobox(
         aria-expanded={context.isVisible}
       >
         {children}
-      </div>
+      </Box>
     </ComboboxContext.Provider>
   )
 })
@@ -231,5 +232,3 @@ export const Combobox = styled(ComboboxInternal)`
   ${position}
   ${space}
 `
-
-Combobox.defaultProps = { width: '100%' }

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -214,6 +214,7 @@ export const InputChips = styled(InputChipsInternal)`
   flex-wrap: wrap;
 
   ${InputText} {
+    width: auto;
     min-width: 25%;
     padding-left: ${props => props.theme.space.xsmall};
   }

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
@@ -219,6 +219,7 @@ export const InputSearch = styled(InputSearchComponent)`
     box-shadow: none;
     flex: 1;
 
+    width: 100%;
     height: ${props => getHeight(props.py)};
 
     &::-webkit-search-decoration,

--- a/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
@@ -94,6 +94,7 @@ exports[`InputSearch default 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
+  width: 100%;
   height: calc(36px - 6px);
 }
 

--- a/packages/www/src/documentation/components/forms/select.mdx
+++ b/packages/www/src/documentation/components/forms/select.mdx
@@ -78,7 +78,6 @@ the user to delete the current value.
       value={value}
       onChange={handleChange}
       onFilter={handleFilter}
-      width={300}
     />
   )
 }
@@ -97,7 +96,6 @@ A name and ID can be specified in the `<Select />` component. Names are importan
     { value: 'gouda', label: 'Gouda' },
     { value: 'swiss', label: 'Swiss' },
   ]}
-  width={300}
 />
 ```
 
@@ -114,6 +112,7 @@ Use the disable property to make an input field uneditable.
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
+    flex={1}
   />
   <Select
     defaultValue="gouda"
@@ -124,6 +123,7 @@ Use the disable property to make an input field uneditable.
       { value: 'swiss', label: 'Swiss' },
     ]}
     ml="large"
+    flex={1}
   />
 </Flex>
 ```
@@ -142,6 +142,7 @@ To allow the user to clear the `Select`'s value, add the `isClearable` prop.
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
+    flex={1}
   />
   <Select
     placeholder="Value can be cleared"
@@ -152,6 +153,7 @@ To allow the user to clear the `Select`'s value, add the `isClearable` prop.
       { value: 'swiss', label: 'Swiss' },
     ]}
     ml="large"
+    flex={1}
   />
 </Flex>
 ```


### PR DESCRIPTION
### :sparkles: Changes

- `InputText` inside of `InputSearch` needs to have width = 100%, otherwise `Select` has issues in a flex row.
- `InputChips` has a different internal layout, so it needs `InputText` to be width = auto.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots
Issue:
![image](https://user-images.githubusercontent.com/53451193/73380078-3de2bd80-4278-11ea-8f1a-7c5c8810655a.png)
Fixed:
![image](https://user-images.githubusercontent.com/53451193/73380121-52bf5100-4278-11ea-9ca4-3763335000f7.png)

