### PR TITLE
Fix usePopover subsequent click issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- `usePopover` issue where the next click after a popover closes is canceled
+
 ## [0.7.20] - 2020-02-25
 
 ### Fixed

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -310,6 +310,7 @@ function usePopoverToggle(
 
     function handleClickOutside(event: MouseEvent) {
       checkCloseAndStopEvent(event)
+      setMouseDownTarget(null)
     }
 
     function handleMouseUp() {


### PR DESCRIPTION
### :sparkles: Changes

- Fixed an issue where the next click after a popover closes is canceled (this should only happen while the popover is open).

### :camera: Screenshots
**Issue:**
![popovers-issue](https://user-images.githubusercontent.com/53451193/75381643-f3ac2680-588d-11ea-94cb-a1468e1ba937.gif)

**Fix:**
![popovers-fix](https://user-images.githubusercontent.com/53451193/75381654-fc046180-588d-11ea-936d-1e077681cd5f.gif)
