### PR TITLE
Fix Popover mousedown issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- `usePopover` issue where the next click after a popover closes is canceled – _actual fix_
+
 ## [0.7.21] - 2020-02-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [0.7.22] - 2020-02-27
 
 ### Fixed
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -220,6 +220,15 @@ function useOpenWithoutElement(isOpen: boolean, element: HTMLElement | null) {
   return openWithoutElem
 }
 
+function isNodeInOrAfter(nodeA: Node, nodeB: Node) {
+  const relationship = nodeA.compareDocumentPosition(nodeB)
+  return (
+    relationship === Node.DOCUMENT_POSITION_FOLLOWING ||
+    relationship ===
+      Node.DOCUMENT_POSITION_FOLLOWING + Node.DOCUMENT_POSITION_CONTAINED_BY
+  )
+}
+
 function usePopoverToggle(
   {
     isOpen: controlledIsOpen = false,
@@ -257,21 +266,16 @@ function usePopoverToggle(
       // component triggers a scroll animation resulting in an
       // unintentional drag, which closes the popover
       if (portalElement && mouseDownTarget) {
-        const relationship = portalElement.compareDocumentPosition(
-          mouseDownTarget as Node
-        )
-        if (
-          relationship === Node.DOCUMENT_POSITION_FOLLOWING ||
-          relationship ===
-            Node.DOCUMENT_POSITION_FOLLOWING +
-              Node.DOCUMENT_POSITION_CONTAINED_BY
-        ) {
+        if (isNodeInOrAfter(portalElement, mouseDownTarget as Node)) {
           return
         }
       }
 
       // User clicked inside the Popover surface/portal
-      if (portalElement && portalElement.contains(event.target as Node)) {
+      if (
+        portalElement &&
+        isNodeInOrAfter(portalElement, event.target as Node)
+      ) {
         return
       }
 
@@ -301,6 +305,7 @@ function usePopoverToggle(
       }
 
       event.stopPropagation()
+      event.preventDefault()
     }
 
     function handleMouseDown(event: MouseEvent) {

--- a/packages/playground/src/Popovers/Testing.tsx
+++ b/packages/playground/src/Popovers/Testing.tsx
@@ -1,14 +1,19 @@
 /*
+
  MIT License
+
  Copyright (c) 2019 Looker Data Sciences, Inc.
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -16,29 +21,45 @@
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
+
  */
 
 import React from 'react'
-import ReactDOM from 'react-dom'
-import { GlobalStyle } from '@looker/components'
-import { theme } from '@looker/design-tokens'
-import { ThemeProvider } from 'styled-components'
+import {
+  Box,
+  Button,
+  DialogManager,
+  Menu,
+  MenuDisclosure,
+  MenuList,
+  MenuItem,
+  ModalContent,
+  Paragraph,
+} from '@looker/components'
 
-import { TestPopovers } from './Popovers/Testing'
-
-const App: React.FC = () => {
+export function TestPopovers() {
+  function openAlert() {
+    alert(`It's working!`)
+  }
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <TestPopovers />
-    </ThemeProvider>
+    <Box m="large">
+      <Menu>
+        <MenuDisclosure tooltip="Select your favorite kind">
+          <Button mb="large">Open Menu</Button>
+        </MenuDisclosure>
+        <MenuList>
+          <DialogManager
+            content={
+              <ModalContent>
+                <Paragraph>Some content inside the Dialog</Paragraph>
+                <Button onClick={openAlert}>Open Alert</Button>
+              </ModalContent>
+            }
+          >
+            {onClick => <MenuItem onClick={onClick}>Open Modal</MenuItem>}
+          </DialogManager>
+        </MenuList>
+      </Menu>
+    </Box>
   )
 }
-
-/**
- * This is the binding site for the playground. If you want to edit the
- * primary application, do your work in App.tsx instead.
- */
-document.addEventListener('DOMContentLoaded', () => {
-  ReactDOM.render(<App />, document.getElementById('container'))
-})


### PR DESCRIPTION
### :sparkles: Changes

Background info:
1. `Select` opens (via `usePopopver`) on mousedown
2. This revealed a scroll-lock bug fixed in https://github.com/looker-open-source/components/pull/562
3. The change above caused the following issue, fixed in the current PR:
  When an element (modal, another popover, etc) is stacking on top of a popover, a mousedown on this element closes the popover (usually thereby removing the other element as well)
