### PR TITLE
Fix usePopper top placement with window "offset parent"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `usePopper` (used in `Popover` and `Tooltip`) positioning issue with `placement="top"` and offset parent is the window
 - `Select` runtime error with no options, defaultValue or placeholder
 
 ## [0.7.25] - 2020-03-23

--- a/packages/components/src/Overlay/OverlaySurface.tsx
+++ b/packages/components/src/Overlay/OverlaySurface.tsx
@@ -121,10 +121,6 @@ OverlaySurface.displayName = 'OverlaySurface'
 
 const Outer = styled.div<{ zIndex?: number }>`
   ${reset};
-  /* PopperJS adds position: fixed via the style prop
-  but this fixes an intermittent "flash" of un-positioned tooltip
-  while the PopperJS instance is initializing */
-  position: fixed;
   animation: ${fadeIn} 150ms ease-in;
   overflow: visible;
   z-index: ${(props) => props.zIndex};

--- a/packages/components/src/utils/usePopper.ts
+++ b/packages/components/src/utils/usePopper.ts
@@ -48,7 +48,17 @@ export function usePopper({
   arrow = true,
   options,
 }: UsePopperProps) {
-  const [styles, setStyles] = useState<State['styles']>({})
+  const [styles, setStyles] = useState<State['styles']>({
+    arrow: {
+      position: 'absolute',
+    },
+    popper: {
+      left: '0',
+      margin: '0',
+      position: 'fixed',
+      top: '0',
+    },
+  })
   const [truePlacement, setTruePlacement] = useState(options.placement)
   const popperInstanceRef = useRef<Instance>()
   const [targetElement, targetRef] = useCallbackRef<HTMLElement>()
@@ -92,7 +102,7 @@ export function usePopper({
             enabled: true,
             name: 'preventOverflow',
             options: {
-              boundariesElement: 'window',
+              boundary: 'viewport',
               // 8px away from edge of window
               padding: 8,
             },
@@ -102,6 +112,12 @@ export function usePopper({
             options: {
               // 8px away from anchor element
               offset: [0, 8],
+            },
+          },
+          {
+            name: 'computeStyles',
+            options: {
+              adaptive: false,
             },
           },
         ]),

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -24,13 +24,13 @@ import { GlobalStyle } from '@looker/components'
 import { theme } from '@looker/design-tokens'
 import { ThemeProvider } from 'styled-components'
 
-import { SelectMultiDemo } from './Select/SelectMultiDemo'
+import { TestPopovers } from './Popovers/Testing'
 
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <SelectMultiDemo />
+      <TestPopovers />
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- PopperJS 2.0 isn't behaving well with `placement: 'top'` (whether set or as a result of "flipping") and an anchor element whose "offset parent" is the window itself.
- I couldn't quite pin down why this was happening but I think it has something to do with PopperJS expecting the `bottom:0` to be the bottom of the page but it's actually the bottom of the window.
- Setting the `adaptive` option to false in `computeStyles` fixes the issue because then it uses only `top` and `left` properties which are more reliable.
- You won't see this issue in components.looker.com because the scrolling content section prevents it from happening, but you can see it in the playground (on master) as demonstrated by this screen capture:
![popper-bug](https://user-images.githubusercontent.com/53451193/78697466-b20f9200-78b5-11ea-9cd1-97ef749bf691.gif)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots
**Fixed:**
![popper-bug-fix](https://user-images.githubusercontent.com/53451193/78709007-d5dbd380-78c7-11ea-970f-255b7abf5816.gif)
