### PR TITLE
Correct bug in Gatsby ESLint configuration

### DIFF
--- a/packages/www/.eslintrc.js
+++ b/packages/www/.eslintrc.js
@@ -25,6 +25,7 @@
  */
 
 module.exports = {
+  root: true,
   extends: ['@looker/eslint-config', 'plugin:mdx/recommended'],
   rules: {
     'mdx/no-unescaped-entities': 'off',


### PR DESCRIPTION

### :sparkles: Changes

-  Correct bug in Gatsby ESLint configuration that was causing console warnings at Gatsby-boot

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC