### PR TITLE
[LENS-670] Fix Checkbox defaultChecked behavior

### DIFF
--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -128,12 +128,16 @@ exports[`A FieldCheckbox 1`] = `
       className=""
     >
       <div
+        checked={false}
         className="c5 "
       >
         <input
+          checked={false}
           className=""
           id="thumbs-up"
           name="thumbsUp"
+          onChange={[Function]}
+          onClick={[Function]}
           role="checkbox"
           type="checkbox"
         />
@@ -310,10 +314,12 @@ exports[`A FieldCheckbox with checked value 1`] = `
         className="c5 "
       >
         <input
+          checked={true}
           className=""
-          defaultChecked={true}
           id="thumbs-up"
           name="thumbsUp"
+          onChange={[Function]}
+          onClick={[Function]}
           role="checkbox"
           type="checkbox"
         />
@@ -497,12 +503,16 @@ exports[`A required FieldCheckbox 1`] = `
       className=""
     >
       <div
+        checked={false}
         className="c6 "
       >
         <input
+          checked={false}
           className=""
           id="thumbs-up"
           name="thumbsUp"
+          onChange={[Function]}
+          onClick={[Function]}
           required={true}
           role="checkbox"
           type="checkbox"

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.test.tsx
@@ -24,22 +24,55 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
-import { mountWithTheme, assertSnapshot } from '@looker/components-test-utils'
+import { assertSnapshot, renderWithTheme } from '@looker/components-test-utils'
+import { fireEvent } from '@testing-library/react'
+import { Checkbox, CheckboxProps } from './Checkbox'
 
-import { Checkbox } from './Checkbox'
-
-test('Checkbox default', () => {
-  assertSnapshot(<Checkbox />)
+afterEach(() => {
+  jest.resetAllMocks()
 })
 
-test('Checkbox checked set to true', () => {
-  assertSnapshot(<Checkbox checked={true} />)
+test('Accepts defaultChecked prop, and toggles value without change handler', () => {
+  const { getByRole } = renderWithTheme(<Checkbox defaultChecked />)
+  const checkboxInput = getByRole('checkbox')
+
+  expect((checkboxInput as HTMLInputElement).checked).toEqual(true)
+
+  fireEvent.click(checkboxInput)
+
+  // toggled state:
+  expect((checkboxInput as HTMLInputElement).checked).toEqual(false)
 })
 
-test('Checkbox checked set to false', () => {
-  assertSnapshot(<Checkbox checked={false} />)
+test('Accepts checked prop, and is read only without a change handler', () => {
+  const { getByRole } = renderWithTheme(<Checkbox checked />)
+  const checkboxInput = getByRole('checkbox')
+
+  expect((checkboxInput as HTMLInputElement).checked).toEqual(true)
+
+  fireEvent.click(checkboxInput)
+
+  // unchanged state:
+  expect((checkboxInput as HTMLInputElement).checked).toEqual(true)
+})
+
+test('Triggers onChange handler', () => {
+  const mockProps: CheckboxProps = {
+    onChange: jest.fn(),
+  }
+
+  const { getByRole } = renderWithTheme(<Checkbox {...mockProps} />)
+
+  const checkboxInput = getByRole('checkbox')
+
+  expect(mockProps.onChange).not.toHaveBeenCalled()
+  expect((checkboxInput as HTMLInputElement).checked).toEqual(false)
+
+  fireEvent.click(checkboxInput)
+
+  expect(mockProps.onChange).toHaveBeenCalledTimes(1)
+  expect((checkboxInput as HTMLInputElement).checked).toEqual(true)
 })
 
 test('Checkbox checked set to mixed', () => {
@@ -56,14 +89,4 @@ test('Checkbox should accept disabled', () => {
 
 test('Checkbox with aria-describedby', () => {
   assertSnapshot(<Checkbox aria-describedby="some-id" />)
-})
-
-test('Should trigger onChange handler', () => {
-  let counter = 0
-  const handleChange = () => counter++
-
-  const wrapper = mountWithTheme(<Checkbox onChange={handleChange} />)
-
-  wrapper.find('input').simulate('change', { target: { value: '' } })
-  expect(counter).toEqual(1)
 })

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -26,9 +26,10 @@
 
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
-import React, { forwardRef, Ref } from 'react'
+import React, { forwardRef, Ref, useState, FormEvent, useEffect } from 'react'
 import styled from 'styled-components'
 import { reset, space, SpaceProps } from '@looker/design-tokens'
+import isUndefined from 'lodash/isUndefined'
 import { InputProps, inputPropKeys } from '../InputProps'
 
 export type MixedBoolean = true | false | 'mixed'
@@ -144,16 +145,31 @@ const CheckboxInput = styled.input.attrs({ type: 'checkbox' })`
 
 const CheckboxComponent = forwardRef(
   (props: CheckboxProps, ref: Ref<HTMLInputElement>) => {
-    const { checked, ...restProps } = props
+    const { checked, defaultChecked, onChange, ...restProps } = props
+    const [isChecked, setIsChecked] = useState<MixedBoolean | undefined>(
+      !!(checked || defaultChecked)
+    )
+
+    const handleClick = (e: FormEvent<HTMLInputElement>) => {
+      const toggledValue = !isChecked
+      if (isUndefined(checked)) {
+        setIsChecked(toggledValue)
+      } else if (onChange) {
+        onChange(e)
+      }
+    }
+
+    useEffect(() => {
+      setIsChecked(checked)
+    }, [checked])
+
     return (
-      <CheckboxContainer
-        {...omit(props, inputPropKeys)}
-        checked={checked || restProps.defaultChecked}
-      >
+      <CheckboxContainer {...omit(props, inputPropKeys)} checked={isChecked}>
         <CheckboxInput
           {...pick(restProps, inputPropKeys)}
           ref={ref}
-          checked={checked === undefined ? undefined : checked === true}
+          checked={!!isChecked}
+          onClick={handleClick}
           role="checkbox"
           aria-checked={checked}
         />

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -24,6 +24,7 @@
 
  */
 
+import noop from 'lodash/noop'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
 import React, { forwardRef, Ref, useState, FormEvent, useEffect } from 'react'
@@ -146,21 +147,22 @@ const CheckboxInput = styled.input.attrs({ type: 'checkbox' })`
 const CheckboxComponent = forwardRef(
   (props: CheckboxProps, ref: Ref<HTMLInputElement>) => {
     const { checked, defaultChecked, onChange, ...restProps } = props
-    const [isChecked, setIsChecked] = useState<MixedBoolean | undefined>(
-      !!(checked || defaultChecked)
-    )
+    const [isChecked, setIsChecked] = useState<MixedBoolean>(!!defaultChecked)
 
     const handleClick = (e: FormEvent<HTMLInputElement>) => {
-      const toggledValue = !isChecked
       if (isUndefined(checked)) {
-        setIsChecked(toggledValue)
-      } else if (onChange) {
+        setIsChecked(!isChecked)
+      }
+      if (onChange) {
         onChange(e)
       }
     }
 
+    // controlled component: update internal state when props.checked changes
     useEffect(() => {
-      setIsChecked(checked)
+      if (!isUndefined(checked)) {
+        setIsChecked(checked)
+      }
     }, [checked])
 
     return (
@@ -169,9 +171,11 @@ const CheckboxComponent = forwardRef(
           {...pick(restProps, inputPropKeys)}
           ref={ref}
           checked={!!isChecked}
-          onClick={handleClick}
           role="checkbox"
           aria-checked={checked}
+          onClick={handleClick}
+          // suppress read-only error as we rely on click rather than change event here
+          onChange={noop}
         />
         <FauxCheckbox>
           {checked === 'mixed' ? <CheckMarkMixed /> : <CheckMark />}

--- a/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,108 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Checkbox checked set to false 1`] = `
-.c2 {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border: solid 1px #DEE1E5;
-  border-radius: 0.125rem;
-  color: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 {
-  position: relative;
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  margin: 3px;
-  vertical-align: middle;
-}
-
-.c0 input[type='checkbox'] {
-  opacity: 0;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.c0 .c1 {
-  background: #FFFFFF;
-  border-color: #DEE1E5;
-  color: #FFFFFF;
-}
-
-.c0 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c0 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
-.c3 .c1 {
-  background: #6C43E0;
-  border-color: #6C43E0;
-  color: #FFFFFF;
-}
-
-.c3 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c3 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
-<div
-  className="c0 "
->
-  <input
-    aria-checked={false}
-    checked={false}
-    className=""
-    role="checkbox"
-    type="checkbox"
-  />
-  <div
-    className="c1 c2"
-  >
-    <svg
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M4 8L7 11L12 4"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-      />
-    </svg>
-  </div>
-</div>
-`;
-
 exports[`Checkbox checked set to mixed 1`] = `
 .c2 {
   position: relative;
@@ -126,8 +23,8 @@ exports[`Checkbox checked set to mixed 1`] = `
 }
 
 .c3 .c1 {
-  background: #FFFFFF;
-  border-color: #DEE1E5;
+  background: #6C43E0;
+  border-color: #6C43E0;
   color: #FFFFFF;
 }
 
@@ -159,8 +56,8 @@ exports[`Checkbox checked set to mixed 1`] = `
 }
 
 .c0 .c1 {
-  background: #6C43E0;
-  border-color: #6C43E0;
+  background: #FFFFFF;
+  border-color: #DEE1E5;
   color: #FFFFFF;
 }
 
@@ -175,13 +72,15 @@ exports[`Checkbox checked set to mixed 1`] = `
 }
 
 <div
-  checked="mixed"
+  checked={false}
   className="c0 "
 >
   <input
     aria-checked="mixed"
     checked={false}
     className=""
+    onChange={[Function]}
+    onClick={[Function]}
     role="checkbox"
     type="checkbox"
   />
@@ -213,195 +112,6 @@ exports[`Checkbox checked set to mixed 1`] = `
 </div>
 `;
 
-exports[`Checkbox checked set to true 1`] = `
-.c2 {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border: solid 1px #DEE1E5;
-  border-radius: 0.125rem;
-  color: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c3 .c1 {
-  background: #FFFFFF;
-  border-color: #DEE1E5;
-  color: #FFFFFF;
-}
-
-.c3 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c3 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
-.c0 {
-  position: relative;
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  margin: 3px;
-  vertical-align: middle;
-}
-
-.c0 input[type='checkbox'] {
-  opacity: 0;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.c0 .c1 {
-  background: #6C43E0;
-  border-color: #6C43E0;
-  color: #FFFFFF;
-}
-
-.c0 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c0 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
-<div
-  checked={true}
-  className="c0 "
->
-  <input
-    aria-checked={true}
-    checked={true}
-    className=""
-    role="checkbox"
-    type="checkbox"
-  />
-  <div
-    className="c1 c2"
-  >
-    <svg
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M4 8L7 11L12 4"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-      />
-    </svg>
-  </div>
-</div>
-`;
-
-exports[`Checkbox default 1`] = `
-.c2 {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border: solid 1px #DEE1E5;
-  border-radius: 0.125rem;
-  color: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 {
-  position: relative;
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  margin: 3px;
-  vertical-align: middle;
-}
-
-.c0 input[type='checkbox'] {
-  opacity: 0;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.c0 .c1 {
-  background: #FFFFFF;
-  border-color: #DEE1E5;
-  color: #FFFFFF;
-}
-
-.c0 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c0 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
-<div
-  className="c0 "
->
-  <input
-    className=""
-    role="checkbox"
-    type="checkbox"
-  />
-  <div
-    className="c1 c2"
-  >
-    <svg
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M4 8L7 11L12 4"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-      />
-    </svg>
-  </div>
-</div>
-`;
-
 exports[`Checkbox should accept disabled 1`] = `
 .c2 {
   position: relative;
@@ -424,6 +134,22 @@ exports[`Checkbox should accept disabled 1`] = `
   align-items: center;
 }
 
+.c3 .c1 {
+  background: #6C43E0;
+  border-color: #6C43E0;
+  color: #FFFFFF;
+}
+
+.c3 input[type='checkbox']:focus + .c1 {
+  border-color: #9785F2;
+  box-shadow: 0 0 0 2px #E8E5FF;
+  outline: none;
+}
+
+.c3 input[type='checkbox']:disabled + .c1 {
+  opacity: 0.5;
+}
+
 .c0 {
   position: relative;
   display: inline-block;
@@ -457,28 +183,16 @@ exports[`Checkbox should accept disabled 1`] = `
   opacity: 0.5;
 }
 
-.c3 .c1 {
-  background: #6C43E0;
-  border-color: #6C43E0;
-  color: #FFFFFF;
-}
-
-.c3 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c3 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
 <div
+  checked={false}
   className="c0 "
 >
   <input
+    checked={false}
     className=""
     disabled={true}
+    onChange={[Function]}
+    onClick={[Function]}
     role="checkbox"
     type="checkbox"
   />
@@ -526,6 +240,22 @@ exports[`Checkbox with aria-describedby 1`] = `
   align-items: center;
 }
 
+.c3 .c1 {
+  background: #6C43E0;
+  border-color: #6C43E0;
+  color: #FFFFFF;
+}
+
+.c3 input[type='checkbox']:focus + .c1 {
+  border-color: #9785F2;
+  box-shadow: 0 0 0 2px #E8E5FF;
+  outline: none;
+}
+
+.c3 input[type='checkbox']:disabled + .c1 {
+  opacity: 0.5;
+}
+
 .c0 {
   position: relative;
   display: inline-block;
@@ -559,28 +289,16 @@ exports[`Checkbox with aria-describedby 1`] = `
   opacity: 0.5;
 }
 
-.c3 .c1 {
-  background: #6C43E0;
-  border-color: #6C43E0;
-  color: #FFFFFF;
-}
-
-.c3 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c3 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
 <div
+  checked={false}
   className="c0 "
 >
   <input
     aria-describedby="some-id"
+    checked={false}
     className=""
+    onChange={[Function]}
+    onClick={[Function]}
     role="checkbox"
     type="checkbox"
   />
@@ -628,6 +346,22 @@ exports[`Checkbox with name and id 1`] = `
   align-items: center;
 }
 
+.c3 .c1 {
+  background: #6C43E0;
+  border-color: #6C43E0;
+  color: #FFFFFF;
+}
+
+.c3 input[type='checkbox']:focus + .c1 {
+  border-color: #9785F2;
+  box-shadow: 0 0 0 2px #E8E5FF;
+  outline: none;
+}
+
+.c3 input[type='checkbox']:disabled + .c1 {
+  opacity: 0.5;
+}
+
 .c0 {
   position: relative;
   display: inline-block;
@@ -661,29 +395,17 @@ exports[`Checkbox with name and id 1`] = `
   opacity: 0.5;
 }
 
-.c3 .c1 {
-  background: #6C43E0;
-  border-color: #6C43E0;
-  color: #FFFFFF;
-}
-
-.c3 input[type='checkbox']:focus + .c1 {
-  border-color: #9785F2;
-  box-shadow: 0 0 0 2px #E8E5FF;
-  outline: none;
-}
-
-.c3 input[type='checkbox']:disabled + .c1 {
-  opacity: 0.5;
-}
-
 <div
+  checked={false}
   className="c0 "
 >
   <input
+    checked={false}
     className=""
     id="Chucky"
     name="Chuck"
+    onChange={[Function]}
+    onClick={[Function]}
     role="checkbox"
     type="checkbox"
   />

--- a/packages/playground/src/Checkbox/CheckboxDemo.tsx
+++ b/packages/playground/src/Checkbox/CheckboxDemo.tsx
@@ -1,14 +1,19 @@
 /*
+
  MIT License
+
  Copyright (c) 2020 Looker Data Sciences, Inc.
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -16,6 +21,7 @@
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
+
  */
 
 import React, { useState } from 'react'

--- a/packages/playground/src/Checkbox/CheckboxDemo.tsx
+++ b/packages/playground/src/Checkbox/CheckboxDemo.tsx
@@ -1,19 +1,14 @@
 /*
-
  MIT License
-
  Copyright (c) 2020 Looker Data Sciences, Inc.
-
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,29 +16,28 @@
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
-
  */
 
-import React from 'react'
-import ReactDOM from 'react-dom'
-import { ComponentsProvider, GlobalStyle } from '@looker/components'
-import { MixedStateCheckboxDemo } from './Checkbox/MixedStateCheckboxDemo'
-import { CheckboxDemo } from './Checkbox/CheckboxDemo'
+import React, { useState } from 'react'
+import { Checkbox, Heading } from '@looker/components'
 
-const App: React.FC = () => {
+/* eslint-disable sort-keys */
+export const CheckboxDemo = () => {
+  const [controlledChecked, setControlledChecked] = useState(true)
+  const handleChange = () => setControlledChecked(!controlledChecked)
   return (
-    <ComponentsProvider>
-      <GlobalStyle />
-      <CheckboxDemo />
-      <MixedStateCheckboxDemo />
-    </ComponentsProvider>
+    <>
+      <div>
+        <Heading mt="small">defaultChecked</Heading>
+        <Checkbox defaultChecked></Checkbox>
+      </div>
+      <div>
+        <Heading mt="small">Controlled component</Heading>
+        <Checkbox
+          checked={controlledChecked}
+          onChange={handleChange}
+        ></Checkbox>
+      </div>
+    </>
   )
 }
-
-/*
-  This is the binding site for the playground. If you want to edit the
-  primary application, do your work in App.tsx instead.
- */
-document.addEventListener('DOMContentLoaded', () => {
-  ReactDOM.render(<App />, document.getElementById('container'))
-})

--- a/packages/playground/src/Checkbox/MixedStateCheckboxDemo.tsx
+++ b/packages/playground/src/Checkbox/MixedStateCheckboxDemo.tsx
@@ -33,6 +33,7 @@ import {
   MixedBoolean,
   CheckboxTree,
   useMixedStateCheckbox,
+  Heading,
 } from '@looker/components'
 
 /* eslint-disable sort-keys */
@@ -64,6 +65,7 @@ export const MixedStateCheckboxDemo = () => {
 
   return (
     <>
+      <Heading mt="small">Mixed State Checkbox</Heading>
       <List p="large">
         <ListItem>
           <Checkbox


### PR DESCRIPTION
### :sparkles: Changes

This PR updates checkbox state to allow defaultChecked to behave more like the standard html element. The checkbox will initially display as checked, but it will allow you to toggle the state without an onchange handler

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] PR is ideally < 400LOC
- [ ] Link(s) to related Github issues

### :camera: Screenshots

#### BEFORE (broken):
![checkbox-before](https://user-images.githubusercontent.com/238293/79016979-1d12d000-7b25-11ea-826c-d19dd1100088.gif)

#### AFTER (fixed):
![checkbox-after](https://user-images.githubusercontent.com/238293/79016985-213eed80-7b25-11ea-86fa-4c0210585fbd.gif)

