### PR TITLE
Remove requestAnimationFrame dependencies

### DIFF
--- a/packages/components/src/ActionList/ActionListItem.tsx
+++ b/packages/components/src/ActionList/ActionListItem.tsx
@@ -9,6 +9,7 @@ import {
 } from '@looker/design-tokens'
 import styled from 'styled-components'
 import React, { createContext, ReactNode, RefObject } from 'react'
+import { OptionsWrapper } from './ActionListItemActions'
 
 export interface ActionListContextProps {
   actionListItemRef: RefObject<HTMLElement> | undefined
@@ -29,7 +30,7 @@ export interface ActionListItemProps
 }
 
 const ActionListItemInternal = (props: ActionListItemProps) => {
-  const { children, className, onClick, options } = props
+  const { children, className, onClick } = props
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!event.defaultPrevented) {
@@ -52,16 +53,9 @@ const ActionListItemInternal = (props: ActionListItemProps) => {
       tabIndex={0}
     >
       {children}
-      {options && <OptionsWrapper>{options}</OptionsWrapper>}
     </div>
   )
 }
-
-const OptionsWrapper = styled.div`
-  visibility: hidden;
-  display: flex;
-  align-items: center;
-`
 
 export const ActionListItem = styled(ActionListItemInternal)`
   ${border}

--- a/packages/components/src/ActionList/ActionListItem.tsx
+++ b/packages/components/src/ActionList/ActionListItem.tsx
@@ -8,7 +8,7 @@ import {
   CompatibleHTMLProps,
 } from '@looker/design-tokens'
 import styled from 'styled-components'
-import React, { createContext, ReactNode, RefObject, useRef } from 'react'
+import React, { createContext, ReactNode, RefObject } from 'react'
 
 export interface ActionListContextProps {
   actionListItemRef: RefObject<HTMLElement> | undefined
@@ -24,16 +24,12 @@ export interface ActionListItemProps
     CompatibleHTMLProps<HTMLElement>,
     SpaceProps {
   children?: ReactNode
+  options?: ReactNode
   className?: string
 }
 
 const ActionListItemInternal = (props: ActionListItemProps) => {
-  const { children, className, onClick } = props
-
-  const actionListItemRef = useRef<HTMLDivElement>(null)
-  const context = {
-    actionListItemRef,
-  }
+  const { children, className, onClick, options } = props
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!event.defaultPrevented) {
@@ -49,19 +45,23 @@ const ActionListItemInternal = (props: ActionListItemProps) => {
   }
 
   return (
-    <ActionListItemContext.Provider value={context}>
-      <div
-        className={className}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        ref={actionListItemRef}
-        tabIndex={0}
-      >
-        {children}
-      </div>
-    </ActionListItemContext.Provider>
+    <div
+      className={className}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      {children}
+      {options && <OptionsWrapper>{options}</OptionsWrapper>}
+    </div>
   )
 }
+
+const OptionsWrapper = styled.div`
+  visibility: hidden;
+  display: flex;
+  align-items: center;
+`
 
 export const ActionListItem = styled(ActionListItemInternal)`
   ${border}
@@ -71,13 +71,17 @@ export const ActionListItem = styled(ActionListItemInternal)`
   display: flex;
 
   &:focus,
-  &:hover {
+  &:hover,
+  &:focus-within {
     outline: none;
     box-shadow: ${({ theme, onClick }) => {
       if (onClick) {
         return theme.shadows[2]
       }
     }};
+    ${OptionsWrapper} {
+      visibility: visible;
+    }
   }
 `
 

--- a/packages/components/src/ActionList/ActionListItemActions.tsx
+++ b/packages/components/src/ActionList/ActionListItemActions.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components'
-import React, { ReactNode, useContext } from 'react'
+import React, { ReactNode } from 'react'
 import { IconButton } from '../Button/IconButton'
 import { Menu, MenuDisclosure, MenuList } from '../Menu'
-import { ActionListItemContext } from './ActionListItem'
 
 export interface ActionListItemActionsProps {
   children?: ReactNode
@@ -10,15 +9,13 @@ export interface ActionListItemActionsProps {
 }
 
 const ActionListItemActionsInternal = (props: ActionListItemActionsProps) => {
-  const context = useContext(ActionListItemContext)
-
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault()
   }
 
   return (
     <div onClick={handleClick}>
-      <Menu hoverDisclosureRef={context.actionListItemRef}>
+      <Menu>
         <MenuDisclosure>
           <IconButton
             className={props.className}

--- a/packages/components/src/ActionList/ActionListItemActions.tsx
+++ b/packages/components/src/ActionList/ActionListItemActions.tsx
@@ -1,14 +1,23 @@
 import styled from 'styled-components'
 import React, { ReactNode } from 'react'
 import { IconButton } from '../Button/IconButton'
-import { Menu, MenuDisclosure, MenuList } from '../Menu'
+import { Menu, MenuDisclosure, MenuList, MenuContext } from '../Menu'
 
 export interface ActionListItemActionsProps {
   children?: ReactNode
   className?: string
 }
 
-const ActionListItemActionsInternal = (props: ActionListItemActionsProps) => {
+export const OptionsWrapper = styled.div<{ menuOpen?: boolean }>`
+  visibility: ${props => (props.menuOpen ? 'visible' : 'hidden')};
+  display: flex;
+  align-items: center;
+`
+
+const ActionListItemActionsInternal = ({
+  children,
+  className,
+}: ActionListItemActionsProps) => {
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault()
   }
@@ -16,15 +25,21 @@ const ActionListItemActionsInternal = (props: ActionListItemActionsProps) => {
   return (
     <div onClick={handleClick}>
       <Menu>
-        <MenuDisclosure>
-          <IconButton
-            className={props.className}
-            icon="DotsVert"
-            label="Actions"
-            size="medium"
-          />
-        </MenuDisclosure>
-        <MenuList>{props.children}</MenuList>
+        <MenuContext.Consumer>
+          {({ isOpen }) => (
+            <OptionsWrapper menuOpen={isOpen}>
+              <MenuDisclosure>
+                <IconButton
+                  className={className}
+                  icon="DotsVert"
+                  label="Actions"
+                  size="medium"
+                />
+              </MenuDisclosure>
+              <MenuList>{children}</MenuList>
+            </OptionsWrapper>
+          )}
+        </MenuContext.Consumer>
       </Menu>
     </div>
   )

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -145,9 +145,7 @@ export function useTooltip({
       return
     }
 
-    window.requestAnimationFrame(() => {
-      handleClose()
-    })
+    handleClose()
   }
 
   const eventHandlers = {

--- a/packages/components/src/utils/useHovered.ts
+++ b/packages/components/src/utils/useHovered.ts
@@ -60,9 +60,7 @@ export function useHovered(
     setIsHovered(true)
   }
   function handleMouseLeave() {
-    window.requestAnimationFrame(() => {
-      setIsHovered(false)
-    })
+    setIsHovered(false)
   }
 
   useEffect(() => {

--- a/packages/playground/src/ActionList/ActionListDemo.tsx
+++ b/packages/playground/src/ActionList/ActionListDemo.tsx
@@ -80,40 +80,40 @@ export const ActionListDemo: FC = () => {
       </ActionListHeader>
       <ActionListItems>
         {data.map(({ id, groupName, roles, members }) => (
-          <ActionListItem
-            key={id}
-            onClick={() => alert(`Row clicked`)}
-            options={
-              <ActionListRowOptionsContainer>
-                <ActionListItemActions>
-                  <ActionListItemAction
-                    icon="Group"
-                    onClick={() => alert('Edited!')}
-                  >
-                    Edit
-                  </ActionListItemAction>
-                  <ActionListItemAction
-                    icon="Edit"
-                    onClick={() => alert('Renamed!')}
-                  >
-                    Rename
-                  </ActionListItemAction>
-                  <ActionListItemAction
-                    icon="CircleRemove"
-                    onClick={() => alert('Removed!')}
-                  >
-                    Remove
-                  </ActionListItemAction>
-                </ActionListItemActions>
-              </ActionListRowOptionsContainer>
-            }
-          >
+          <ActionListItem key={id} onClick={() => alert(`Row clicked`)}>
             <ActionListRowContainer>
               <ActionListItemColumn primaryKey>{id}</ActionListItemColumn>
-              <ActionListItemColumn>{groupName}</ActionListItemColumn>
+              <ActionListItemColumn>
+                {groupName}
+                <div>
+                  <a href="https://google.com">Google</a>
+                </div>
+              </ActionListItemColumn>
               <ActionListItemColumn>{roles}</ActionListItemColumn>
               <ActionListItemColumn>{members}</ActionListItemColumn>
             </ActionListRowContainer>
+            <ActionListRowOptionsContainer>
+              <ActionListItemActions>
+                <ActionListItemAction
+                  icon="Group"
+                  onClick={() => alert('Edited!')}
+                >
+                  Edit
+                </ActionListItemAction>
+                <ActionListItemAction
+                  icon="Edit"
+                  onClick={() => alert('Renamed!')}
+                >
+                  Rename
+                </ActionListItemAction>
+                <ActionListItemAction
+                  icon="CircleRemove"
+                  onClick={() => alert('Removed!')}
+                >
+                  Remove
+                </ActionListItemAction>
+              </ActionListItemActions>
+            </ActionListRowOptionsContainer>
           </ActionListItem>
         ))}
       </ActionListItems>

--- a/packages/playground/src/ActionList/ActionListDemo.tsx
+++ b/packages/playground/src/ActionList/ActionListDemo.tsx
@@ -80,35 +80,40 @@ export const ActionListDemo: FC = () => {
       </ActionListHeader>
       <ActionListItems>
         {data.map(({ id, groupName, roles, members }) => (
-          <ActionListItem key={id} onClick={() => alert(`Row clicked`)}>
+          <ActionListItem
+            key={id}
+            onClick={() => alert(`Row clicked`)}
+            options={
+              <ActionListRowOptionsContainer>
+                <ActionListItemActions>
+                  <ActionListItemAction
+                    icon="Group"
+                    onClick={() => alert('Edited!')}
+                  >
+                    Edit
+                  </ActionListItemAction>
+                  <ActionListItemAction
+                    icon="Edit"
+                    onClick={() => alert('Renamed!')}
+                  >
+                    Rename
+                  </ActionListItemAction>
+                  <ActionListItemAction
+                    icon="CircleRemove"
+                    onClick={() => alert('Removed!')}
+                  >
+                    Remove
+                  </ActionListItemAction>
+                </ActionListItemActions>
+              </ActionListRowOptionsContainer>
+            }
+          >
             <ActionListRowContainer>
               <ActionListItemColumn primaryKey>{id}</ActionListItemColumn>
               <ActionListItemColumn>{groupName}</ActionListItemColumn>
               <ActionListItemColumn>{roles}</ActionListItemColumn>
               <ActionListItemColumn>{members}</ActionListItemColumn>
             </ActionListRowContainer>
-            <ActionListRowOptionsContainer>
-              <ActionListItemActions>
-                <ActionListItemAction
-                  icon="Group"
-                  onClick={() => alert('Edited!')}
-                >
-                  Edit
-                </ActionListItemAction>
-                <ActionListItemAction
-                  icon="Edit"
-                  onClick={() => alert('Renamed!')}
-                >
-                  Rename
-                </ActionListItemAction>
-                <ActionListItemAction
-                  icon="CircleRemove"
-                  onClick={() => alert('Removed!')}
-                >
-                  Remove
-                </ActionListItemAction>
-              </ActionListItemActions>
-            </ActionListRowOptionsContainer>
           </ActionListItem>
         ))}
       </ActionListItems>


### PR DESCRIPTION
A super rough stab at using pure css to hide/show the action list options menu. This should hopefully simplify the lifecycle and remove the need to coordinate disparate requestAnimationFrame calls.

![tab-focus-behavior](https://user-images.githubusercontent.com/238293/75201588-b9237c00-571d-11ea-8f97-206f29ecd22c.gif)
