### PR TITLE
update InlineInputText to have the correct import path for pick

### DIFF
--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import pick from 'lodash/omit'
+import pick from 'lodash/pick'
 import React, { forwardRef, Ref } from 'react'
 import isFunction from 'lodash/isFunction'
 import styled from 'styled-components'

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`InlineInputText renders an input with the correct styling 1`] = `
     className="c1"
     onChange={[Function]}
     size={1}
-    title="type something"
     type="text"
     value=""
   />


### PR DESCRIPTION
### :sparkles: Changes

-  update InlineInputText to have the correct import path for pick
<img width="353" alt="Screen Shot 2020-04-15 at 2 16 05 PM" src="https://user-images.githubusercontent.com/23616264/79389754-7dd64a00-7f23-11ea-9cd7-a9a0f7d4395a.png">

