### PR TITLE
InputDate followup revisions

### DIFF
--- a/packages/components/src/Calendar/CalendarNav.tsx
+++ b/packages/components/src/Calendar/CalendarNav.tsx
@@ -2,6 +2,7 @@ import React, { FC, useContext, SyntheticEvent } from 'react'
 import { NavbarElementProps } from 'react-day-picker'
 import styled from 'styled-components'
 import noop from 'lodash/noop'
+import { Tooltip } from '../Tooltip'
 import { IconButton, ButtonTransparent } from '../Button'
 import { Heading } from '../Text'
 import { CalendarSize } from './calendar-size'
@@ -62,15 +63,22 @@ export const CalendarNav: FC<NavbarElementProps> = ({
           />
         )}
       </NextButtonWrapper>
-      <ButtonTransparent
-        onClick={handleLabelClick}
-        color="neutral"
-        aria-label="View today"
-      >
-        <Heading as={headingSizeMap(size)} fontWeight="semiBold">
-          {localeUtils.formatMonthTitle(month, locale)}
-        </Heading>
-      </ButtonTransparent>
+
+      <Tooltip content="View Current Month">
+        {(eventHandlers, ref) => (
+          <ButtonTransparent
+            ref={ref}
+            {...eventHandlers}
+            onClick={handleLabelClick}
+            color="neutral"
+            aria-label="View today"
+          >
+            <Heading as={headingSizeMap(size)} fontWeight="semiBold">
+              {localeUtils.formatMonthTitle(month, locale)}
+            </Heading>
+          </ButtonTransparent>
+        )}
+      </Tooltip>
 
       <PrevButtonWrapper>
         {showNextButton && (

--- a/packages/components/src/Calendar/CalendarNav.tsx
+++ b/packages/components/src/Calendar/CalendarNav.tsx
@@ -71,7 +71,6 @@ export const CalendarNav: FC<NavbarElementProps> = ({
             {...eventHandlers}
             onClick={handleLabelClick}
             color="neutral"
-            aria-label="View today"
           >
             <Heading as={headingSizeMap(size)} fontWeight="semiBold">
               {localeUtils.formatMonthTitle(month, locale)}

--- a/packages/www/src/documentation/components/content/calendar.mdx
+++ b/packages/www/src/documentation/components/content/calendar.mdx
@@ -25,7 +25,7 @@ import { CalendarPropTable } from './demos'
 
 <CalendarPropTable />
 
-## Prop: size
+## Size
 
 We support three sizes: `small`, **`medium (default)`**, and `large`. The font and grid are sized accordingly.
 

--- a/packages/www/src/documentation/components/forms/input-date.mdx
+++ b/packages/www/src/documentation/components/forms/input-date.mdx
@@ -8,7 +8,7 @@ import { InputDateLocales } from './demos'
 
 `InputDate` provides a text input and calendar to select a single date, which can be used as a form input or filter.
 
-## Prop: defaultValue
+## Default Value
 
 `InputDate` can be initialized with a default selected date.
 
@@ -16,7 +16,7 @@ import { InputDateLocales } from './demos'
 <InputDate defaultValue={new Date('June 3, 2019')} />
 ```
 
-## Prop: onChange
+## Change Event
 
 `InputDate` accepts a single event callback: `onDayClick`. The handler will receive a javascript `Date` object.
 
@@ -40,7 +40,7 @@ import { InputDateLocales } from './demos'
 }
 ```
 
-## Prop: locale
+## Internationalization
 
 `InputDate` comes with a range of supported language formats, which will automatically update month/day translations, as well as the appropriate first day of the week. Simply pass in the two-character locale code and everything will be formatted accordingly.
 
@@ -48,7 +48,9 @@ import { InputDateLocales } from './demos'
 
 <InputDateLocales />
 
-## Prop: validationType
+## Date Validation
+
+### validationType
 
 If you handle form validation externally (such as treating this date field as required), `InputDate` accepts the `validationType` prop to render an error state.
 
@@ -56,7 +58,7 @@ If you handle form validation externally (such as treating this date field as re
 <InputDate validationType="error" />
 ```
 
-## Prop: onValidationFail
+### onValidationFail
 
 `InputDate` has built-in validation to verify that users enter a valid date string when manually typing into the provided textarea. If you wish to build into this validation, you can pass an `onValidationFail` callback which will fire on blur if the text value does not match expected localized format.
 
@@ -91,9 +93,9 @@ If you handle form validation externally (such as treating this date field as re
 }
 ```
 
-## Recipe: Dashboard Filter UI
+## Composing InputDate in a Popover
 
-`InputDate` can be combined with [Popover](/components/overlays/popover), [Button](/components/actions/button), and [DateFormat](/components/content/date-time-format) to render this common filter UI pattern found within the Looker app.
+A common UI pattern is to combine `InputDate` with [Popover](/components/overlays/popover), [Button](/components/actions/button), and [DateFormat](/components/content/date-time-format). This enables the full calendar functionality without having to take up so much space on the page.
 
 ```jsx
 ;() => {


### PR DESCRIPTION
A few small tweaks to InputDate based on @lukelooker's feedback last week.

### :sparkles: Changes

- Add tooltip describing "view today" button when focusing on the current month label 
- Update documentation headings for clarity, and on-page linking by removing `:` characters 
- Update the "recipe" title to remove reference to filters

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues
