### PR TITLE
Fix focus trap for modal's with no tabbable element

### DIFF
--- a/packages/components/src/Modal/ModalPortal.tsx
+++ b/packages/components/src/Modal/ModalPortal.tsx
@@ -55,7 +55,11 @@ export const ModalPortal = forwardRef(
     }, [el])
 
     const content = (
-      <InvisiBox ref={ref} zIndex={CustomizableModalAttributes.zIndex}>
+      <InvisiBox
+        ref={ref}
+        tabIndex={-1}
+        zIndex={CustomizableModalAttributes.zIndex}
+      >
         {children}
       </InvisiBox>
     )

--- a/packages/components/src/Modal/ModalSurface.tsx
+++ b/packages/components/src/Modal/ModalSurface.tsx
@@ -100,7 +100,6 @@ export const ModalSurface: FC<ModalSurfaceProps> = ({
     >
       <Style
         className={`surface-overflow ${className}`}
-        tabIndex={-1}
         surfaceStyles={style as CSSObject}
         {...props}
       />

--- a/packages/playground/src/Menu/MenuDemo.tsx
+++ b/packages/playground/src/Menu/MenuDemo.tsx
@@ -32,13 +32,15 @@ import {
   MenuDisclosure,
   MenuList,
   MenuItem,
-  ModalContext,
+  Dialog,
   MenuGroup,
   Paragraph,
   Card,
   Flex,
   IconButton,
+  MenuContext,
 } from '@looker/components'
+import { FlexItem } from '@looker/components/src'
 const FancyMenuItem = ({
   text,
   current,
@@ -46,10 +48,10 @@ const FancyMenuItem = ({
   text: string
   current?: boolean
 }) => {
-  const { closeModal } = useContext(ModalContext)
+  const { setOpen } = useContext(MenuContext)
   const handleClick = () => {
     alert(`You picked ${text}`)
-    closeModal && closeModal()
+    setOpen && setOpen(false)
   }
   return (
     <MenuItem icon="FavoriteOutline" onClick={handleClick} current={current}>
@@ -60,30 +62,54 @@ const FancyMenuItem = ({
 
 const HoverMenu = () => {
   const hoverRef = React.useRef<HTMLDivElement>(null)
+  const [modalIsOpen, setOpen] = React.useState(false)
+  function openModal() {
+    setOpen(true)
+  }
+  function closeModal() {
+    setOpen(false)
+  }
   return (
     <Card ref={hoverRef} p="large" raised height="auto">
       <Flex justifyContent="space-between">
-        <Paragraph>
+        <FlexItem flex={1}>
           Hovering in this card will show the button that triggers the menu.
-        </Paragraph>
-        <Menu hoverDisclosureRef={hoverRef}>
-          <MenuDisclosure>
-            <IconButton
-              icon="DotsVert"
-              label="More Options"
-              aria-haspopup="true"
-            />
-          </MenuDisclosure>
-          <MenuList compact>
-            <FancyMenuItem text="Gouda" />
-            <FancyMenuItem text="Swiss" current />
-            <MenuGroup compact={false}>
-              <FancyMenuItem text="Gouda w/ Space" />
-              <FancyMenuItem text="Swiss w/ Space" />
-            </MenuGroup>
-          </MenuList>
-        </Menu>
+        </FlexItem>
+        <FlexItem>
+          <Menu hoverDisclosureRef={hoverRef}>
+            <MenuContext.Consumer>
+              {({ showDisclosure, isOpen }) =>
+                (showDisclosure || isOpen) && (
+                  <IconButton
+                    icon="AddAlerts"
+                    label="Add Alert"
+                    mr="small"
+                    onClick={openModal}
+                  />
+                )
+              }
+            </MenuContext.Consumer>
+            <MenuDisclosure>
+              <IconButton
+                icon="DotsVert"
+                label="More Options"
+                aria-haspopup="true"
+              />
+            </MenuDisclosure>
+            <MenuList compact>
+              <FancyMenuItem text="Gouda" />
+              <FancyMenuItem text="Swiss" current />
+              <MenuGroup compact={false}>
+                <FancyMenuItem text="Gouda w/ Space" />
+                <FancyMenuItem text="Swiss w/ Space" />
+              </MenuGroup>
+            </MenuList>
+          </Menu>
+        </FlexItem>
       </Flex>
+      <Dialog isOpen={modalIsOpen} onClose={closeModal}>
+        <Box p="large">Alert icon should be hidden now.</Box>
+      </Dialog>
     </Card>
   )
 }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { TooltipDemo } from './Tooltip/TooltipDemo'
+import { MenuDemo } from './Menu/MenuDemo'
 
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <TooltipDemo />
+      <MenuDemo />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- If a `Modal` opens without any tabbable elements, the containing div itself should receive focus as a fallback (often this occurs as when the UI loads data from an API)
- This functionality was lost when I moved the focus trap target to during an overhaul of focus trap & scroll lock
- The issue is evident in the core product where an icon shown only on hover & focus opens a modal that initially has no buttons (while data loads). Focus remains on the icon when it should move to the modal container.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots
**Issue:**
![issue](https://user-images.githubusercontent.com/53451193/76380538-4a931080-6310-11ea-8118-bfd6bfb40c30.gif)

**Fix:**
![fix](https://user-images.githubusercontent.com/53451193/76380554-52eb4b80-6310-11ea-804b-eee1053fea4b.gif)
