### PR TITLE
Arrow icon updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.24] - 2020-03-12
 
 ### Added
-
+- `ArrowLeft` Icon added
 - `Checkbox` supports `defaultChecked` property.
 - `TabPanels` supports `FlexBoxProps` & `LayoutProps`
+
+### Change
+- `ArrowDropDown` and `ArrowDropUp` Icons renamed to `ArrowUp` and `ArrowDown`
 
 ## Fixed
 

--- a/packages/icons/src/svg/ArrowDown.svg
+++ b/packages/icons/src/svg/ArrowDown.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10 17L15 12L10 7V17Z" fill="#1C2125"/>
+<path d="M7 10L12 15L17 10H7Z" fill="#1C2125"/>
 </svg>

--- a/packages/icons/src/svg/ArrowDropDown.svg
+++ b/packages/icons/src/svg/ArrowDropDown.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M5 9L12 16L19 9H5Z" fill="#1C2125"/>
-</svg>

--- a/packages/icons/src/svg/ArrowDropUp.svg
+++ b/packages/icons/src/svg/ArrowDropUp.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M5 16L12 9L19 16H5Z" fill="#1C2125"/>
-</svg>

--- a/packages/icons/src/svg/ArrowLeft.svg
+++ b/packages/icons/src/svg/ArrowLeft.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10 17L15 12L10 7V17Z" fill="#1C2125"/>
+<path d="M14 7L9 12L14 17V7Z" fill="#1C2125"/>
 </svg>

--- a/packages/icons/src/svg/ArrowUp.svg
+++ b/packages/icons/src/svg/ArrowUp.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10 17L15 12L10 7V17Z" fill="#1C2125"/>
+<path d="M7 14L12 9L17 14H7Z" fill="#1C2125"/>
 </svg>

--- a/packages/playground/src/ActionList/ActionListDemo.tsx
+++ b/packages/playground/src/ActionList/ActionListDemo.tsx
@@ -144,7 +144,7 @@ export const ActionListDemo: FC = () => {
           }
           indicator={
             <Icon
-              name={status === 'Success' ? 'ArrowDropUp' : 'ArrowDropDown'}
+              name={status === 'Success' ? 'ArrowUp' : 'ArrowDown'}
               color={
                 status === 'Success' ? 'palette.green300' : 'palette.red300'
               }

--- a/packages/playground/src/Popovers/ContentOverflow.tsx
+++ b/packages/playground/src/Popovers/ContentOverflow.tsx
@@ -50,7 +50,7 @@ export const ContentOverflow: FC = ({ children }) => (
     >
       {(onClick, ref, className) => (
         <ButtonOutline
-          iconAfter="ArrowDropDown"
+          iconAfter="ArrowDown"
           m="xxlarge"
           className={className}
           onClick={onClick}

--- a/packages/playground/src/Popovers/EdgeOverflow.tsx
+++ b/packages/playground/src/Popovers/EdgeOverflow.tsx
@@ -51,7 +51,7 @@ export const EdgeOverflow: FC<Props> = ({
     >
       {(onClick, ref, className) => (
         <ButtonOutline
-          iconAfter="ArrowDropDown"
+          iconAfter="ArrowDown"
           m="xxlarge"
           className={className}
           onClick={onClick}


### PR DESCRIPTION
### :sparkles: Changes

This PR adds an icon `ArrowLeft` as well as it renames `ArrowDropDown` and `ArrowDropUp` Icon's to be more consistent to `ArrowDown` and `ArrowUp` 

![image](https://user-images.githubusercontent.com/170681/76998319-2045e200-6912-11ea-88ce-36ff0a897ff3.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots
