### PR TITLE
Fix controlled FieldColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- `FieldColor` state can now be fully controlled.
 - `Slider` component style updates
 - `InputDate` now supports controlled component behavior
 

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
@@ -28,7 +28,10 @@ import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
-import { renderWithTheme } from '@looker/components-test-utils'
+import {
+  assertSnapshotShallow,
+  renderWithTheme,
+} from '@looker/components-test-utils'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
@@ -36,11 +39,15 @@ import { Button } from '../../../Button'
 import { FieldColor } from './FieldColor'
 
 describe('FieldColor', () => {
+  test('Default render', () => {
+    assertSnapshotShallow(<FieldColor />)
+  })
+
   test('with hidden input', () => {
-    const { queryByRole } = renderWithTheme(
+    const { queryByDisplayValue } = renderWithTheme(
       <FieldColor value="yellow" hideInput />
     )
-    expect(queryByRole('input')).not.toBeInTheDocument()
+    expect(queryByDisplayValue('yellow')).not.toBeInTheDocument()
   })
 
   test('starts with a named color value', () => {
@@ -48,22 +55,21 @@ describe('FieldColor', () => {
     expect(getByDisplayValue('green')).toBeInTheDocument()
   })
 
-  test('starts with a named color value', () => {
+  test('responds to input value change', () => {
     const { getByDisplayValue } = renderWithTheme(<FieldColor value="green" />)
     fireEvent.change(getByDisplayValue('green'), { target: { value: 'blue' } })
     expect(getByDisplayValue('blue')).toBeInTheDocument()
   })
 
+  const FieldColorValidationMessage = () => {
+    return (
+      <ThemeProvider theme={theme}>
+        <FieldColor validationMessage={{ message: 'Error!', type: 'error' }} />
+      </ThemeProvider>
+    )
+  }
+
   test('with a validation message', () => {
-    const FieldColorValidationMessage = () => {
-      return (
-        <ThemeProvider theme={theme}>
-          <FieldColor
-            validationMessage={{ message: 'Error!', type: 'error' }}
-          />
-        </ThemeProvider>
-      )
-    }
     const { queryByText } = renderWithTheme(<FieldColorValidationMessage />)
     expect(queryByText('Error!')).toBeInTheDocument()
   })

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
@@ -57,7 +57,9 @@ describe('FieldColor', () => {
 
   test('responds to input value change', () => {
     const { getByDisplayValue } = renderWithTheme(<FieldColor value="green" />)
-    fireEvent.change(getByDisplayValue('green'), { target: { value: 'blue' } })
+    const input = getByDisplayValue('green')
+    input.focus()
+    fireEvent.change(input, { target: { value: 'blue' } })
     expect(getByDisplayValue('blue')).toBeInTheDocument()
   })
 
@@ -82,8 +84,8 @@ describe('FieldColor', () => {
     const input = getByLabelText('Background Color')
     fireEvent.change(input, { target: { value: '#FFFF00' } })
     expect(onChangeMock).toHaveBeenCalledWith({
-      currentTarget: { value: '#ffff00' },
-      target: { value: '#ffff00' },
+      currentTarget: { value: '#FFFF00' },
+      target: { value: '#FFFF00' },
     })
   })
 

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
@@ -28,10 +28,7 @@ import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
-import {
-  assertSnapshotShallow,
-  renderWithTheme,
-} from '@looker/components-test-utils'
+import { renderWithTheme } from '@looker/components-test-utils'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
@@ -39,10 +36,6 @@ import { Button } from '../../../Button'
 import { FieldColor } from './FieldColor'
 
 describe('FieldColor', () => {
-  test('Default render', () => {
-    assertSnapshotShallow(<FieldColor />)
-  })
-
   test('with hidden input', () => {
     const { queryByRole } = renderWithTheme(
       <FieldColor value="yellow" hideInput />
@@ -61,15 +54,16 @@ describe('FieldColor', () => {
     expect(getByDisplayValue('blue')).toBeInTheDocument()
   })
 
-  const FieldColorValidationMessage = () => {
-    return (
-      <ThemeProvider theme={theme}>
-        <FieldColor validationMessage={{ message: 'Error!', type: 'error' }} />
-      </ThemeProvider>
-    )
-  }
-
   test('with a validation message', () => {
+    const FieldColorValidationMessage = () => {
+      return (
+        <ThemeProvider theme={theme}>
+          <FieldColor
+            validationMessage={{ message: 'Error!', type: 'error' }}
+          />
+        </ThemeProvider>
+      )
+    }
     const { queryByText } = renderWithTheme(<FieldColorValidationMessage />)
     expect(queryByText('Error!')).toBeInTheDocument()
   })

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
@@ -35,52 +35,94 @@ import {
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
+import { Button } from '../../../Button'
 import { FieldColor } from './FieldColor'
 
-test('Default FieldColor', () => {
-  assertSnapshotShallow(<FieldColor />)
-})
+describe('FieldColor', () => {
+  test('Default render', () => {
+    assertSnapshotShallow(<FieldColor />)
+  })
 
-test('FieldColor with hidden input', () => {
-  const { queryByRole } = renderWithTheme(
-    <FieldColor value="yellow" hideInput />
-  )
-  expect(queryByRole('input')).not.toBeInTheDocument()
-})
+  test('with hidden input', () => {
+    const { queryByRole } = renderWithTheme(
+      <FieldColor value="yellow" hideInput />
+    )
+    expect(queryByRole('input')).not.toBeInTheDocument()
+  })
 
-test('FieldColor starts with a named color value', () => {
-  const { getByDisplayValue } = renderWithTheme(<FieldColor value="green" />)
-  expect(getByDisplayValue('green')).toBeInTheDocument()
-})
+  test('starts with a named color value', () => {
+    const { getByDisplayValue } = renderWithTheme(<FieldColor value="green" />)
+    expect(getByDisplayValue('green')).toBeInTheDocument()
+  })
 
-test('FieldColor starts with a named color value', () => {
-  const { getByDisplayValue } = renderWithTheme(<FieldColor value="green" />)
-  fireEvent.change(getByDisplayValue('green'), { target: { value: 'blue' } })
-  expect(getByDisplayValue('blue')).toBeInTheDocument()
-})
+  test('starts with a named color value', () => {
+    const { getByDisplayValue } = renderWithTheme(<FieldColor value="green" />)
+    fireEvent.change(getByDisplayValue('green'), { target: { value: 'blue' } })
+    expect(getByDisplayValue('blue')).toBeInTheDocument()
+  })
 
-const FieldColorValidationMessage = () => {
-  return (
-    <ThemeProvider theme={theme}>
-      <FieldColor validationMessage={{ message: 'Error!', type: 'error' }} />
-    </ThemeProvider>
-  )
-}
+  const FieldColorValidationMessage = () => {
+    return (
+      <ThemeProvider theme={theme}>
+        <FieldColor validationMessage={{ message: 'Error!', type: 'error' }} />
+      </ThemeProvider>
+    )
+  }
 
-test('FieldColor with a validation message', () => {
-  const { queryByText } = renderWithTheme(<FieldColorValidationMessage />)
-  expect(queryByText('Error!')).toBeInTheDocument()
-})
+  test('with a validation message', () => {
+    const { queryByText } = renderWithTheme(<FieldColorValidationMessage />)
+    expect(queryByText('Error!')).toBeInTheDocument()
+  })
 
-test('FieldColor with an onChange', () => {
-  const onChangeMock = jest.fn()
-  const { getByLabelText } = renderWithTheme(
-    <FieldColor onChange={onChangeMock} label="Background Color" />
-  )
-  const input = getByLabelText('Background Color')
-  fireEvent.change(input, { target: { value: '#FFFF00' } })
-  expect(onChangeMock).toHaveBeenCalledWith({
-    currentTarget: { value: '#ffff00' },
-    target: { value: '#ffff00' },
+  test('with an onChange', () => {
+    const onChangeMock = jest.fn()
+    const { getByLabelText } = renderWithTheme(
+      <FieldColor onChange={onChangeMock} label="Background Color" />
+    )
+    const input = getByLabelText('Background Color')
+    fireEvent.change(input, { target: { value: '#FFFF00' } })
+    expect(onChangeMock).toHaveBeenCalledWith({
+      currentTarget: { value: '#ffff00' },
+      target: { value: '#ffff00' },
+    })
+  })
+
+  test('with a defaultValue', () => {
+    const { getByLabelText } = renderWithTheme(
+      <FieldColor defaultValue="purple" label="Background Color" />
+    )
+    const input = getByLabelText('Background Color')
+    expect(input).toHaveValue('purple')
+  })
+
+  test('with controlled state', () => {
+    function Wrapper() {
+      const [value, setValue] = React.useState('')
+      function handleClick() {
+        setValue('yellow')
+      }
+      function handleChange(e: React.FormEvent<HTMLInputElement>) {
+        setValue(e.currentTarget.value)
+      }
+      return (
+        <>
+          <Button onClick={handleClick}>Turn yellow</Button>
+          <FieldColor
+            value={value}
+            onChange={handleChange}
+            placeholder="Select a color"
+          />
+        </>
+      )
+    }
+    const { getByText, getByPlaceholderText } = renderWithTheme(<Wrapper />)
+
+    const button = getByText('Turn yellow')
+    const input = getByPlaceholderText('Select a color')
+    expect(input).toHaveValue('')
+    fireEvent.click(button)
+    expect(input).toHaveValue('yellow')
+    fireEvent.change(input, { target: { value: 'purple' } })
+    expect(input).toHaveValue('purple')
   })
 })

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
@@ -98,36 +98,29 @@ export const FieldColorComponent = forwardRef(
     }: FieldColorProps,
     ref: Ref<HTMLInputElement>
   ) => {
-    const inputID = useID(id)
-    const validationMessage = useFormContext(props)
-
     const isControlled = useControlWarn({
       controllingProps: ['onChange', 'value'],
       isControlledCheck: () => onChange !== undefined,
-      name: 'ButtonGroup',
+      name: 'FieldColor',
     })
 
-    const colorFromProps = getColorFromText(controlledValue)
-    const defaultColorFromProps = getColorFromText(defaultValue)
+    const whiteHSV = polarbrightness2hsv(white())
+    const colorFromProps =
+      getColorFromText(controlledValue || defaultValue) || whiteHSV
 
-    const initialWhite = polarbrightness2hsv(white())
-    const initialValue = colorFromProps
-      ? controlledValue
-      : defaultColorFromProps
-      ? defaultValue
-      : ''
-    const initialColor = colorFromProps || defaultColorFromProps || initialWhite
+    const [color, setColor] = useState<SimpleHSV>(colorFromProps)
+    const [value, setValue] = useState(defaultValue || '')
 
-    const [color, setColor] = useState<SimpleHSV>(initialColor)
-    const [value, setValue] = useState(initialValue)
-
-    // If there's been an external change, update the input text value
+    // If there's been an external change in the color, update the input value
+    // except when the user is manually typing a color string (isInputting.current === true)
+    // since onChange will have been called with #ffffff until the typed value is a valid color
+    // and updating the input text with that would interfere with typing
     const isInputting = useRef(false)
     if (controlledValue && value !== controlledValue && !isInputting.current) {
       setValue(controlledValue)
     }
 
-    const colorToUse = isControlled ? colorFromProps || initialWhite : color
+    const colorToUse = isControlled ? colorFromProps || whiteHSV : color
 
     const updateColor = (newColor: SimpleHSV) => {
       if (onChange) {
@@ -158,7 +151,7 @@ export const FieldColorComponent = forwardRef(
 
       const newColor =
         !newValue || !isValidColor(newValue)
-          ? initialWhite
+          ? whiteHSV
           : str2simpleHsv(newValue)
       updateColor(newColor)
 
@@ -166,6 +159,8 @@ export const FieldColorComponent = forwardRef(
         isInputting.current = false
       })
     }
+    const inputID = useID(id)
+    const validationMessage = useFormContext(props)
 
     const content = (
       <PopoverContent display="flex" flexDirection="column">

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
@@ -98,6 +98,9 @@ export const FieldColorComponent = forwardRef(
     }: FieldColorProps,
     ref: Ref<HTMLInputElement>
   ) => {
+    const inputID = useID(id)
+    const validationMessage = useFormContext(props)
+
     const isControlled = useControlWarn({
       controllingProps: ['onChange', 'value'],
       isControlledCheck: () => onChange !== undefined,
@@ -163,8 +166,6 @@ export const FieldColorComponent = forwardRef(
         isInputting.current = false
       })
     }
-    const inputID = useID(id)
-    const validationMessage = useFormContext(props)
 
     const content = (
       <PopoverContent display="flex" flexDirection="column">

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.tsx
@@ -69,14 +69,20 @@ export interface FieldColorProps
 }
 
 const createEventWithHSVValue = (
-  color: SimpleHSV
+  color: SimpleHSV | string
 ): ChangeEvent<HTMLInputElement> => {
   return {
     currentTarget: {
-      value: simpleHSVtoFormattedColorString(color),
+      value:
+        typeof color === 'string'
+          ? color
+          : simpleHSVtoFormattedColorString(color),
     },
     target: {
-      value: simpleHSVtoFormattedColorString(color),
+      value:
+        typeof color === 'string'
+          ? color
+          : simpleHSVtoFormattedColorString(color),
     },
   } as ChangeEvent<HTMLInputElement>
 }
@@ -124,7 +130,7 @@ export const FieldColorComponent = forwardRef(
       }
     }, [isFocused, value, inputTextValue])
 
-    const callOnChange = (newColor: SimpleHSV) => {
+    const callOnChange = (newColor: SimpleHSV | string) => {
       if (!onChange || !newColor) return
       onChange(createEventWithHSVValue(newColor))
     }
@@ -145,11 +151,12 @@ export const FieldColorComponent = forwardRef(
       })
 
     const handleInputTextChange = (event: FormEvent<HTMLInputElement>) => {
-      setInputTextValue(event.currentTarget.value)
+      const newValue = event.currentTarget.value
+      setInputTextValue(newValue)
 
-      const newColor = getColorFromText(event.currentTarget.value)
-      callOnChange(newColor)
-      setColor(newColor)
+      const isValid = isValidColor(newValue)
+      callOnChange(isValid ? newValue : initialWhite)
+      setColor(getColorFromText(event.currentTarget.value))
     }
 
     const content = (
@@ -176,7 +183,7 @@ export const FieldColorComponent = forwardRef(
 
     return (
       <Field
-        id={id}
+        id={inputID}
         validationMessage={validationMessage}
         alignValidationMessage={alignValidationMessage || 'bottom'}
         {...pickFieldProps(props)}

--- a/packages/components/src/Form/Fields/FieldColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/Swatch/Swatch.tsx
@@ -66,6 +66,7 @@ export const Swatch = styled.div<SwatchProps>`
 
   background-color: ${props => props.color};
   margin-top: auto;
+  flex-shrink: 0;
 `
 
 Swatch.defaultProps = {

--- a/packages/components/src/Form/Fields/FieldColor/Swatch/__snapshots__/Swatch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldColor/Swatch/__snapshots__/Swatch.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`Default Swatch 1`] = `
   border-radius: 0.25rem;
   background-color: white;
   margin-top: auto;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c0:hover {
@@ -32,6 +35,9 @@ exports[`Swatch with hex value passed 1`] = `
   border-radius: 0.25rem;
   background-color: #4c6670;
   margin-top: auto;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c0:hover {
@@ -55,6 +61,9 @@ exports[`Swatch with width and height set 1`] = `
   border-radius: 0.25rem;
   background-color: blue;
   margin-top: auto;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .c0:hover {

--- a/packages/components/src/Form/Fields/FieldColor/__snapshots__/FieldColor.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldColor/__snapshots__/FieldColor.test.tsx.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`FieldColor Default render 1`] = `ShallowWrapper {}`;

--- a/packages/components/src/Form/Fields/FieldColor/__snapshots__/FieldColor.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldColor/__snapshots__/FieldColor.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FieldColor Default render 1`] = `ShallowWrapper {}`;

--- a/packages/components/src/Form/Fields/FieldColor/__snapshots__/FieldColor.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldColor/__snapshots__/FieldColor.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Default FieldColor 1`] = `ShallowWrapper {}`;
+exports[`FieldColor Default render 1`] = `ShallowWrapper {}`;

--- a/packages/playground/src/Form/FieldColorDemo.tsx
+++ b/packages/playground/src/Form/FieldColorDemo.tsx
@@ -19,7 +19,7 @@
  */
 
 import React from 'react'
-import { Box, FieldColor, Select, Swatch } from '@looker/components'
+import { Box, FieldColor, FieldSelect } from '@looker/components'
 
 export function FieldColorDemo() {
   const [color, setColor] = React.useState('red')
@@ -33,14 +33,13 @@ export function FieldColorDemo() {
   }
 
   return (
-    <Box>
-      <Select
+    <Box p="large" width={300}>
+      <FieldSelect
         options={[{ value: 'green' }, { value: 'purple' }, { value: 'red' }]}
         defaultValue="red"
         onChange={handleChange}
       />
       <FieldColor value={color} onChange={handleColorChange} />
-      <Swatch color={color} />
     </Box>
   )
 }

--- a/packages/playground/src/Form/FieldColorDemo.tsx
+++ b/packages/playground/src/Form/FieldColorDemo.tsx
@@ -1,0 +1,46 @@
+/*
+ MIT License
+ Copyright (c) 2019 Looker Data Sciences, Inc.
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import React from 'react'
+import { Box, FieldColor, Select, Swatch } from '@looker/components'
+
+export function FieldColorDemo() {
+  const [color, setColor] = React.useState('red')
+
+  function handleChange(value: string) {
+    setColor(value)
+  }
+
+  function handleColorChange(e: React.FormEvent<HTMLInputElement>) {
+    setColor(e.currentTarget.value)
+  }
+
+  return (
+    <Box>
+      <Select
+        options={[{ value: 'green' }, { value: 'purple' }, { value: 'red' }]}
+        defaultValue="red"
+        onChange={handleChange}
+      />
+      <FieldColor value={color} onChange={handleColorChange} />
+      <Swatch color={color} />
+    </Box>
+  )
+}


### PR DESCRIPTION
### :sparkles: Changes

- `FieldColor` was not truly controllable – any change to the value prop would not register.
- With these changes, a developer takes control of the state using the `onChange` and `value` props
- Added support for `defaultValue` for when an initial value is needed but the field can still be uncontrolled.
- A demo of the issue: https://codesandbox.io/s/reverent-curran-inmig

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots
**Issue:**
![issue](https://user-images.githubusercontent.com/53451193/74473275-2a2e7e00-4e58-11ea-850b-a80e3400f7b7.gif)

**Fix:**
![fix](https://user-images.githubusercontent.com/53451193/74473286-31ee2280-4e58-11ea-982f-b301948fa988.gif)
