### PR TITLE
Remove Slider's branded option

### DIFF
--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -40,7 +40,6 @@ export interface SliderProps
     Omit<InputProps, 'type'>,
     SliderSizeProps {
   'aria-labelledby'?: string
-  branded?: boolean
   max?: number
   min?: number
   step?: number
@@ -50,7 +49,6 @@ export interface SliderProps
 const SliderInternal = forwardRef(
   (
     {
-      branded,
       min = 0,
       max = 10,
       value = 0,
@@ -120,21 +118,15 @@ const SliderInternal = forwardRef(
           <SliderValue
             fontSize={fontSize}
             knobSize={knobSize}
-            branded={branded}
             disabled={disabled}
           >
             {displayValue}
           </SliderValue>
         </SliderValueWrapper>
         <SliderTrack knobSize={knobSize} trackHeight={trackHeight}>
-          <SliderFill
-            offsetPercent={fillPercent}
-            branded={branded}
-            disabled={disabled}
-          />
+          <SliderFill offsetPercent={fillPercent} disabled={disabled} />
         </SliderTrack>
         <SliderInput
-          branded={branded}
           disabled={disabled}
           id={id}
           isFocused={isFocused}
@@ -158,18 +150,13 @@ const SliderInternal = forwardRef(
 interface SliderInputProps {
   knobSize: number
   isFocused?: boolean
-  branded?: boolean
 }
 
 const sliderThumbFocusCss = css<SliderInputProps>`
-  ${({ theme: { colors }, branded }) => {
-    const brandedFocusRing = rgba(colors.semanticColors.primary.main, 0.2)
-    const unbrandedFocusRing = rgba(
-      colors.semanticColors.primary.linkColor,
-      0.2
-    )
+  ${({ theme: { colors } }) => {
+    const focusRing = rgba(colors.semanticColors.primary.main, 0.2)
     return css`
-      box-shadow: 0 0 0 3px ${branded ? brandedFocusRing : unbrandedFocusRing};
+      box-shadow: 0 0 0 3px ${focusRing};
       transform: scale3d(1.15, 1.15, 1);
       border-width: 4px;
     `
@@ -180,11 +167,8 @@ const sliderThumbCss = css<SliderInputProps>`
   border-radius: 100%;
   cursor: pointer;
   transition: transform 0.25s, box-shadow 0.25s;
-  ${({ theme: { colors }, branded, knobSize, isFocused }) => css`
-    border: 3px solid
-      ${branded
-        ? colors.semanticColors.primary.main
-        : colors.semanticColors.primary.linkColor};
+  ${({ theme: { colors }, knobSize, isFocused }) => css`
+    border: 3px solid ${colors.semanticColors.primary.main};
     height: ${knobSize}px;
     width: ${knobSize}px;
     background: ${colors.palette.white};
@@ -288,17 +272,12 @@ const SliderTrack = styled.div<SliderTrackProps>`
 interface ControlProps {
   offsetPercent: number
   disabled?: boolean
-  branded?: boolean
 }
 
 const SliderFill = styled.div<ControlProps>`
   height: 100%;
-  background: ${({ theme: { colors }, branded, disabled }) =>
-    disabled
-      ? colors.palette.charcoal400
-      : branded
-      ? colors.semanticColors.primary.main
-      : colors.semanticColors.primary.linkColor};
+  background: ${({ theme: { colors }, disabled }) =>
+    disabled ? colors.palette.charcoal400 : colors.semanticColors.primary.main};
   width: ${({ offsetPercent }) => offsetPercent * 100}%;
   border-radius: ${({ theme }) => theme.radii.small};
 `
@@ -309,12 +288,8 @@ interface SliderValueProps extends SliderInputProps, FontSizeProps {
 
 const SliderValue = styled.div<SliderValueProps>`
   ${fontSize}
-  color: ${({ theme: { colors }, branded, disabled }) =>
-    disabled
-      ? colors.palette.charcoal700
-      : branded
-      ? colors.semanticColors.primary.main
-      : colors.semanticColors.primary.linkColor};
+  color: ${({ theme: { colors }, disabled }) =>
+    disabled ? colors.palette.charcoal700 : colors.semanticColors.primary.main};
   line-height: 1;
   user-select: none;
   transform: translate(-35%);

--- a/packages/components/src/Form/Inputs/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Slider/__snapshots__/Slider.test.tsx.snap
@@ -17,11 +17,11 @@ exports[`renders focus styles on keypress 1`] = `
   -webkit-transition: -webkit-transform 0.25s,box-shadow 0.25s;
   -webkit-transition: transform 0.25s,box-shadow 0.25s;
   transition: transform 0.25s,box-shadow 0.25s;
-  border: 3px solid #0087e1;
+  border: 3px solid #6C43E0;
   height: 16px;
   width: 16px;
   background: #FFFFFF;
-  box-shadow: 0 0 0 3px rgba(0,135,225,0.2);
+  box-shadow: 0 0 0 3px rgba(108,67,224,0.2);
   -webkit-transform: scale3d(1.15,1.15,1);
   -ms-transform: scale3d(1.15,1.15,1);
   transform: scale3d(1.15,1.15,1);
@@ -34,11 +34,11 @@ exports[`renders focus styles on keypress 1`] = `
   -webkit-transition: -webkit-transform 0.25s,box-shadow 0.25s;
   -webkit-transition: transform 0.25s,box-shadow 0.25s;
   transition: transform 0.25s,box-shadow 0.25s;
-  border: 3px solid #0087e1;
+  border: 3px solid #6C43E0;
   height: 16px;
   width: 16px;
   background: #FFFFFF;
-  box-shadow: 0 0 0 3px rgba(0,135,225,0.2);
+  box-shadow: 0 0 0 3px rgba(108,67,224,0.2);
   -webkit-transform: scale3d(1.15,1.15,1);
   -ms-transform: scale3d(1.15,1.15,1);
   transform: scale3d(1.15,1.15,1);
@@ -51,11 +51,11 @@ exports[`renders focus styles on keypress 1`] = `
   -webkit-transition: -webkit-transform 0.25s,box-shadow 0.25s;
   -webkit-transition: transform 0.25s,box-shadow 0.25s;
   transition: transform 0.25s,box-shadow 0.25s;
-  border: 3px solid #0087e1;
+  border: 3px solid #6C43E0;
   height: 16px;
   width: 16px;
   background: #FFFFFF;
-  box-shadow: 0 0 0 3px rgba(0,135,225,0.2);
+  box-shadow: 0 0 0 3px rgba(108,67,224,0.2);
   -webkit-transform: scale3d(1.15,1.15,1);
   -ms-transform: scale3d(1.15,1.15,1);
   transform: scale3d(1.15,1.15,1);
@@ -79,7 +79,7 @@ exports[`renders focus styles on keypress 1`] = `
 }
 
 .c0:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 3px rgba(0,135,225,0.2);
+  box-shadow: 0 0 0 3px rgba(108,67,224,0.2);
   -webkit-transform: scale3d(1.15,1.15,1);
   -ms-transform: scale3d(1.15,1.15,1);
   transform: scale3d(1.15,1.15,1);
@@ -87,7 +87,7 @@ exports[`renders focus styles on keypress 1`] = `
 }
 
 .c0:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 3px rgba(0,135,225,0.2);
+  box-shadow: 0 0 0 3px rgba(108,67,224,0.2);
   -webkit-transform: scale3d(1.15,1.15,1);
   -ms-transform: scale3d(1.15,1.15,1);
   transform: scale3d(1.15,1.15,1);
@@ -95,7 +95,7 @@ exports[`renders focus styles on keypress 1`] = `
 }
 
 .c0:focus::-ms-thumb {
-  box-shadow: 0 0 0 3px rgba(0,135,225,0.2);
+  box-shadow: 0 0 0 3px rgba(108,67,224,0.2);
   -webkit-transform: scale3d(1.15,1.15,1);
   -ms-transform: scale3d(1.15,1.15,1);
   transform: scale3d(1.15,1.15,1);

--- a/packages/playground/src/Slider/SliderDemo.tsx
+++ b/packages/playground/src/Slider/SliderDemo.tsx
@@ -40,9 +40,6 @@ export const SliderDemo = () => {
   const [value4, setValue4] = useState(2)
   const [value5, setValue5] = useState(3)
   const [value6, setValue6] = useState(1)
-  const [value8, setValue8] = useState(3)
-  const [value9, setValue9] = useState(1)
-  const [value10, setValue10] = useState(2)
   const [value11, setValue11] = useState(3)
 
   const sliderRef = useRef<HTMLInputElement>(null)
@@ -58,9 +55,6 @@ export const SliderDemo = () => {
   const onChange4 = handleEvent(setValue4)
   const onChange5 = handleEvent(setValue5)
   const onChange6 = handleEvent(setValue6)
-  const onChange8 = handleEvent(setValue8)
-  const onChange9 = handleEvent(setValue9)
-  const onChange10 = handleEvent(setValue10)
   const onChange11 = handleEvent(setValue11)
 
   return (
@@ -112,35 +106,6 @@ export const SliderDemo = () => {
               value={value6}
               size="large"
               onChange={onChange6}
-            />
-          </CardContent>
-        </Card>
-        <Card height="auto">
-          <CardContent p="xxlarge">
-            <Heading pt="large">Branded Sizes:</Heading>
-            <Slider
-              min={0}
-              max={5}
-              value={value8}
-              size="small"
-              onChange={onChange8}
-              branded
-            />
-            <Slider
-              min={0}
-              max={5}
-              value={value9}
-              size="medium"
-              onChange={onChange9}
-              branded
-            />
-            <Slider
-              min={0}
-              max={5}
-              value={value10}
-              size="large"
-              onChange={onChange10}
-              branded
             />
           </CardContent>
         </Card>

--- a/packages/www/src/documentation/components/forms/slider.mdx
+++ b/packages/www/src/documentation/components/forms/slider.mdx
@@ -63,46 +63,6 @@ If you'd like to read and control the input value externally, `Slider` accepts a
 <Slider size="large" value={8} />
 ```
 
-# Colors
-
-In addition to the standard blue default color scheme, `Slider` provides an alternate `branded` color which uses brand colors specified <a href="http://localhost:8000/getting-started/theme">our standard Theme object.</a>
-
-```jsx
-<Slider size="small" value={4} branded />
-<Slider size="medium" value={6} branded />
-<Slider size="large" value={8} branded />
-```
-
-You can customize the appearance by modifying the `theme.colors.semanticColors.primary.main` value:
-
-```jsx
-;() => {
-  /**
-   *  import { theme } from '@looker/components'
-   *  import { ThemeProvider } from 'styled-components'
-   **/
-
-  const myTheme = {
-    ...theme,
-    colors: {
-      ...theme.colors,
-      semanticColors: {
-        ...theme.colors.semanticColors,
-        primary: { ...theme.colors.semanticColors.primary, main: '#008930' },
-      },
-    },
-  }
-
-  return (
-    <ThemeProvider theme={myTheme}>
-      <Slider size="small" value={4} branded />
-      <Slider size="medium" value={6} branded />
-      <Slider size="large" value={8} branded />
-    </ThemeProvider>
-  )
-}
-```
-
 # Step
 
 Just like the standard HTML range input, you change the granularity of slider options by using the `step` prop.


### PR DESCRIPTION
### :sparkles: Changes

- Remove Slider's `branded` option
- Small snapshot updates to match

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots
