### PR TITLE
Scale icon size in Button

### DIFF
--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -153,6 +153,11 @@ exports[`Dismissable banner 1`] = `
   color: #939BA5;
 }
 
+.c5 .c8 {
+  width: 14px;
+  height: 14px;
+}
+
 .c5:active,
 .c5.active {
   background: #F5F6F7;

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -83,6 +83,32 @@ test('Button validates all sizes', () => {
   expect(getByText('large button')).toMatchSnapshot()
 })
 
+test('Button with icon validates all sizes', () => {
+  const { getByText } = render(
+    <ThemeProvider theme={theme}>
+      <>
+        <Button size={'xsmall'} iconBefore={'Account'}>
+          xsmall button
+        </Button>
+        <Button size={'small'} iconBefore={'Account'}>
+          small button
+        </Button>
+        <Button size={'medium'} iconBefore={'Account'}>
+          medium button
+        </Button>
+        <Button size={'large'} iconBefore={'Account'}>
+          large button
+        </Button>
+      </>
+    </ThemeProvider>
+  )
+
+  expect(getByText('xsmall button')).toMatchSnapshot()
+  expect(getByText('small button')).toMatchSnapshot()
+  expect(getByText('medium button')).toMatchSnapshot()
+  expect(getByText('large button')).toMatchSnapshot()
+})
+
 test('Button can be full width', () => {
   const { getByText } = render(
     <ThemeProvider theme={theme}>

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Button Focus: renders outline when tabbing into focus, but not when cli
 
 exports[`Button Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje kAurnO"
+  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje jgIVXP"
 >
   focus
 </button>

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -495,6 +495,518 @@ exports[`Button validates all sizes 4`] = `
 </button>
 `;
 
+exports[`Button with icon validates all sizes 1`] = `
+.c2 {
+  width: 1rem;
+  height: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  height: 24px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c1 {
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
+  color: #FFFFFF;
+}
+
+.c1 .c3 {
+  margin-left: -0.125rem;
+  margin-right: 0.25rem;
+  width: 12px;
+  height: 12px;
+}
+
+.c1:active,
+.c1.active {
+  background: #412399;
+  border-color: #412399;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  background: #4F2ABA;
+  border-color: #4F2ABA;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  background-color: #6C43E0;
+  border-color: #C1C6CC;
+}
+
+.c4 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 14px;
+  height: 14px;
+}
+
+.c5 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 18px;
+  height: 18px;
+}
+
+<button
+  class="c0 c1"
+>
+  <div
+    class="c2 c3 "
+  >
+    <svg
+      fill="currentColor"
+      height="100%"
+      viewBox="0 0 24 24"
+      width="100%"
+    >
+      <title>
+        Account
+      </title>
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM7.07 18.28c.43-.9 3.05-1.78 4.93-1.78s4.51.88 4.93 1.78A7.893 7.893 0 0112 20c-1.86 0-3.57-.64-4.93-1.72zm11.29-1.45c-1.43-1.74-4.9-2.33-6.36-2.33s-4.93.59-6.36 2.33A7.95 7.95 0 014 12c0-4.41 3.59-8 8-8s8 3.59 8 8c0 1.82-.62 3.49-1.64 4.83zM12 6c-1.94 0-3.5 1.56-3.5 3.5S10.06 13 12 13s3.5-1.56 3.5-3.5S13.94 6 12 6zm0 5c-.83 0-1.5-.67-1.5-1.5S11.17 8 12 8s1.5.67 1.5 1.5S12.83 11 12 11z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  xsmall button
+</button>
+`;
+
+exports[`Button with icon validates all sizes 2`] = `
+.c2 {
+  width: 1rem;
+  height: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  height: 28px;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c4 .c3 {
+  margin-left: -0.125rem;
+  margin-right: 0.25rem;
+  width: 12px;
+  height: 12px;
+}
+
+.c1 {
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
+  color: #FFFFFF;
+}
+
+.c1 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 14px;
+  height: 14px;
+}
+
+.c1:active,
+.c1.active {
+  background: #412399;
+  border-color: #412399;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  background: #4F2ABA;
+  border-color: #4F2ABA;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  background-color: #6C43E0;
+  border-color: #C1C6CC;
+}
+
+.c5 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 18px;
+  height: 18px;
+}
+
+<button
+  class="c0 c1"
+>
+  <div
+    class="c2 c3 "
+  >
+    <svg
+      fill="currentColor"
+      height="100%"
+      viewBox="0 0 24 24"
+      width="100%"
+    >
+      <title>
+        Account
+      </title>
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM7.07 18.28c.43-.9 3.05-1.78 4.93-1.78s4.51.88 4.93 1.78A7.893 7.893 0 0112 20c-1.86 0-3.57-.64-4.93-1.72zm11.29-1.45c-1.43-1.74-4.9-2.33-6.36-2.33s-4.93.59-6.36 2.33A7.95 7.95 0 014 12c0-4.41 3.59-8 8-8s8 3.59 8 8c0 1.82-.62 3.49-1.64 4.83zM12 6c-1.94 0-3.5 1.56-3.5 3.5S10.06 13 12 13s3.5-1.56 3.5-3.5S13.94 6 12 6zm0 5c-.83 0-1.5-.67-1.5-1.5S11.17 8 12 8s1.5.67 1.5 1.5S12.83 11 12 11z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  small button
+</button>
+`;
+
+exports[`Button with icon validates all sizes 3`] = `
+.c2 {
+  width: 1rem;
+  height: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 1rem;
+  height: 36px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c4 .c3 {
+  margin-left: -0.125rem;
+  margin-right: 0.25rem;
+  width: 12px;
+  height: 12px;
+}
+
+.c5 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 14px;
+  height: 14px;
+}
+
+.c1 {
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
+  color: #FFFFFF;
+}
+
+.c1 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 16px;
+  height: 16px;
+}
+
+.c1:active,
+.c1.active {
+  background: #412399;
+  border-color: #412399;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  background: #4F2ABA;
+  border-color: #4F2ABA;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  background-color: #6C43E0;
+  border-color: #C1C6CC;
+}
+
+.c6 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 18px;
+  height: 18px;
+}
+
+<button
+  class="c0 c1"
+>
+  <div
+    class="c2 c3 "
+  >
+    <svg
+      fill="currentColor"
+      height="100%"
+      viewBox="0 0 24 24"
+      width="100%"
+    >
+      <title>
+        Account
+      </title>
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM7.07 18.28c.43-.9 3.05-1.78 4.93-1.78s4.51.88 4.93 1.78A7.893 7.893 0 0112 20c-1.86 0-3.57-.64-4.93-1.72zm11.29-1.45c-1.43-1.74-4.9-2.33-6.36-2.33s-4.93.59-6.36 2.33A7.95 7.95 0 014 12c0-4.41 3.59-8 8-8s8 3.59 8 8c0 1.82-.62 3.49-1.64 4.83zM12 6c-1.94 0-3.5 1.56-3.5 3.5S10.06 13 12 13s3.5-1.56 3.5-3.5S13.94 6 12 6zm0 5c-.83 0-1.5-.67-1.5-1.5S11.17 8 12 8s1.5.67 1.5 1.5S12.83 11 12 11z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  medium button
+</button>
+`;
+
+exports[`Button with icon validates all sizes 4`] = `
+.c2 {
+  width: 1rem;
+  height: 1rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-weight: 600;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1;
+  outline: none;
+  -webkit-transition: border 80ms;
+  transition: border 80ms;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 1.375rem;
+  height: 44px;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.c0[disabled] {
+  cursor: default;
+  -webkit-filter: grayscale(0.3);
+  filter: grayscale(0.3);
+  opacity: 0.25;
+}
+
+.c4 .c3 {
+  margin-left: -0.125rem;
+  margin-right: 0.25rem;
+  width: 12px;
+  height: 12px;
+}
+
+.c5 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 14px;
+  height: 14px;
+}
+
+.c6 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 16px;
+  height: 16px;
+}
+
+.c1 {
+  background: #6C43E0;
+  border: 1px solid #6C43E0;
+  color: #FFFFFF;
+}
+
+.c1 .c3 {
+  margin-left: -0.25rem;
+  margin-right: 0.5rem;
+  width: 18px;
+  height: 18px;
+}
+
+.c1:active,
+.c1.active {
+  background: #412399;
+  border-color: #412399;
+}
+
+.c1:hover,
+.c1:focus,
+.c1.hover {
+  background: #4F2ABA;
+  border-color: #4F2ABA;
+}
+
+.c1[disabled]:hover,
+.c1[disabled]:active,
+.c1[disabled]:focus {
+  background-color: #6C43E0;
+  border-color: #C1C6CC;
+}
+
+<button
+  class="c0 c1"
+>
+  <div
+    class="c2 c3 "
+  >
+    <svg
+      fill="currentColor"
+      height="100%"
+      viewBox="0 0 24 24"
+      width="100%"
+    >
+      <title>
+        Account
+      </title>
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM7.07 18.28c.43-.9 3.05-1.78 4.93-1.78s4.51.88 4.93 1.78A7.893 7.893 0 0112 20c-1.86 0-3.57-.64-4.93-1.72zm11.29-1.45c-1.43-1.74-4.9-2.33-6.36-2.33s-4.93.59-6.36 2.33A7.95 7.95 0 014 12c0-4.41 3.59-8 8-8s8 3.59 8 8c0 1.82-.62 3.49-1.64 4.83zM12 6c-1.94 0-3.5 1.56-3.5 3.5S10.06 13 12 13s3.5-1.56 3.5-3.5S13.94 6 12 6zm0 5c-.83 0-1.5-.67-1.5-1.5S11.17 8 12 8s1.5.67 1.5 1.5S12.83 11 12 11z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  large button
+</button>
+`;
+
 exports[`Button works with color danger 1`] = `
 .c0 {
   -webkit-align-items: center;

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -42,6 +42,11 @@ exports[`Button Focus: renders outline when tabbing into focus, but not when cli
   color: #FFFFFF;
 }
 
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
+}
+
 .c1:active,
 .c1.active {
   background: #412399;
@@ -71,7 +76,7 @@ exports[`Button Focus: renders outline when tabbing into focus, but not when cli
 
 exports[`Button Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje jgIVXP"
+  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje bHbNgz"
 >
   focus
 </button>
@@ -118,6 +123,11 @@ exports[`Button can be full width 1`] = `
   background: #6C43E0;
   border: 1px solid #6C43E0;
   color: #FFFFFF;
+}
+
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
 }
 
 .c1:active,
@@ -187,6 +197,11 @@ exports[`Button disable 1`] = `
   background: #6C43E0;
   border: 1px solid #6C43E0;
   color: #FFFFFF;
+}
+
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
 }
 
 .c1:active,
@@ -261,6 +276,11 @@ exports[`Button validates all sizes 1`] = `
   color: #FFFFFF;
 }
 
+.c1 .c2 {
+  width: 12px;
+  height: 12px;
+}
+
 .c1:active,
 .c1.active {
   background: #412399;
@@ -328,6 +348,11 @@ exports[`Button validates all sizes 2`] = `
   background: #6C43E0;
   border: 1px solid #6C43E0;
   color: #FFFFFF;
+}
+
+.c1 .c2 {
+  width: 14px;
+  height: 14px;
 }
 
 .c1:active,
@@ -399,6 +424,11 @@ exports[`Button validates all sizes 3`] = `
   color: #FFFFFF;
 }
 
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
+}
+
 .c1:active,
 .c1.active {
   background: #412399;
@@ -466,6 +496,11 @@ exports[`Button validates all sizes 4`] = `
   background: #6C43E0;
   border: 1px solid #6C43E0;
   color: #FFFFFF;
+}
+
+.c1 .c2 {
+  width: 18px;
+  height: 18px;
 }
 
 .c1:active,
@@ -544,6 +579,31 @@ exports[`Button with icon validates all sizes 1`] = `
   opacity: 0.25;
 }
 
+.c4 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c5 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c3 {
+  width: 12px;
+  height: 12px;
+}
+
+.c7 .c3 {
+  width: 14px;
+  height: 14px;
+}
+
+.c8 .c3 {
+  width: 18px;
+  height: 18px;
+}
+
 .c1 {
   background: #6C43E0;
   border: 1px solid #6C43E0;
@@ -577,21 +637,21 @@ exports[`Button with icon validates all sizes 1`] = `
   border-color: #C1C6CC;
 }
 
-.c4 .c3 {
+.c9 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 14px;
   height: 14px;
 }
 
-.c5 .c3 {
+.c10 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 16px;
   height: 16px;
 }
 
-.c6 .c3 {
+.c11 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 18px;
@@ -673,6 +733,31 @@ exports[`Button with icon validates all sizes 2`] = `
 }
 
 .c4 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c5 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c3 {
+  width: 12px;
+  height: 12px;
+}
+
+.c7 .c3 {
+  width: 14px;
+  height: 14px;
+}
+
+.c8 .c3 {
+  width: 18px;
+  height: 18px;
+}
+
+.c9 .c3 {
   margin-left: -0.125rem;
   margin-right: 0.25rem;
   width: 12px;
@@ -712,14 +797,14 @@ exports[`Button with icon validates all sizes 2`] = `
   border-color: #C1C6CC;
 }
 
-.c5 .c3 {
+.c10 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 16px;
   height: 16px;
 }
 
-.c6 .c3 {
+.c11 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 18px;
@@ -801,13 +886,38 @@ exports[`Button with icon validates all sizes 3`] = `
 }
 
 .c4 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c5 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c3 {
+  width: 12px;
+  height: 12px;
+}
+
+.c7 .c3 {
+  width: 14px;
+  height: 14px;
+}
+
+.c8 .c3 {
+  width: 18px;
+  height: 18px;
+}
+
+.c9 .c3 {
   margin-left: -0.125rem;
   margin-right: 0.25rem;
   width: 12px;
   height: 12px;
 }
 
-.c5 .c3 {
+.c10 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 14px;
@@ -847,7 +957,7 @@ exports[`Button with icon validates all sizes 3`] = `
   border-color: #C1C6CC;
 }
 
-.c6 .c3 {
+.c11 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 18px;
@@ -929,20 +1039,45 @@ exports[`Button with icon validates all sizes 4`] = `
 }
 
 .c4 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c5 .c3 {
+  width: 16px;
+  height: 16px;
+}
+
+.c6 .c3 {
+  width: 12px;
+  height: 12px;
+}
+
+.c7 .c3 {
+  width: 14px;
+  height: 14px;
+}
+
+.c8 .c3 {
+  width: 18px;
+  height: 18px;
+}
+
+.c9 .c3 {
   margin-left: -0.125rem;
   margin-right: 0.25rem;
   width: 12px;
   height: 12px;
 }
 
-.c5 .c3 {
+.c10 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 14px;
   height: 14px;
 }
 
-.c6 .c3 {
+.c11 .c3 {
   margin-left: -0.25rem;
   margin-right: 0.5rem;
   width: 16px;
@@ -1047,6 +1182,11 @@ exports[`Button works with color danger 1`] = `
   background: #CC1F36;
   border: 1px solid #CC1F36;
   color: #FFFFFF;
+}
+
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
 }
 
 .c1:active,

--- a/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not w
 
 exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje iGIddR"
+  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje imymvE"
 >
   focus
 </button>

--- a/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
@@ -42,6 +42,11 @@ exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not w
   color: #6C43E0;
 }
 
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
+}
+
 .c1:hover,
 .c1:focus,
 .c1.hover {
@@ -74,7 +79,7 @@ exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not w
 
 exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje imymvE"
+  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje iBRqXz"
 >
   focus
 </button>
@@ -120,6 +125,11 @@ exports[`ButtonOutline has the correct style 1`] = `
   background: #FFFFFF;
   border: 1px solid #C1C6CC;
   color: #6C43E0;
+}
+
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
 }
 
 .c1:hover,

--- a/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
@@ -42,6 +42,11 @@ exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but n
   color: #6C43E0;
 }
 
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
+}
+
 .c1:active,
 .c1.active {
   background: #E8E5FF;
@@ -72,7 +77,7 @@ exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but n
 
 exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje YuRpY"
+  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje kFWnwj"
 >
   focus
 </button>
@@ -118,6 +123,11 @@ exports[`ButtonTransparent has the correct style 1`] = `
   background: transparent;
   border: 1px solid transparent;
   color: #6C43E0;
+}
+
+.c1 .c2 {
+  width: 16px;
+  height: 16px;
 }
 
 .c1:active,

--- a/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but n
 
 exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje ewBWhA"
+  class="sc-bxivhb deKSKn sc-ifAKCX sc-EHOje YuRpY"
 >
   focus
 </button>

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -57,6 +57,11 @@ exports[`IconButton accepts color 1`] = `
   color: #CC1F36;
 }
 
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
+}
+
 .c1:active,
 .c1.active {
   background: #FFE5E9;
@@ -186,6 +191,11 @@ exports[`IconButton accepts events 1`] = `
   background: transparent;
   border: 1px solid transparent;
   color: #939BA5;
+}
+
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
 }
 
 .c1:active,
@@ -320,6 +330,11 @@ exports[`IconButton accepts events 2`] = `
   color: #939BA5;
 }
 
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
+}
+
 .c1:active,
 .c1.active {
   background: #F5F6F7;
@@ -450,6 +465,11 @@ exports[`IconButton allows for ARIA attributes 1`] = `
   background: transparent;
   border: 1px solid transparent;
   color: #939BA5;
+}
+
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
 }
 
 .c1:active,
@@ -584,6 +604,11 @@ exports[`IconButton default 1`] = `
   color: #939BA5;
 }
 
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
+}
+
 .c1:active,
 .c1.active {
   background: #F5F6F7;
@@ -713,6 +738,11 @@ exports[`IconButton outline 1`] = `
   background: transparent;
   border: 1px solid transparent;
   color: #939BA5;
+}
+
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
 }
 
 .c1:active,
@@ -867,6 +897,11 @@ exports[`IconButton renders focus ring on tab input but not on click 1`] = `
   color: #CC1F36;
 }
 
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
+}
+
 .c1:active,
 .c1.active {
   background: #FFE5E9;
@@ -998,6 +1033,11 @@ exports[`IconButton renders focus ring on tab input but not on click 2`] = `
   color: #CC1F36;
 }
 
+.c1 .c5 {
+  width: 12px;
+  height: 12px;
+}
+
 .c1:active,
 .c1.active {
   background: #FFE5E9;
@@ -1127,6 +1167,11 @@ exports[`IconButton resized 1`] = `
   background: transparent;
   border: 1px solid transparent;
   color: #939BA5;
+}
+
+.c1 .c5 {
+  width: 18px;
+  height: 18px;
 }
 
 .c1:active,

--- a/packages/components/src/Button/icon.ts
+++ b/packages/components/src/Button/icon.ts
@@ -76,6 +76,7 @@ export const iconSizes = (props: ButtonProps) => {
     case 'large':
       iconSize = 18
       break
+    case 'medium':
     default:
       iconSize = 16
   }

--- a/packages/components/src/Button/icon.ts
+++ b/packages/components/src/Button/icon.ts
@@ -64,10 +64,37 @@ export const iconMargins = (props: ButtonProps) => {
   }
 }
 
+export const iconSizes = (props: ButtonProps) => {
+  let iconSize = 16
+  switch (props.size) {
+    case 'xsmall':
+      iconSize = 12
+      break
+    case 'small':
+      iconSize = 14
+      break
+    case 'large':
+      iconSize = 18
+      break
+    default:
+      iconSize = 16
+  }
+
+  if (props.iconBefore || props.iconAfter) {
+    return css`
+      width: ${iconSize}px;
+      height: ${iconSize}px;
+    `
+  } else {
+    return false
+  }
+}
+
 export const ButtonIcon = styled(Icon)``
 
 export const buttonIcon = (props: ButtonProps) => css`
   ${ButtonIcon} {
     ${iconMargins(props)};
+    ${iconSizes(props)}
   }
 `

--- a/packages/components/src/Button/icon.ts
+++ b/packages/components/src/Button/icon.ts
@@ -81,14 +81,10 @@ export const iconSizes = (props: ButtonProps) => {
       iconSize = 16
   }
 
-  if (props.iconBefore || props.iconAfter) {
-    return css`
-      width: ${iconSize}px;
-      height: ${iconSize}px;
-    `
-  } else {
-    return false
-  }
+  return css`
+    width: ${iconSize}px;
+    height: ${iconSize}px;
+  `
 }
 
 export const ButtonIcon = styled(Icon)``

--- a/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
+++ b/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
@@ -57,6 +57,11 @@ exports[`ModalHeader 1`] = `
   color: #939BA5;
 }
 
+.c3 .c7 {
+  width: 14px;
+  height: 14px;
+}
+
 .c3:active,
 .c3.active {
   background: #F5F6F7;


### PR DESCRIPTION
### :sparkles: Changes

This PR updates how icons are sized in `Button` before the icon was the same at all `Button` sizes. With this PR we scale the icon size based on the size of the `Button`

**Before**
Here is before where all the icons render at 16px
![image](https://user-images.githubusercontent.com/170681/78148279-89852500-73e9-11ea-80ca-28fd90b76ce2.png)

**After**
Now the icon scales with the button, most noticeable in `xsmall` and `large` sizes
![image](https://user-images.githubusercontent.com/170681/78148509-c81adf80-73e9-11ea-9aaf-00a426151ab8.png)



### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots
