### PR TITLE
Fix source links in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected links to source in documentation
 - `Select` styling issues when `GlobalStyle` is not used, missing down caret icon in documentation
 - `usePopover`, when the toggle was a mousedown event, would open just before the "click outside" listener was able to close any prior popovers. If both popovers were inside a `Modal`, the closing popover would re-enable the parent scroll lock, and the one that just opened would be un-scrollable. This especially affected multiple `Select`s inside a `Modal`.
 

--- a/packages/www/src/documentation/components/actions/button-group.mdx
+++ b/packages/www/src/documentation/components/actions/button-group.mdx
@@ -1,7 +1,7 @@
 ---
 title: ButtonGroup & ButtonToggle
 figma: file/Ut0DDG4hiuRG1HiZrC5Zyf/Dashboards-Next-Components?node-id=529%3A776
-github: Button/ButtonGroup.mdx
+github: Button/ButtonGroup.tsx
 ---
 
 ## ButtonGroup

--- a/packages/www/src/documentation/components/actions/button.mdx
+++ b/packages/www/src/documentation/components/actions/button.mdx
@@ -1,7 +1,7 @@
 ---
 title: Button
 status: stable
-github: Button/Button.mdx
+github: Button/Button.tsx
 propsOf: Button
 figma: file/Dirjx0RKbOOrLacqHq61By/Button-%26-Links?node-id=914%3A981&viewport=1741%2C951%2C1
 ---

--- a/packages/www/src/documentation/components/content/inline-input-text.mdx
+++ b/packages/www/src/documentation/components/content/inline-input-text.mdx
@@ -1,6 +1,7 @@
 ---
 title: InlineInputText
 propsOf: InlineInputText
+github: InlineInputText/InlineInputText.tsx
 ---
 
 ## InlineInputText

--- a/packages/www/src/documentation/components/forms/input-date.mdx
+++ b/packages/www/src/documentation/components/forms/input-date.mdx
@@ -1,7 +1,7 @@
 ---
 title: InputDate
 propsOf: InputDate
-github: Form/Inputs/InputDate.tsx
+github: Form/Inputs/InputDate/InputDate.tsx
 ---
 
 import { InputDateLocales } from './demos'

--- a/packages/www/src/documentation/components/text/paragraph.mdx
+++ b/packages/www/src/documentation/components/text/paragraph.mdx
@@ -2,7 +2,7 @@
 title: Paragraph
 propsOf: Paragraph
 figma: file/SmIM3VUQUgo8xb4o7UUxflkT/Typography
-github: Text/Paragaph.tsx
+github: Text/Paragraph.tsx
 ---
 
 Renders a block level `<Paragraph />` element on the page.


### PR DESCRIPTION
### :sparkles: Changes

- Fixed a few docs pages that had 404 source links