### PR TITLE
Fix duplicate tooltips on IconButton

### DIFF
--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -29,6 +29,7 @@ import React from 'react'
 import noop from 'lodash/noop'
 import { assertSnapshot, renderWithTheme } from '@looker/components-test-utils'
 import { fireEvent } from '@testing-library/react'
+import { Tooltip } from '../Tooltip'
 import { IconButton } from './IconButton'
 
 test('IconButton default', () => {
@@ -112,4 +113,26 @@ test('IconButton tooltipDisabled actually disables tooltip', () => {
   fireEvent.mouseOver(getByTitle('Favorite'))
   const notTooltip = container.querySelector('p') // Get Tooltip content
   expect(notTooltip).toBeNull()
+})
+
+test('IconButton built-in tooltip defers to outer tooltip', () => {
+  const tooltip = 'Add to favorites'
+  const label = 'Mark as my Favorite'
+  const { getByText, getByTitle } = renderWithTheme(
+    <Tooltip content={tooltip}>
+      {(eventHandlers, ref) => (
+        <IconButton
+          tooltipDisabled
+          label={label}
+          icon="Favorite"
+          {...eventHandlers}
+          ref={ref}
+        />
+      )}
+    </Tooltip>
+  )
+
+  fireEvent.mouseOver(getByTitle('Favorite'))
+  expect(getByText(tooltip)).toBeInTheDocument()
+  expect(getByText(label)).toHaveStyle('height: 1px')
 })

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -136,12 +136,27 @@ const IconButtonComponent = forwardRef(
       placement: tooltipPlacement,
     })
 
-    const eventHandlers = {
-      onBlur: useWrapEvent(onBlur, propsOnBlur),
-      onFocus: useWrapEvent(onFocus, propsOnFocus),
-      onMouseOut: useWrapEvent(onMouseOut, propsOnMouseOut),
-      onMouseOver: useWrapEvent(onMouseOver, propsOnMouseOver),
-    }
+    const hasOuterTooltip =
+      (propsOnFocus && onFocus.toString() === propsOnFocus.toString()) ||
+      (propsOnBlur && onBlur.toString() === propsOnBlur.toString()) ||
+      (propsOnMouseOut &&
+        onMouseOut.toString() === propsOnMouseOut.toString()) ||
+      (propsOnMouseOver &&
+        onMouseOver.toString() === propsOnMouseOver.toString())
+
+    const eventHandlers = hasOuterTooltip
+      ? {
+          onBlur: propsOnBlur,
+          onFocus: propsOnFocus,
+          onMouseOut: propsOnMouseOut,
+          onMouseOver: propsOnMouseOver,
+        }
+      : {
+          onBlur: useWrapEvent(onBlur, propsOnBlur),
+          onFocus: useWrapEvent(onFocus, propsOnFocus),
+          onMouseOut: useWrapEvent(onMouseOut, propsOnMouseOut),
+          onMouseOver: useWrapEvent(onMouseOver, propsOnMouseOver),
+        }
 
     const actualRef = useForkedRef<HTMLButtonElement>(forwardRef, ref)
 

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -24,6 +24,8 @@
 
  */
 
+import some from 'lodash/some'
+import isFunction from 'lodash/isFunction'
 import styled, { css } from 'styled-components'
 import {
   CompatibleHTMLProps,
@@ -126,37 +128,28 @@ const IconButtonComponent = forwardRef(
       ...rest
     } = props
 
+    // any of the hover/focus handlers being present disables built-in tooltip
+    const hasOuterTooltip = some(
+      [propsOnFocus, propsOnBlur, propsOnMouseOver, propsOnMouseOut],
+      isFunction
+    )
+
     const {
       ref,
       tooltip,
       eventHandlers: { onFocus, onBlur, onMouseOver, onMouseOut },
     } = useTooltip({
       content: label,
-      disabled: tooltipDisabled,
+      disabled: tooltipDisabled || hasOuterTooltip,
       placement: tooltipPlacement,
     })
 
-    const hasOuterTooltip =
-      (propsOnFocus && onFocus.toString() === propsOnFocus.toString()) ||
-      (propsOnBlur && onBlur.toString() === propsOnBlur.toString()) ||
-      (propsOnMouseOut &&
-        onMouseOut.toString() === propsOnMouseOut.toString()) ||
-      (propsOnMouseOver &&
-        onMouseOver.toString() === propsOnMouseOver.toString())
-
-    const eventHandlers = hasOuterTooltip
-      ? {
-          onBlur: propsOnBlur,
-          onFocus: propsOnFocus,
-          onMouseOut: propsOnMouseOut,
-          onMouseOver: propsOnMouseOver,
-        }
-      : {
-          onBlur: useWrapEvent(onBlur, propsOnBlur),
-          onFocus: useWrapEvent(onFocus, propsOnFocus),
-          onMouseOut: useWrapEvent(onMouseOut, propsOnMouseOut),
-          onMouseOver: useWrapEvent(onMouseOver, propsOnMouseOver),
-        }
+    const eventHandlers = {
+      onBlur: useWrapEvent(onBlur, propsOnBlur),
+      onFocus: useWrapEvent(onFocus, propsOnFocus),
+      onMouseOut: useWrapEvent(onMouseOut, propsOnMouseOut),
+      onMouseOver: useWrapEvent(onMouseOver, propsOnMouseOver),
+    }
 
     const actualRef = useForkedRef<HTMLButtonElement>(forwardRef, ref)
 

--- a/packages/playground/src/Tooltip/TooltipDemo.tsx
+++ b/packages/playground/src/Tooltip/TooltipDemo.tsx
@@ -19,26 +19,21 @@
  */
 
 import React from 'react'
-import ReactDOM from 'react-dom'
-import { GlobalStyle } from '@looker/components'
-import { theme } from '@looker/design-tokens'
-import { ThemeProvider } from 'styled-components'
+import { Box, IconButton, Tooltip } from '@looker/components'
 
-import { TooltipDemo } from './Tooltip/TooltipDemo'
-
-const App: React.FC = () => {
+export function TooltipDemo() {
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <TooltipDemo />
-    </ThemeProvider>
+    <Box p="xxxlarge">
+      <Tooltip content="Start editing" placement="top">
+        {(eventHandlers, ref) => (
+          <IconButton
+            icon="Edit"
+            label="Edit something"
+            {...eventHandlers}
+            ref={ref}
+          />
+        )}
+      </Tooltip>
+    </Box>
   )
 }
-
-/**
- * This is the binding site for the playground. If you want to edit the
- * primary application, do your work in App.tsx instead.
- */
-document.addEventListener('DOMContentLoaded', () => {
-  ReactDOM.render(<App />, document.getElementById('container'))
-})


### PR DESCRIPTION
### :sparkles: Changes

- As of https://github.com/looker-open-source/components/pull/576 we are no longer clobbering `IconButton` event handlers coming from props, which resulted in duplicate tooltips in the core product.
- This update checks if any of the props event handlers matches (via `toString` ??) the event handlers for built-in tooltip to detect an outer tooltip.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC

### :camera: Screenshots
**Issue:**
![issue](https://user-images.githubusercontent.com/53451193/76383307-a95c8800-6318-11ea-8f8a-10edbdce87f7.gif)

**Fix:**
![fix](https://user-images.githubusercontent.com/53451193/76383312-ad88a580-6318-11ea-85ad-7e832b86fb69.gif)
