### PR TITLE
Fix: Multiple `Select`s in a `Modal` opened successively break scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Select` styling issues when `GlobalStyle` is not used, missing down caret icon in documentation
+- `usePopover`, when the toggle was a mousedown event, would open just before the "click outside" listener was able to close any prior popovers. If both popovers were inside a `Modal`, the closing popover would re-enable the parent scroll lock, and the one that just opened would be un-scrollable. This especially affected multiple `Select`s inside a `Modal`.
 
 ## [0.7.18] - 2020-02-11
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -247,24 +247,30 @@ function usePopoverToggle(
     isControlled && controlledSetOpen ? controlledSetOpen : uncontrolledSetOpen
 
   useEffect(() => {
-    function handleMouseDown(event: MouseEvent) {
-      mouseDownTarget.current = event.target
-    }
-
-    function handleClickOutside(event: MouseEvent) {
+    function checkCloseAndStopEvent(event: MouseEvent) {
       if (canClose && !canClose()) return
-      // User clicked inside the Popover surface/portal
-      if (portalElement && portalElement.contains(event.target as Node)) {
-        return
+
+      // Check if the click started in (or on top of) the popover
+      // If so, don't close the popover even if the user has dragged
+      // outside the popover as this is preferable to a bug where another
+      // component triggers a scroll animation resulting in an
+      // unintentional drag, which closes the popover
+      if (portalElement && mouseDownTarget.current) {
+        const relationship = portalElement.compareDocumentPosition(
+          mouseDownTarget.current as Node
+        )
+        if (
+          relationship === Node.DOCUMENT_POSITION_FOLLOWING ||
+          relationship ===
+            Node.DOCUMENT_POSITION_FOLLOWING +
+              Node.DOCUMENT_POSITION_CONTAINED_BY
+        ) {
+          return
+        }
       }
 
-      if (
-        portalElement &&
-        mouseDownTarget.current &&
-        portalElement.compareDocumentPosition(
-          mouseDownTarget.current as Node
-        ) === Node.DOCUMENT_POSITION_FOLLOWING
-      ) {
+      // User clicked inside the Popover surface/portal
+      if (portalElement && portalElement.contains(event.target as Node)) {
         return
       }
 
@@ -295,17 +301,38 @@ function usePopoverToggle(
 
       event.stopPropagation()
     }
+
+    function handleMouseDown(event: MouseEvent) {
+      mouseDownTarget.current = event.target
+      checkCloseAndStopEvent(event)
+    }
+
+    function handleClickOutside(event: MouseEvent) {
+      checkCloseAndStopEvent(event)
+    }
+
+    function handleMouseUp() {
+      window.requestAnimationFrame(() => {
+        mouseDownTarget.current = null
+        document.removeEventListener('click', handleClickOutside, true)
+        document.removeEventListener('mouseup', handleMouseUp, true)
+      })
+    }
+
     if (isOpen) {
       document.addEventListener('mousedown', handleMouseDown, true)
+      if (mouseDownTarget.current === null) {
+        document.addEventListener('click', handleClickOutside, true)
+      }
+    } else if (mouseDownTarget.current) {
       document.addEventListener('click', handleClickOutside, true)
-    } else {
-      document.removeEventListener('mousedown', handleMouseDown, true)
-      document.removeEventListener('click', handleClickOutside, true)
+      document.addEventListener('mouseup', handleMouseUp, true)
     }
 
     return () => {
       document.removeEventListener('mousedown', handleMouseDown, true)
       document.removeEventListener('click', handleClickOutside, true)
+      document.removeEventListener('mouseup', handleMouseUp, true)
     }
   }, [
     canClose,

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -321,7 +321,7 @@ function usePopoverToggle(
 
     if (isOpen) {
       document.addEventListener('mousedown', handleMouseDown, true)
-      if (mouseDownTarget.current === null) {
+      if (!mouseDownTarget.current) {
         document.addEventListener('click', handleClickOutside, true)
       }
     } else if (mouseDownTarget.current) {

--- a/packages/playground/src/Select/SelectDemo.tsx
+++ b/packages/playground/src/Select/SelectDemo.tsx
@@ -40,6 +40,26 @@ const options = [
   { label: 'Oranges', value: '3' },
   { label: 'Pineapples', value: '4' },
   { label: 'Kiwis', value: '5' },
+  { label: 'Apples2', value: '12' },
+  { label: 'Bananas2', value: '22' },
+  { label: 'Oranges2', value: '32' },
+  { label: 'Pineapples2', value: '42' },
+  { label: 'Kiwis3', value: '52' },
+  { label: 'Apples3', value: '13' },
+  { label: 'Bananas3', value: '23' },
+  { label: 'Oranges3', value: '33' },
+  { label: 'Pineapples3', value: '43' },
+  { label: 'Kiwis3', value: '53' },
+  { label: 'Apples4', value: '14' },
+  { label: 'Bananas4', value: '24' },
+  { label: 'Oranges4', value: '34' },
+  { label: 'Pineapples4', value: '44' },
+  { label: 'Kiwis4', value: '54' },
+  { label: 'Apples5', value: '15' },
+  { label: 'Bananas5', value: '25' },
+  { label: 'Oranges5', value: '35' },
+  { label: 'Pineapples5', value: '45' },
+  { label: 'Kiwis5', value: '55' },
 ]
 
 const optionsWithGroups = [
@@ -165,6 +185,15 @@ export function SelectContent() {
         defaultValue="1"
       />
       <FieldSelect
+        label="Error"
+        width={300}
+        options={options}
+        aria-label="Fruits"
+        placeholder="Select One"
+        defaultValue="1"
+        validationMessage={{ message: 'An error message', type: 'error' }}
+      />
+      <FieldSelect
         label="Disabled"
         width={300}
         mb="medium"
@@ -173,15 +202,6 @@ export function SelectContent() {
         placeholder="Select One"
         disabled
         defaultValue="1"
-      />
-      <FieldSelect
-        label="Error"
-        width={300}
-        options={options}
-        aria-label="Fruits"
-        placeholder="Select One"
-        defaultValue="1"
-        validationMessage={{ message: 'An error message', type: 'error' }}
       />
     </Box>
   )
@@ -204,7 +224,9 @@ export const SelectDemo = () => {
       <Dialog isOpen={isOpen} onClose={handleClose}>
         <ModalInner />
       </Dialog>
-      <Button onClick={handleClick}>Open</Button>
+      <Button onClick={handleClick} m="large">
+        Open
+      </Button>
     </>
   )
 }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { SelectContent } from './Select/SelectDemo'
+import { SelectDemo } from './Select/SelectDemo'
 
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <SelectContent />
+      <SelectDemo />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

The root issue was in `usePopover` – when the toggle was a mousedown event, it would open just before the "click outside" listener was able to close any prior popovers (and would also bypass the event.stopPropagation since it was only stopping a click event, not mousedown). If both popovers were inside a `Modal`, the closing popover would re-enable the parent scroll lock, and the one that just opened would be un-scrollable. This specifically affected multiple `Select`s inside a `Modal`.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
