### PR TITLE
Fix issue with Select/Combobox integration testing

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/state.ts
@@ -147,6 +147,7 @@ export const stateChart: StateChart = {
         [ComboboxActionType.BLUR]: ComboboxState.IDLE,
         [ComboboxActionType.ESCAPE]: ComboboxState.IDLE,
         [ComboboxActionType.NAVIGATE]: ComboboxState.NAVIGATING,
+        [ComboboxActionType.SELECT_WITH_CLICK]: ComboboxState.IDLE,
         [ComboboxActionType.SELECT_WITH_KEYBOARD]: ComboboxState.IDLE,
         [ComboboxActionType.SELECT_SILENT]: ComboboxState.IDLE,
         [ComboboxActionType.INTERACT]: ComboboxState.INTERACTING,

--- a/packages/playground/src/Select/SelectDemo.tsx
+++ b/packages/playground/src/Select/SelectDemo.tsx
@@ -37,7 +37,7 @@ const options = [
   { label: 'Kiwis', value: '5' },
 ]
 
-function SelectContent() {
+export function SelectContent() {
   const [value, setValue] = React.useState()
   const [searchTerm, setSearchTerm] = React.useState('')
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { InputChipsDemo } from './Form/InputChipsDemo'
+import { SelectContent } from './Select/SelectDemo'
 
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <InputChipsDemo />
+      <SelectContent />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- An integration test in the core product is getting into a state such that this warning occurs `"Unknown action \"SELECT_WITH_CLICK\" for state \"NAVIGATING\""`.
- Though I'm not able to reproduce that state, there's no reason NAVIGATING -> SELECT with click can't be a valid flow, so now it is.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
