### PR TITLE
Group options within Select component without titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Select` and `SelectMulti` option groups `title` is now `label` and optional.
 - `Badge` style updated to use lighter colors for intents. Badges are now always round.
 
 ### Fixed

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -104,14 +104,18 @@ describe('Select / SelectMulti', () => {
 
   const groupedOptions = [
     {
+      label: 'FOO',
       options: [{ value: 'BAR' }, { value: 'BAZ' }],
-      title: 'FOO',
     },
     {
+      label: 'OTHER',
       options: [
         { description: 'A description for something', value: 'something' },
       ],
-      title: 'OTHER',
+    },
+    // label is not required
+    {
+      options: [{ value: 'FOO' }, { value: 'QUX' }],
     },
   ]
 
@@ -138,7 +142,7 @@ describe('Select / SelectMulti', () => {
         />
       ),
     ],
-  ])('with option descriptions and group titles (%s)', async (name, getJSX) => {
+  ])('with option descriptions and group labels (%s)', async (name, getJSX) => {
     const handleChange = jest.fn()
     const { getByText, getByPlaceholderText } = renderWithTheme(
       getJSX(handleChange)

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -115,7 +115,7 @@ describe('Select / SelectMulti', () => {
     },
     // label is not required
     {
-      options: [{ value: 'FOO' }, { value: 'QUX' }],
+      options: [{ value: 'QUX' }, { value: 'TEST' }],
     },
   ]
 

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -45,7 +45,7 @@ export interface SelectOptionObject extends ComboboxOptionObject {
 
 export interface SelectOptionGroupProps {
   options: SelectOptionObject[]
-  title: string | ReactNode
+  label?: string | ReactNode
 }
 
 export type SelectOptionProps = SelectOptionObject | SelectOptionGroupProps
@@ -88,6 +88,7 @@ export function SelectOptionWithDescription({
 }
 
 const SelectOptionGroupTitle = styled(Heading)<{ isMulti?: boolean }>`
+  padding-top: ${({ theme }) => theme.space.xxsmall};
   ${comboboxOptionGrid}
   ${({ isMulti, theme }) =>
     isMulti ? `grid-template-columns: ${theme.space.xlarge} 1fr;` : ''}
@@ -103,17 +104,33 @@ SelectOptionGroupTitle.defaultProps = {
 
 export const SelectOptionGroup = ({
   options,
-  title,
+  label,
   isMulti,
 }: SelectOptionGroupProps & { isMulti?: boolean }) => (
-  <Box py="xxsmall">
-    <SelectOptionGroupTitle isMulti={isMulti}>
-      <span />
-      {title}
-    </SelectOptionGroupTitle>
+  <SelectOptionGroupContainer>
+    {label && (
+      <SelectOptionGroupTitle isMulti={isMulti}>
+        <span />
+        {label}
+      </SelectOptionGroupTitle>
+    )}
     {options.map(isMulti ? renderMultiOption : renderOption)}
-  </Box>
+  </SelectOptionGroupContainer>
 )
+
+const SelectOptionGroupContainer = styled.div`
+  padding: ${({ theme }) => theme.space.xsmall} 0;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: ${({ theme }) => theme.colors.palette.charcoal200};
+  &:first-child,
+  & + div {
+    border-top: none;
+  }
+  &:last-child {
+    border-bottom: none;
+  }
+`
 
 export interface SelectOptionsBaseProps {
   /**
@@ -179,7 +196,7 @@ export function SelectOptions({
         ? [
             ...options.map((option: SelectOptionProps, index: number) => {
               const optionAsGroup = option as SelectOptionGroupProps
-              return optionAsGroup.title ? (
+              return optionAsGroup.options ? (
                 <SelectOptionGroup
                   key={index}
                   {...optionAsGroup}

--- a/packages/components/src/Form/Inputs/Select/utils/options.ts
+++ b/packages/components/src/Form/Inputs/Select/utils/options.ts
@@ -35,7 +35,7 @@ export function flattenOptions(options: SelectOptionProps[]) {
   return options.reduce(
     (acc: SelectOptionObject[], option: SelectOptionProps) => {
       const optionAsGroup = option as SelectOptionGroupProps
-      if (optionAsGroup.title) {
+      if (optionAsGroup.options) {
         return [...acc, ...optionAsGroup.options]
       }
       return [...acc, option as SelectOptionObject]
@@ -71,7 +71,7 @@ export function getFirstOption(
   options: SelectOptionProps[]
 ): SelectOptionObject {
   const optionAsGroup = options[0] as SelectOptionGroupProps
-  if (optionAsGroup && optionAsGroup.title) return optionAsGroup.options[0]
+  if (optionAsGroup && optionAsGroup.options) return optionAsGroup.options[0]
   return options[0] as SelectOptionObject
 }
 

--- a/packages/playground/src/Select/SelectDemo.tsx
+++ b/packages/playground/src/Select/SelectDemo.tsx
@@ -46,21 +46,29 @@ const options = [
   { label: 'Oranges', value: '3' },
   { label: 'Pineapples', value: '4' },
   { label: 'Kiwis', value: '5' },
+]
+const options2 = [
   { label: 'Apples2', value: '12' },
   { label: 'Bananas2', value: '22' },
   { label: 'Oranges2', value: '32' },
   { label: 'Pineapples2', value: '42' },
-  { label: 'Kiwis3', value: '52' },
+  { label: 'Kiwis2', value: '52' },
+]
+const options3 = [
   { label: 'Apples3', value: '13' },
   { label: 'Bananas3', value: '23' },
   { label: 'Oranges3', value: '33' },
   { label: 'Pineapples3', value: '43' },
   { label: 'Kiwis3', value: '53' },
+]
+const options4 = [
   { label: 'Apples4', value: '14' },
   { label: 'Bananas4', value: '24' },
   { label: 'Oranges4', value: '34' },
   { label: 'Pineapples4', value: '44' },
   { label: 'Kiwis4', value: '54' },
+]
+const options5 = [
   { label: 'Apples5', value: '15' },
   { label: 'Bananas5', value: '25' },
   { label: 'Oranges5', value: '35' },
@@ -69,13 +77,17 @@ const options = [
 ]
 
 const optionsWithGroups = [
-  { options, title: 'FRUITS' },
+  { options },
+  { options: options2 },
+  { options: options3 },
+  { options: options4 },
+  { options: options5 },
   {
+    label: 'CARS',
     options: [
-      { label: 'Honda', value: 'honda' },
-      { label: 'Toyota', value: 'toyota' },
+      { description: 'Great resale value', label: 'Honda', value: 'honda' },
+      { description: 'Most popular make', label: 'Toyota', value: 'toyota' },
     ],
-    title: 'CARS',
   },
 ]
 
@@ -94,7 +106,7 @@ function checkOption(option: ComboboxOptionObject, searchTerm: string) {
 function optionReducer(searchTerm: string) {
   return (acc: SelectOptionProps[], option: SelectOptionProps) => {
     const optionAsGroup = option as SelectOptionGroupProps
-    if (optionAsGroup.title) {
+    if (optionAsGroup.options) {
       const filteredGroupOptions = optionAsGroup.options.filter((option) =>
         checkOption(option, searchTerm)
       )

--- a/packages/playground/src/Select/SelectMultiDemo.tsx
+++ b/packages/playground/src/Select/SelectMultiDemo.tsx
@@ -53,6 +53,7 @@ const selectOptions = [
 ]
 const selectGroups = [
   {
+    label: 'Fruits',
     options: [
       { label: 'Apples', value: '1' },
       { label: 'Bananas', value: '2' },
@@ -60,9 +61,9 @@ const selectGroups = [
       { label: 'Pineapples', value: '4' },
       { label: 'Kiwis', value: '5' },
     ],
-    title: 'Fruits',
   },
   {
+    label: 'Fruits 2',
     options: [
       { label: 'Apples2', value: '12' },
       { label: 'Bananas2', value: '22' },
@@ -70,9 +71,9 @@ const selectGroups = [
       { label: 'Pineapples2', value: '42' },
       { label: 'Kiwis2', value: '52' },
     ],
-    title: 'Fruits 2',
   },
   {
+    label: 'Fruits 3',
     options: [
       { label: 'Apples3', value: '13' },
       { label: 'Bananas3', value: '23' },
@@ -80,9 +81,9 @@ const selectGroups = [
       { label: 'Pineapples3', value: '43' },
       { label: 'Kiwis3', value: '53' },
     ],
-    title: 'Fruits 3',
   },
   {
+    label: 'Fruits 4',
     options: [
       { label: 'Apples4', value: '14' },
       { label: 'Bananas4', value: '24' },
@@ -90,9 +91,9 @@ const selectGroups = [
       { label: 'Pineapples4', value: '44' },
       { label: 'Kiwis4', value: '54' },
     ],
-    title: 'Fruits 4',
   },
   {
+    label: 'Fruits 5',
     options: [
       { label: 'Apples5', value: '15' },
       { label: 'Bananas5', value: '25' },
@@ -100,7 +101,6 @@ const selectGroups = [
       { label: 'Pineapples5', value: '45' },
       { label: 'Kiwis5', value: '55' },
     ],
-    title: 'Fruits 5',
   },
 ]
 

--- a/packages/www/src/documentation/components/forms/select.mdx
+++ b/packages/www/src/documentation/components/forms/select.mdx
@@ -103,26 +103,32 @@ A name and ID can be specified in the `<Select />` component. Names are importan
 
 ## Groups
 
-Options can be grouped under a `title`.
+Options can be organized into groups, with an optional `label`.
 
 ```jsx
 <Select
   options={[
     {
+      label: 'CHEESES',
       options: [
         { value: 'cheddar', label: 'Cheddar' },
         { value: 'gouda', label: 'Gouda' },
         { value: 'swiss', label: 'Swiss' },
       ],
-      title: 'CHEESES',
     },
     {
+      label: 'FRUITS',
       options: [
         { value: 'grape', label: 'Grapes' },
         { value: 'apple', label: 'Apples' },
         { value: 'strawberries', label: 'Strawberries' },
       ],
-      title: 'FRUITS',
+    },
+    {
+      options: [
+        { value: 'pizza', label: 'Pizza' },
+        { value: 'hamburgers', label: 'Hamburgers' },
+      ],
     },
   ]}
 />


### PR DESCRIPTION
### :sparkles: Changes

- Renamed option group `title` to `label` (closer to [HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup), audit of core product shows it's not being used yet) and made it optional
- Added dividers between groups, per design spec:
![image-20200330-235436](https://user-images.githubusercontent.com/53451193/78933818-be831e80-7a5e-11ea-9ab6-671c65efcb96.png)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
