### PR TITLE
TabPanels: Added FlexboxProps and LayoutProps

### DIFF
--- a/packages/components/src/Tabs/TabPanels.tsx
+++ b/packages/components/src/Tabs/TabPanels.tsx
@@ -50,7 +50,7 @@ export const TabPanels: FC<TabPanelsProps> = ({
   selectedIndex,
   ...props
 }) => {
-  const styleProps = omit(props, 'onSelectTab')
+  const tabPanelLayoutProps = omit(props, 'onSelectTab')
 
   const clonedChildren = Children.map(
     children,
@@ -61,7 +61,7 @@ export const TabPanels: FC<TabPanelsProps> = ({
     }
   )
 
-  return <Layout {...styleProps}>{clonedChildren}</Layout>
+  return <Layout {...tabPanelLayoutProps}>{clonedChildren}</Layout>
 }
 
 const Layout = styled.div<TabPanelLayoutProps>`

--- a/packages/components/src/Tabs/TabPanels.tsx
+++ b/packages/components/src/Tabs/TabPanels.tsx
@@ -26,21 +26,31 @@
 
 import React, { Children, cloneElement, FC } from 'react'
 import styled from 'styled-components'
-import { SpaceProps, space, reset } from '@looker/design-tokens'
+import {
+  FlexboxProps,
+  LayoutProps,
+  SpaceProps,
+  flexbox,
+  layout,
+  space,
+  reset,
+} from '@looker/design-tokens'
 import omit from 'lodash/omit'
 
-export interface TabPanelsProps extends SpaceProps {
+export interface TabPanelsProps extends FlexboxProps, LayoutProps, SpaceProps {
   children: JSX.Element[]
   selectedIndex?: number
   onSelectTab?: (index: number) => void
 }
+
+interface TabPanelLayoutProps extends FlexboxProps, LayoutProps, SpaceProps {}
 
 export const TabPanels: FC<TabPanelsProps> = ({
   children,
   selectedIndex,
   ...props
 }) => {
-  const spaceProps = omit(props, 'onSelectTab')
+  const styleProps = omit(props, 'onSelectTab')
 
   const clonedChildren = Children.map(
     children,
@@ -51,11 +61,13 @@ export const TabPanels: FC<TabPanelsProps> = ({
     }
   )
 
-  return <Layout {...spaceProps}>{clonedChildren}</Layout>
+  return <Layout {...styleProps}>{clonedChildren}</Layout>
 }
 
-const Layout = styled.div<SpaceProps>`
+const Layout = styled.div<TabPanelLayoutProps>`
   ${reset}
+  ${flexbox}
+  ${layout}
   ${space}
 `
 

--- a/packages/components/src/Tabs/TabPanels.tsx
+++ b/packages/components/src/Tabs/TabPanels.tsx
@@ -43,14 +43,14 @@ export interface TabPanelsProps extends FlexboxProps, LayoutProps, SpaceProps {
   onSelectTab?: (index: number) => void
 }
 
-interface TabPanelLayoutProps extends FlexboxProps, LayoutProps, SpaceProps {}
+interface TabPanelsLayoutProps extends FlexboxProps, LayoutProps, SpaceProps {}
 
 export const TabPanels: FC<TabPanelsProps> = ({
   children,
   selectedIndex,
   ...props
 }) => {
-  const tabPanelLayoutProps = omit(props, 'onSelectTab')
+  const tabPanelsLayoutProps = omit(props, 'onSelectTab')
 
   const clonedChildren = Children.map(
     children,
@@ -61,10 +61,10 @@ export const TabPanels: FC<TabPanelsProps> = ({
     }
   )
 
-  return <Layout {...tabPanelLayoutProps}>{clonedChildren}</Layout>
+  return <Layout {...tabPanelsLayoutProps}>{clonedChildren}</Layout>
 }
 
-const Layout = styled.div<TabPanelLayoutProps>`
+const Layout = styled.div<TabPanelsLayoutProps>`
   ${reset}
   ${flexbox}
   ${layout}

--- a/packages/components/src/Tabs/TabPanels.tsx
+++ b/packages/components/src/Tabs/TabPanels.tsx
@@ -39,14 +39,14 @@ import omit from 'lodash/omit'
 
 export interface TabPanelsProps extends FlexboxProps, LayoutProps, SpaceProps {
   children: JSX.Element[]
+  className?: string
   selectedIndex?: number
   onSelectTab?: (index: number) => void
 }
 
-interface TabPanelsLayoutProps extends FlexboxProps, LayoutProps, SpaceProps {}
-
-export const TabPanels: FC<TabPanelsProps> = ({
+const Layout: FC<TabPanelsProps> = ({
   children,
+  className,
   selectedIndex,
   ...props
 }) => {
@@ -61,14 +61,18 @@ export const TabPanels: FC<TabPanelsProps> = ({
     }
   )
 
-  return <Layout {...tabPanelsLayoutProps}>{clonedChildren}</Layout>
+  return (
+    <div className={className} {...tabPanelsLayoutProps}>
+      {clonedChildren}
+    </div>
+  )
 }
 
-const Layout = styled.div<TabPanelsLayoutProps>`
+export const TabPanels = styled(Layout)`
   ${reset}
   ${flexbox}
   ${layout}
   ${space}
 `
 
-Layout.defaultProps = { pt: 'large' }
+TabPanels.defaultProps = { pt: 'large' }

--- a/packages/playground/src/Tabs/TabsDemo.tsx
+++ b/packages/playground/src/Tabs/TabsDemo.tsx
@@ -19,7 +19,7 @@ export const TabsDemo: FC = () => (
         <TabPanel>
           <div
             style={{
-              backgroundColor: 'coral',
+              backgroundColor: 'lightblue',
               height: '100%',
             }}
           ></div>
@@ -28,7 +28,7 @@ export const TabsDemo: FC = () => (
           <div
             style={{
               backgroundColor: 'coral',
-              height: '300px',
+              height: '200px',
               width: '100%',
             }}
           ></div>

--- a/packages/playground/src/Tabs/TabsDemo.tsx
+++ b/packages/playground/src/Tabs/TabsDemo.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react'
+import {
+  Tab,
+  Tabs,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Box,
+} from '@looker/components'
+
+export const TabsDemo: FC = () => (
+  <Box height={400} display="flex" flexDirection="column">
+    <Tabs>
+      <TabList>
+        <Tab>height: 100%</Tab>
+        <Tab>height: 200px</Tab>
+      </TabList>
+      <TabPanels flex={1}>
+        <TabPanel>
+          <div
+            style={{
+              backgroundColor: 'coral',
+              height: '100%',
+            }}
+          ></div>
+        </TabPanel>
+        <TabPanel>
+          <div
+            style={{
+              backgroundColor: 'coral',
+              height: '300px',
+              width: '100%',
+            }}
+          ></div>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  </Box>
+)

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { ComboboxDemo } from './Select/ComboboxDemo'
+import { TabsDemo } from './Tabs/TabsDemo'
 
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <ComboboxDemo />
+      <TabsDemo />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes
- Added FlexboxProps and Layout Props to `TabPanels` component
  - **Use case:** There are times where you want the contents of TabPanel to take up whatever space is left in a surrounding flex container. Adding these props means that `TabPanels` will take up all remaining space in a flex container using "height: 100%" or "flex: 1".
- **Note:** Also added TabsDemo to demonstrate a "flex container surrounding a Tabs element scenario".

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] PR is ideally < 400LOC