### PR TITLE
Checkbox: Support for "defaultChecked"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+## Fixed
+
+- `Checkbox` supports `defaultChecked` property. Using `defaultChecked` serves as a workaround to a bug where using the `checked` property without an `onChange` produces a React error.
+
 ## [0.7.23] - 2020-03-09
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
-## Fixed
+## Changed
 
-- `Checkbox` supports `defaultChecked` property. Using `defaultChecked` serves as a workaround to a bug where using the `checked` property without an `onChange` produces a React error.
+- `Checkbox` supports `defaultChecked` property.
 
 ## [0.7.23] - 2020-03-09
 

--- a/packages/components/src/Form/Fields/FieldCheckbox/FieldCheckbox.test.tsx
+++ b/packages/components/src/Form/Fields/FieldCheckbox/FieldCheckbox.test.tsx
@@ -40,7 +40,7 @@ test('A FieldCheckbox', () => {
 
 test('A FieldCheckbox with checked value', () => {
   const component = createWithTheme(
-    <FieldCheckbox label="👍" name="thumbsUp" id="thumbs-up" checked />
+    <FieldCheckbox label="👍" name="thumbsUp" id="thumbs-up" defaultChecked />
   )
   const tree = component.toJSON()
   expect(tree).toMatchSnapshot()

--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -129,7 +129,6 @@ exports[`A FieldCheckbox 1`] = `
         className="c5 "
       >
         <input
-          checked={false}
           className=""
           id="thumbs-up"
           name="thumbsUp"
@@ -305,9 +304,8 @@ exports[`A FieldCheckbox with checked value 1`] = `
         className="c5 "
       >
         <input
-          aria-checked={true}
-          checked={true}
           className=""
+          defaultChecked={true}
           id="thumbs-up"
           name="thumbsUp"
           role="checkbox"
@@ -492,7 +490,6 @@ exports[`A required FieldCheckbox 1`] = `
         className="c6 "
       >
         <input
-          checked={false}
           className=""
           id="thumbs-up"
           name="thumbsUp"

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -151,11 +151,14 @@ const CheckboxComponent = forwardRef(
   (props: CheckboxProps, ref: Ref<HTMLInputElement>) => {
     const { checked, ...restProps } = props
     return (
-      <CheckboxContainer {...omit(props, inputPropKeys)} checked={checked}>
+      <CheckboxContainer
+        {...omit(props, inputPropKeys)}
+        checked={checked || restProps.defaultChecked}
+      >
         <CheckboxInput
           {...pick(restProps, inputPropKeys)}
           ref={ref}
-          checked={checked === true}
+          checked={checked === undefined ? undefined : checked === true}
           role="checkbox"
           aria-checked={checked}
         />

--- a/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -68,7 +68,6 @@ exports[`Checkbox checked set to false 1`] = `
 }
 
 <div
-  checked={false}
   className="c0 "
 >
   <input
@@ -363,7 +362,6 @@ exports[`Checkbox default 1`] = `
   className="c0 "
 >
   <input
-    checked={false}
     className=""
     role="checkbox"
     type="checkbox"
@@ -461,7 +459,6 @@ exports[`Checkbox should accept disabled 1`] = `
   className="c0 "
 >
   <input
-    checked={false}
     className=""
     disabled={true}
     role="checkbox"
@@ -561,7 +558,6 @@ exports[`Checkbox with aria-describedby 1`] = `
 >
   <input
     aria-describedby="some-id"
-    checked={false}
     className=""
     role="checkbox"
     type="checkbox"
@@ -659,7 +655,6 @@ exports[`Checkbox with name and id 1`] = `
   className="c0 "
 >
   <input
-    checked={false}
     className=""
     id="Chucky"
     name="Chuck"

--- a/packages/www/src/documentation/components/forms/checkbox.mdx
+++ b/packages/www/src/documentation/components/forms/checkbox.mdx
@@ -11,10 +11,12 @@ The `<Checkbox />` component renders a single checkbox element on the page, with
 
 The `<Checkbox />` component can be rendered in three different states: checked, unchecked, and "mixed". In addition to the standard boolean, rendering a "mixed" value can be used to indicate that only a fraction of related sub-options have been selected.
 
+**Note:** The "mixed" value is only available to the `checked` property and not available to `defaultChecked` property.
+
 ```jsx
-<Checkbox checked={true} />
-<Checkbox checked='mixed' />
-<Checkbox checked={false} />
+<Checkbox defaultChecked />
+<Checkbox defaultChecked={false} />
+<Checkbox checked='mixed' onChange={() => {}} />
 ```
 
 ## onChange Property
@@ -38,8 +40,8 @@ The `<Checkbox />` component can be rendered in three different states: checked,
 The `branded` property turns the background to the theme's primary color when checked.
 
 ```jsx
-<Checkbox branded checked />
-<Checkbox branded checked="mixed" />
+<Checkbox branded defaultChecked />
+<Checkbox branded checked="mixed" onChange={() => {}} />
 ```
 
 ## Advanced Use: Controlling parent/child mixed states


### PR DESCRIPTION
### :sparkles: Changes

- The `defaultChecked` property serves as a workaround to a bug with using the "checked" prop without an "onChange" prop. Resolves [this JIRA issue](https://looker.atlassian.net/browse/LENS-614).

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC