### PR TITLE
Deprecate customizable input attribute support

### DIFF
--- a/packages/components/src/Button/ButtonBase.tsx
+++ b/packages/components/src/Button/ButtonBase.tsx
@@ -26,8 +26,6 @@
 
 import {
   CompatibleHTMLProps,
-  radii,
-  RadiusSizes,
   reset,
   SemanticColors,
   space,
@@ -46,14 +44,6 @@ import {
 } from 'styled-system'
 import { buttonSize, ButtonSizes, ButtonSizeProps } from './size'
 import { ButtonIcon, buttonIcon, ButtonIconProps } from './icon'
-
-export interface CustomizableButtonAttributes {
-  borderRadius: RadiusSizes
-}
-
-export const CustomizableButtonAttributes: CustomizableButtonAttributes = {
-  borderRadius: 'medium',
-}
 
 type ButtonColors = keyof SemanticColors
 
@@ -105,7 +95,7 @@ export const buttonCSS = css<ButtonBaseProps>`
   `}
 
   align-items: center;
-  border-radius: ${radii[CustomizableButtonAttributes.borderRadius]};
+  border-radius: ${({ theme }) => theme.radii.medium};
   cursor: pointer;
   display: inline-flex;
   font-weight: 600;

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -148,15 +148,19 @@ const InputArea = styled.div``
 const MessageArea = styled.div``
 
 export const Field = styled(FieldLayout)`
+  height: fit-content;
+  width: ${({ width }) => width || 'fit-content'};
   align-items: left;
+  justify-content: space-between;
+  margin-bottom: ${({ theme }) => theme.space.xsmall};
+
   display: grid;
   grid-template-areas: ${({ inline }) =>
     inline
       ? '"label input detail" ". messages messages"'
       : '"label detail" "input input" "messages messages"'};
-  height: fit-content;
-  justify-content: space-between;
-  width: ${({ width }) => width || 'fit-content'};
+  grid-template-columns: ${({ inline, labelWidth }) =>
+    inline ? `${labelWidth} 1fr` : undefined};
 
   ${InputArea} {
     display: flex;
@@ -173,16 +177,16 @@ export const Field = styled(FieldLayout)`
     ${({ inline, theme }) =>
       inline
         ? `
-        height: ${inputHeight};
-        justify-self: end;
-        line-height: ${inputHeight};
-        padding-right: ${theme.space.small};
-        width: 150px;
-        `
+      text-align: right;
+      line-height: ${inputHeight};
+      justify-self: end;
+      height: ${inputHeight};
+      padding-right: ${theme.space.small};
+      `
         : `
         padding-bottom: ${theme.space.xsmall};
 
-        `}
+      `}
   }
 
   ${FieldDetail} {

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -27,7 +27,6 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 import styled from 'styled-components'
 import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
-import { CustomizableAttributes, SpacingSizes } from '@looker/design-tokens'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
 import { inputHeight } from '../Inputs/InputText/InputText'
@@ -38,15 +37,6 @@ import { ValidationMessage } from '../ValidationMessage'
 import { FieldBaseProps, RequiredStar } from './FieldBase'
 
 type ResponsiveSpaceValue = ResponsiveValue<TLengthStyledSystem>
-
-export interface CustomizableFieldAttributesInterface
-  extends CustomizableAttributes {
-  labelMargin: SpacingSizes
-}
-
-export const CustomizableFieldAttributes: CustomizableFieldAttributesInterface = {
-  labelMargin: 'xsmall',
-}
 
 export interface FieldProps extends FieldBaseProps {
   /*

--- a/packages/components/src/Form/Fields/FieldColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/Swatch/Swatch.tsx
@@ -35,7 +35,6 @@ import {
   WidthProps,
 } from 'styled-system'
 import {
-  CustomizableInputTextAttributes,
   inputTextDefaults,
   inputTextDisabled,
   inputTextHover,
@@ -70,8 +69,7 @@ export const Swatch = styled.div<SwatchProps>`
 `
 
 Swatch.defaultProps = {
-  ...inputTextDefaults,
-  ...omit(CustomizableInputTextAttributes, 'fontSize'),
+  ...omit(inputTextDefaults, 'fontSize'),
   color: 'white',
-  width: CustomizableInputTextAttributes.height,
+  width: inputTextDefaults.height,
 }

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -26,15 +26,9 @@
 
 import React, { FC } from 'react'
 import styled from 'styled-components'
-import { CustomizableAttributes, SpacingSizes } from '@looker/design-tokens'
 import { Label } from '../Label/Label'
 import { ValidationMessage } from '../ValidationMessage/ValidationMessage'
 import { FieldBaseProps, RequiredStar } from './FieldBase'
-
-export interface CustomizableFieldAttributesInterface
-  extends CustomizableAttributes {
-  labelMargin: SpacingSizes
-}
 
 /**
  * `<FieldInline />` allows the rendering of a label (for FieldCheckbox, FieldRadio and FieldToggleSwitch),

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`A FieldSelect 1`] = `
 }
 
 .c5 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
   width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -82,11 +82,11 @@ exports[`A FieldSelect 1`] = `
 }
 
 .c10 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;
@@ -281,13 +281,13 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
 }
 
 .c5 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
   width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -353,11 +353,11 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
 }
 
 .c10 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;
@@ -597,13 +597,13 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
 }
 
 .c5 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
   width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -669,11 +669,11 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
 }
 
 .c10 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;
@@ -913,13 +913,13 @@ exports[`A required FieldSelect 1`] = `
 }
 
 .c6 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
   width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -985,11 +985,11 @@ exports[`A required FieldSelect 1`] = `
 }
 
 .c11 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;
@@ -1196,13 +1196,13 @@ exports[`FieldSelect supports labelWeight 1`] = `
 }
 
 .c5 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
   width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1268,11 +1268,11 @@ exports[`FieldSelect supports labelWeight 1`] = `
 }
 
 .c10 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -107,20 +107,21 @@ exports[`A FieldSelect 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c3 {
@@ -382,20 +383,21 @@ exports[`A FieldSelect with an error validation aligned to the left 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c3 {
@@ -697,20 +699,21 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c3 {
@@ -1011,20 +1014,21 @@ exports[`A required FieldSelect 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c4 {
@@ -1289,20 +1293,21 @@ exports[`FieldSelect supports labelWeight 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c3 {

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -59,11 +59,11 @@ exports[`A FieldText with default label 1`] = `
 }
 
 .c5 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -214,11 +214,11 @@ exports[`A FieldText with label inline 1`] = `
 }
 
 .c5 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -80,20 +80,21 @@ exports[`A FieldText with default label 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c3 {
@@ -251,20 +252,22 @@ exports[`A FieldText with label inline 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label input detail" ". messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label input detail" ". messages messages";
+  grid-template-columns: 150px 1fr;
 }
 
 .c0 .c3 {
@@ -281,11 +284,11 @@ exports[`A FieldText with label inline 1`] = `
 
 .c0 .c1 {
   grid-area: label;
-  height: 36px;
-  justify-self: end;
+  text-align: right;
   line-height: 36px;
+  justify-self: end;
+  height: 36px;
   padding-right: 0.75rem;
-  width: 150px;
 }
 
 .c0 .c9 {

--- a/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
@@ -47,20 +47,21 @@ exports[`A FieldTextArea with default label 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c0 .c3 {
@@ -181,20 +182,22 @@ exports[`A FieldTextArea with label inline 1`] = `
 }
 
 .c0 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label input detail" ". messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label input detail" ". messages messages";
+  grid-template-columns: 150px 1fr;
 }
 
 .c0 .c3 {
@@ -211,11 +214,11 @@ exports[`A FieldTextArea with label inline 1`] = `
 
 .c0 .c1 {
   grid-area: label;
-  height: 36px;
-  justify-self: end;
+  text-align: right;
   line-height: 36px;
+  justify-self: end;
+  height: 36px;
   padding-right: 0.75rem;
-  width: 150px;
 }
 
 .c0 .c9 {

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`A FieldToggleSwitch 1`] = `
-.c7 {
+.c6 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -13,7 +13,7 @@ exports[`A FieldToggleSwitch 1`] = `
   background: #FFFFFF;
 }
 
-.c6 {
+.c5 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -23,20 +23,6 @@ exports[`A FieldToggleSwitch 1`] = `
   right: 0;
   border-radius: 1.25rem;
   background: #C1C6CC;
-}
-
-.c6:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
-}
-
-.c5 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
 }
 
 .c4 {
@@ -49,6 +35,13 @@ exports[`A FieldToggleSwitch 1`] = `
 
 .c4 input {
   cursor: pointer;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .c4 input:focus + div {
@@ -83,7 +76,7 @@ exports[`A FieldToggleSwitch 1`] = `
   padding-left: 0.5rem;
 }
 
-.c0 .c8 {
+.c0 .c7 {
   grid-area: messages;
   padding-left: 0.75rem;
 }
@@ -106,28 +99,28 @@ exports[`A FieldToggleSwitch 1`] = `
       className="c4 "
     >
       <input
-        className="c5"
         id="FieldToggleSwitchID"
         role="switch"
         type="checkbox"
       />
       <div
-        className="c6"
+        className="c5"
       >
         <div
-          className="c7"
+          className="c6"
+          size={20}
         />
       </div>
     </div>
   </div>
   <div
-    className="c8 "
+    className="c7 "
   />
 </label>
 `;
 
 exports[`A FieldToggleSwitch turned on 1`] = `
-.c7 {
+.c6 {
   -webkit-transform: translateX(0.9375rem);
   -ms-transform: translateX(0.9375rem);
   transform: translateX(0.9375rem);
@@ -142,7 +135,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   background: #FFFFFF;
 }
 
-.c6 {
+.c5 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -152,20 +145,6 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   right: 0;
   border-radius: 1.25rem;
   background: #6C43E0;
-}
-
-.c6:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
-}
-
-.c5 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
 }
 
 .c4 {
@@ -178,6 +157,13 @@ exports[`A FieldToggleSwitch turned on 1`] = `
 
 .c4 input {
   cursor: pointer;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .c4 input:focus + div {
@@ -212,7 +198,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   padding-left: 0.5rem;
 }
 
-.c0 .c8 {
+.c0 .c7 {
   grid-area: messages;
   padding-left: 0.75rem;
 }
@@ -237,22 +223,23 @@ exports[`A FieldToggleSwitch turned on 1`] = `
       <input
         aria-checked={true}
         checked={true}
-        className="c5"
         id="FieldToggleSwitchID"
         role="switch"
         type="checkbox"
       />
       <div
-        className="c6"
+        className="c5"
       >
         <div
-          className="c7"
+          className="c6"
+          on={true}
+          size={20}
         />
       </div>
     </div>
   </div>
   <div
-    className="c8 "
+    className="c7 "
   />
 </label>
 `;

--- a/packages/components/src/Form/Fields/RequiredStar.tsx
+++ b/packages/components/src/Form/Fields/RequiredStar.tsx
@@ -1,0 +1,46 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, { FC } from 'react'
+import styled from 'styled-components'
+import { VisuallyHidden } from '../../VisuallyHidden'
+
+interface RequiredStarProps {
+  className?: string
+}
+
+const RequiredStarLayout: FC<RequiredStarProps> = ({ className }) => (
+  <>
+    <span aria-hidden="true" className={className}>
+      *
+    </span>
+    <VisuallyHidden>required</VisuallyHidden>
+  </>
+)
+
+export const RequiredStar = styled(RequiredStarLayout)`
+  color: ${(props) => props.theme.colors.palette.red500};
+`

--- a/packages/components/src/Form/Fieldset/Legend.tsx
+++ b/packages/components/src/Form/Fieldset/Legend.tsx
@@ -29,29 +29,16 @@ import {
   color,
   ColorProps,
   CompatibleHTMLProps,
-  CustomizableAttributes,
   layout,
   LayoutProps,
   reset,
   space,
   SpaceProps,
-  SpacingSizes,
   textTransform,
   TextTransformProps,
   typography,
   TypographyProps,
 } from '@looker/design-tokens'
-
-export interface CustomizableLegendAttributes extends CustomizableAttributes {
-  bottomPadding: SpacingSizes
-}
-
-export const CustomizableLegendAttributes: CustomizableLegendAttributes = {
-  bottomPadding: 'xsmall',
-  color: 'palette.charcoal800',
-  fontSize: 'xxxlarge',
-  fontWeight: 'light',
-}
 
 export interface LegendProps
   extends ColorProps,
@@ -62,13 +49,7 @@ export interface LegendProps
     CompatibleHTMLProps<HTMLLegendElement> {}
 
 export const Legend = styled.legend.attrs((props: LegendProps) => ({
-  color: props.color || CustomizableLegendAttributes.color,
-  fontSize: props.fontSize || CustomizableLegendAttributes.fontSize,
-  fontWeight: props.fontWeight || CustomizableLegendAttributes.fontWeight,
-  pb:
-    props.pb || props.py || props.p
-      ? undefined
-      : CustomizableLegendAttributes.bottomPadding,
+  pb: props.pb || props.py || props.p ? undefined : 'xsmall',
 }))<LegendProps>`
   ${reset}
 
@@ -78,3 +59,9 @@ export const Legend = styled.legend.attrs((props: LegendProps) => ({
   ${textTransform};
   ${typography}
 `
+
+Legend.defaultProps = {
+  color: 'palette.charcoal800',
+  fontSize: 'xxxlarge',
+  fontWeight: 'light',
+}

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -80,20 +80,21 @@ exports[`Fieldset with left aligned legend 1`] = `
 }
 
 .c3 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c3 .c6 {

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -59,11 +59,11 @@ exports[`Fieldset with left aligned legend 1`] = `
 }
 
 .c8 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;

--- a/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
+++ b/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
@@ -32,16 +32,22 @@ import min from 'lodash/min'
 import max from 'lodash/max'
 import isEqual from 'lodash/isEqual'
 import values from 'lodash/values'
-import { border, SpaceProps, color, space } from '@looker/design-tokens'
+import {
+  border,
+  SpaceProps,
+  color,
+  space,
+  BorderProps,
+  ColorProps,
+} from '@looker/design-tokens'
 import { ValidationType } from '../../ValidationMessage'
 
 import {
   InputText,
+  inputTextDefaults,
   inputTextHover,
   inputTextFocus,
-  inputTextDefaults,
   inputTextValidation,
-  CustomizableInputTextAttributes,
 } from '../InputText'
 import { Calendar } from '../../../Calendar'
 import {
@@ -398,12 +404,15 @@ const MultiCalendarLayout = styled.div<SpaceProps>`
   grid-column-gap: ${({ theme }) => theme.space.large};
 `
 
-const InputTextWrapper = styled.div.attrs({
-  ...inputTextDefaults,
-  ...CustomizableInputTextAttributes,
-})<{ active: boolean; validationType?: 'error' }>`
+interface InputTextWrapperProps extends BorderProps, ColorProps {
+  active: boolean
+  validationType?: 'error'
+}
+
+const InputTextWrapper = styled.div<InputTextWrapperProps>`
   ${border}
   ${color}
+
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
@@ -428,6 +437,10 @@ const InputTextWrapper = styled.div.attrs({
     background: transparent;
   }
 `
+
+InputTextWrapper.defaultProps = {
+  ...inputTextDefaults,
+}
 
 const CalendarWrapper = styled.div`
   ${Calendar} {

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
@@ -39,7 +39,6 @@ import styled from 'styled-components'
 import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
 import { inputPropKeys } from '../InputProps'
 import {
-  CustomizableInputTextAttributes,
   InputText,
   InputTextProps,
   inputTextDefaults,
@@ -64,7 +63,7 @@ const getHeight = (
     typeof py === 'number'
       ? `${((py || 0) + 1) * 2}px`
       : `(${String(py)} * 2) - 2px`
-  return `calc(${CustomizableInputTextAttributes.height} - ${verticalSpace})`
+  return `calc(${inputTextDefaults.height} - ${verticalSpace})`
 }
 
 export interface InputSearchProps extends InputTextProps {
@@ -261,8 +260,7 @@ export const InputSearch = styled(InputSearchComponent)`
 `
 
 InputSearch.defaultProps = {
-  ...omit(CustomizableInputTextAttributes, ['height', 'px']),
-  ...inputTextDefaults,
+  ...omit(inputTextDefaults, ['height', 'px']),
   pr: 'xxsmall',
   py: 2,
 }

--- a/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
@@ -2,12 +2,13 @@
 
 exports[`InputSearch default 1`] = `
 .c0 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
+  width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -86,11 +87,11 @@ exports[`InputSearch default 1`] = `
 }
 
 .c6 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;
@@ -153,6 +154,7 @@ exports[`InputSearch default 1`] = `
   className="c0 c1"
   fontSize="small"
   onMouseDown={[Function]}
+  width="100%"
 >
   <div
     className="c2 c3"
@@ -188,12 +190,13 @@ exports[`InputSearch default 1`] = `
 
 exports[`InputSearch hideSearchIcon removes the icon 1`] = `
 .c0 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
+  border-radius: 0.25rem;
+  width: 100%;
+  padding-right: 0.25rem;
   padding-top: 2px;
   padding-bottom: 2px;
-  padding-right: 0.25rem;
   font-size: 0.875rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -259,11 +262,11 @@ exports[`InputSearch hideSearchIcon removes the icon 1`] = `
 }
 
 .c4 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   padding-top: 0rem;
@@ -321,6 +324,7 @@ exports[`InputSearch hideSearchIcon removes the icon 1`] = `
   className="c0 c1"
   fontSize="small"
   onMouseDown={[Function]}
+  width="100%"
 >
   <div
     className="c2 c3 c4"

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -32,7 +32,6 @@ import {
   typography,
   layout,
   LayoutProps,
-  CustomizableAttributes,
   pseudoClasses,
   PseudoProps,
   space,
@@ -40,6 +39,7 @@ import {
   TypographyProps,
   reset,
   color,
+  FontSizes,
 } from '@looker/design-tokens'
 import { IconNames } from '@looker/icons'
 import React, { forwardRef, Ref, useRef } from 'react'
@@ -49,14 +49,6 @@ import { Flex } from '../../../Layout'
 import { Icon } from '../../../Icon/Icon'
 import { Text } from '../../../Text/Text'
 import { useForkedRef } from '../../../utils'
-
-export const CustomizableInputTextAttributes: CustomizableAttributes = {
-  borderRadius: 'medium',
-  fontSize: 'small',
-  height: '36px',
-  px: 'small',
-  py: 'none',
-}
 
 export interface InputTextProps
   extends BorderProps,
@@ -104,13 +96,13 @@ const InputComponent = forwardRef(
   ) => {
     if (iconBefore && prefix) {
       // eslint-disable-next-line no-console
-      console.warn(`Only use IconBefore or Prefix not both at the same time. `)
+      console.warn(`Only use IconBefore or prefix not both at the same time. `)
       return null
     }
 
     if (iconAfter && suffix) {
       // eslint-disable-next-line no-console
-      console.warn(`Only use IconAfter or Suffix not both at the same time. `)
+      console.warn(`Only use IconAfter or suffix not both at the same time. `)
       return null
     }
 
@@ -232,8 +224,8 @@ export const inputTextValidation = css<{ validationType?: 'error' }>`
 export const InputText = styled(InputComponent).attrs(
   (props: InputTextProps) => {
     const padding: SpaceProps = {
-      px: props.px || props.p || CustomizableInputTextAttributes.px,
-      py: props.py || props.p || CustomizableInputTextAttributes.py,
+      px: props.px || props.p || 'small',
+      py: props.py || props.p || 'none',
     }
     if (props.prefix || props.iconBefore) {
       padding.pl = 'xsmall'
@@ -262,11 +254,13 @@ export const InputText = styled(InputComponent).attrs(
 export const inputTextDefaults = {
   border: 'solid 1px',
   borderColor: 'palette.charcoal200',
+  borderRadius: 'medium',
+  fontSize: 'small' as FontSizes,
+  height: '36px',
+  width: '100%',
 }
 
 InputText.defaultProps = {
-  width: '100%',
-  ...CustomizableInputTextAttributes,
   ...inputTextDefaults,
   type: 'text',
 }

--- a/packages/components/src/Form/Inputs/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputText/__snapshots__/InputText.test.tsx.snap
@@ -59,11 +59,11 @@ exports[`InputText default 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -141,11 +141,11 @@ exports[`InputText should accept disabled 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -230,11 +230,11 @@ exports[`InputText should accept readOnly 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -313,11 +313,11 @@ exports[`InputText should accept required 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -396,11 +396,11 @@ exports[`InputText with a placeholder 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -479,11 +479,11 @@ exports[`InputText with a value 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -586,11 +586,11 @@ exports[`InputText with an error validation 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -703,11 +703,11 @@ exports[`InputText with aria-describedby 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;
@@ -786,11 +786,11 @@ exports[`InputText with name and id 1`] = `
 }
 
 .c1 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -49,12 +49,11 @@ import {
 } from '@looker/design-tokens'
 import {
   InputText,
+  inputTextDefaults,
   inputTextHover,
   inputTextFocus,
   inputTextDisabled,
   inputTextValidation,
-  inputTextDefaults,
-  CustomizableInputTextAttributes,
 } from '../InputText'
 import {
   formatTimeString,
@@ -523,10 +522,7 @@ const InternalInputTime: FC<InputTimeProps> = ({
   )
 }
 
-export const InputTime = styled(InternalInputTime).attrs({
-  ...inputTextDefaults,
-  ...CustomizableInputTextAttributes,
-})`
+export const InputTime = styled(InternalInputTime)`
   ${reset}
   ${border}
   ${space}
@@ -546,6 +542,10 @@ export const InputTime = styled(InternalInputTime).attrs({
 
   ${inputTextValidation}
 `
+
+InputTime.defaultProps = {
+  ...inputTextDefaults,
+}
 
 const InputTimeWrapper = styled.div<{
   hasInputValues: boolean

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -26,7 +26,6 @@
 
 import React, { forwardRef, Ref, FormEvent } from 'react'
 import styled from 'styled-components'
-import { CustomizableAttributes } from '@looker/design-tokens'
 import { ValidationType } from '../../ValidationMessage'
 import {
   Combobox,
@@ -40,14 +39,6 @@ import {
   SelectOptionsBaseProps,
 } from './SelectOptions'
 import { getOption, getFirstOption } from './utils/options'
-
-export const CustomizableSelectAttributes: CustomizableAttributes = {
-  borderRadius: 'medium',
-  fontSize: 'small',
-  height: '28px',
-  px: 'xsmall',
-  py: 'none',
-}
 
 export interface SelectBaseProps extends SelectOptionsBaseProps {
   placeholder?: string

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -26,7 +26,6 @@
 
 import React, { forwardRef, KeyboardEvent, Ref } from 'react'
 import styled from 'styled-components'
-import { CustomizableAttributes } from '@looker/design-tokens'
 import {
   ComboboxMulti,
   ComboboxMultiInput,
@@ -40,14 +39,6 @@ import {
   SelectOptions,
 } from './SelectOptions'
 import { getOptions } from './utils/options'
-
-export const CustomizableSelectMultiAttributes: CustomizableAttributes = {
-  borderRadius: 'medium',
-  fontSize: 'small',
-  height: '28px',
-  px: 'xsmall',
-  py: 'none',
-}
 
 export interface SelectMultiProps
   extends Omit<ComboboxMultiProps, 'values' | 'defaultValues' | 'onChange'>,

--- a/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
@@ -1,0 +1,84 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { rem, rgba } from 'polished'
+import React, { FC } from 'react'
+import styled from 'styled-components'
+import { reset } from '@looker/design-tokens'
+
+export interface KnobProps {
+  size: number
+  disabled?: boolean
+  on?: boolean
+}
+
+const Knob = styled.div<KnobProps>`
+  transform: ${({ on, size }) => (on ? `translateX(${rem(size * 0.75)})` : '')};
+  transition: ${({ theme }) => theme.transitions.durationModerate};
+  position: absolute;
+  bottom: ${({ size }) => rem(size * 0.1)};
+  left: ${({ size }) => rem(size * 0.1)};
+  width: ${({ size }) => rem(size * 0.8)};
+  height: ${({ size }) => rem(size * 0.8)};
+  border-radius: 50%;
+  background: ${({ theme }) => theme.colors.palette.white};
+`
+
+interface KnobContainerProps extends KnobProps {
+  className?: string
+}
+
+const KnobContainerLayout: FC<KnobContainerProps> = ({
+  className,
+  ...props
+}) => (
+  <div className={className}>
+    <Knob {...props} />
+  </div>
+)
+
+export const KnobContainer = styled(KnobContainerLayout)<KnobContainerProps>`
+  ${reset}
+
+  transition: ${({ theme }) => theme.transitions.durationModerate};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: ${({ size }) => rem(size)};
+  background: ${({ on, theme }) =>
+    on ? theme.colors.palette.purple400 : theme.colors.palette.charcoal300};
+
+  &:hover {
+    ${({ disabled, theme }) =>
+      disabled &&
+      `box-shadow: 0 0 0.01rem 0.01rem ${rgba(
+        theme.colors.palette.primary500,
+        0.5
+      )}`};
+  }
+`

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
@@ -24,45 +24,13 @@
 
  */
 
+import { reset, space, SpaceProps } from '@looker/design-tokens'
+import pick from 'lodash/pick'
 import { rem, rgba } from 'polished'
-import React, { forwardRef, Ref, ReactNode, FC } from 'react'
+import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import {
-  CustomizableAttributes,
-  palette,
-  PseudoProps,
-  pseudoClasses,
-  reset,
-  space,
-  SpaceProps,
-} from '@looker/design-tokens'
-import { InputProps } from '../InputProps'
-
-export interface CustomizableToggleSwitchAttributes
-  extends CustomizableAttributes {
-  knobOnColor: string
-  knobOffColor: string
-  onColor: string
-  offColor: string
-}
-
-export const CustomizableToggleSwitchAttributes: CustomizableToggleSwitchAttributes = {
-  knobOffColor: palette.white,
-  knobOnColor: palette.white,
-  offColor: palette.charcoal300,
-  onColor: palette.purple400,
-}
-
-export interface KnobProps {
-  className?: string
-  size: number
-  disabled?: boolean
-  on?: boolean
-}
-
-interface KnobContainerBaseProps extends KnobProps, PseudoProps {
-  children: ReactNode
-}
+import { InputProps, inputPropKeys } from '../InputProps'
+import { KnobContainer, KnobProps } from './Knob'
 
 export interface ToggleSwitchProps
   extends SpaceProps,
@@ -70,67 +38,6 @@ export interface ToggleSwitchProps
     Omit<KnobProps, 'size'> {
   size?: number
 }
-
-const Knob = styled(({ className }) => <div className={className} />)`
-  transform: ${(props) =>
-    props.on ? `translateX(${rem(props.size * 0.75)})` : ''};
-  transition: ${(props) => props.theme.transitions.durationModerate};
-  position: absolute;
-  bottom: ${(props) => rem(props.size * 0.1)};
-  left: ${(props) => rem(props.size * 0.1)};
-  width: ${(props) => rem(props.size * 0.8)};
-  height: ${(props) => rem(props.size * 0.8)};
-  border-radius: 50%;
-  background: ${(props) =>
-    props.on
-      ? CustomizableToggleSwitchAttributes.knobOnColor
-      : CustomizableToggleSwitchAttributes.knobOffColor};
-`
-
-const KnobContainer: FC<KnobProps> = ({ className, ...props }) => {
-  const hoverStyle = props.disabled
-    ? undefined
-    : { boxShadow: `0 0 .01rem 0.01rem ${rgba(palette.primary500, 0.5)}` }
-  return (
-    <KnobContainerBase
-      className={className}
-      hoverStyle={hoverStyle}
-      size={props.size}
-      on={props.on}
-    >
-      <Knob {...props} />
-    </KnobContainerBase>
-  )
-}
-
-const KnobContainerBase = styled(({ children, className }) => (
-  <div className={className}>{children}</div>
-))<KnobContainerBaseProps>`
-  ${reset}
-  ${pseudoClasses}
-
-  transition: ${(props) => props.theme.transitions.durationModerate};
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  border-radius: ${(props) => rem(props.size)};
-  background: ${(props) =>
-    props.on
-      ? CustomizableToggleSwitchAttributes.onColor
-      : CustomizableToggleSwitchAttributes.offColor};
-`
-
-const HiddenCheckbox = styled.input.attrs({ type: 'checkbox' })`
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-`
 
 const DisabledKnob = styled.div<{ size: number }>`
   ${reset}
@@ -144,20 +51,21 @@ const DisabledKnob = styled.div<{ size: number }>`
   border-radius: ${(props) => rem(props.size)};
 `
 
-export const ToggleSwitchComponent = forwardRef(
+export const ToggleSwitchLayout = forwardRef(
   (
     { className, disabled, on, size = 20, ...props }: ToggleSwitchProps,
     ref: Ref<HTMLInputElement>
   ) => {
     return (
       <div className={className}>
-        <HiddenCheckbox
+        <input
+          type="checkbox"
           checked={on}
           disabled={disabled}
           role="switch"
           aria-checked={on}
           ref={ref}
-          {...props}
+          {...pick(props, inputPropKeys)}
         />
         <KnobContainer size={size} on={on} disabled={disabled} />
         {disabled && <DisabledKnob size={size} />}
@@ -166,20 +74,31 @@ export const ToggleSwitchComponent = forwardRef(
   }
 )
 
-ToggleSwitchComponent.displayName = 'ToggleSwitchComponent'
+ToggleSwitchLayout.displayName = 'ToggleSwitchLayout'
 
-export const ToggleSwitch = styled(ToggleSwitchComponent)`
+export const ToggleSwitch = styled(ToggleSwitchLayout)`
   ${reset}
-  input {
-    cursor: ${(props) => (!props.disabled ? 'pointer' : undefined)};
-    &:focus + div {
-      box-shadow: 0 0 0 0.2rem ${rgba(palette.primary500, 0.4)};
-    }
-  }
+  ${space}
+
   width: ${(props) => rem((props.size || 20) * 1.75)};
   height: ${(props) => rem(props.size || 20)};
   display: inline-block;
   position: relative;
   vertical-align: middle;
-  ${space}
+
+  input {
+    cursor: ${({ disabled }) => (!disabled ? 'pointer' : undefined)};
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+
+    &:focus + div {
+      box-shadow: 0 0 0 0.2rem
+        ${({ theme }) => rgba(theme.colors.palette.primary500, 0.4)};
+    }
+  }
 `

--- a/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Big ToggleSwitch 1`] = `
-.c3 {
+.c2 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -13,7 +13,7 @@ exports[`Big ToggleSwitch 1`] = `
   background: #FFFFFF;
 }
 
-.c2 {
+.c1 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -23,20 +23,6 @@ exports[`Big ToggleSwitch 1`] = `
   right: 0;
   border-radius: 3.75rem;
   background: #C1C6CC;
-}
-
-.c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
-}
-
-.c1 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
 }
 
 .c0 {
@@ -49,6 +35,13 @@ exports[`Big ToggleSwitch 1`] = `
 
 .c0 input {
   cursor: pointer;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .c0 input:focus + div {
@@ -59,22 +52,22 @@ exports[`Big ToggleSwitch 1`] = `
   className="c0"
 >
   <input
-    className="c1"
     role="switch"
     type="checkbox"
   />
   <div
-    className="c2"
+    className="c1"
   >
     <div
-      className="c3"
+      className="c2"
+      size={60}
     />
   </div>
 </div>
 `;
 
 exports[`ToggleSwitch default 1`] = `
-.c3 {
+.c2 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -86,7 +79,7 @@ exports[`ToggleSwitch default 1`] = `
   background: #FFFFFF;
 }
 
-.c2 {
+.c1 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -96,20 +89,6 @@ exports[`ToggleSwitch default 1`] = `
   right: 0;
   border-radius: 1.25rem;
   background: #C1C6CC;
-}
-
-.c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
-}
-
-.c1 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
 }
 
 .c0 {
@@ -122,6 +101,13 @@ exports[`ToggleSwitch default 1`] = `
 
 .c0 input {
   cursor: pointer;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .c0 input:focus + div {
@@ -132,22 +118,22 @@ exports[`ToggleSwitch default 1`] = `
   className="c0"
 >
   <input
-    className="c1"
     role="switch"
     type="checkbox"
   />
   <div
-    className="c2"
+    className="c1"
   >
     <div
-      className="c3"
+      className="c2"
+      size={20}
     />
   </div>
 </div>
 `;
 
 exports[`ToggleSwitch on set to false 1`] = `
-.c3 {
+.c2 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -159,7 +145,7 @@ exports[`ToggleSwitch on set to false 1`] = `
   background: #FFFFFF;
 }
 
-.c2 {
+.c1 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -169,20 +155,6 @@ exports[`ToggleSwitch on set to false 1`] = `
   right: 0;
   border-radius: 1.25rem;
   background: #C1C6CC;
-}
-
-.c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
-}
-
-.c1 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
 }
 
 .c0 {
@@ -195,6 +167,13 @@ exports[`ToggleSwitch on set to false 1`] = `
 
 .c0 input {
   cursor: pointer;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .c0 input:focus + div {
@@ -207,22 +186,23 @@ exports[`ToggleSwitch on set to false 1`] = `
   <input
     aria-checked={false}
     checked={false}
-    className="c1"
     role="switch"
     type="checkbox"
   />
   <div
-    className="c2"
+    className="c1"
   >
     <div
-      className="c3"
+      className="c2"
+      on={false}
+      size={20}
     />
   </div>
 </div>
 `;
 
 exports[`ToggleSwitch on set to true 1`] = `
-.c3 {
+.c2 {
   -webkit-transform: translateX(0.9375rem);
   -ms-transform: translateX(0.9375rem);
   transform: translateX(0.9375rem);
@@ -237,7 +217,7 @@ exports[`ToggleSwitch on set to true 1`] = `
   background: #FFFFFF;
 }
 
-.c2 {
+.c1 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -247,20 +227,6 @@ exports[`ToggleSwitch on set to true 1`] = `
   right: 0;
   border-radius: 1.25rem;
   background: #6C43E0;
-}
-
-.c2:hover {
-  box-shadow: 0 0 .01rem 0.01rem rgba(79,42,186,0.5);
-}
-
-.c1 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
 }
 
 .c0 {
@@ -273,6 +239,13 @@ exports[`ToggleSwitch on set to true 1`] = `
 
 .c0 input {
   cursor: pointer;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
 }
 
 .c0 input:focus + div {
@@ -285,22 +258,23 @@ exports[`ToggleSwitch on set to true 1`] = `
   <input
     aria-checked={true}
     checked={true}
-    className="c1"
     role="switch"
     type="checkbox"
   />
   <div
-    className="c2"
+    className="c1"
   >
     <div
-      className="c3"
+      className="c2"
+      on={true}
+      size={20}
     />
   </div>
 </div>
 `;
 
 exports[`ToggleSwitch that is disabled 1`] = `
-.c3 {
+.c2 {
   -webkit-transform: translateX(0.9375rem);
   -ms-transform: translateX(0.9375rem);
   transform: translateX(0.9375rem);
@@ -315,7 +289,7 @@ exports[`ToggleSwitch that is disabled 1`] = `
   background: #FFFFFF;
 }
 
-.c2 {
+.c1 {
   -webkit-transition: 300ms;
   transition: 300ms;
   position: absolute;
@@ -327,17 +301,11 @@ exports[`ToggleSwitch that is disabled 1`] = `
   background: #6C43E0;
 }
 
-.c1 {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
+.c1:hover {
+  box-shadow: 0 0 0.01rem 0.01rem rgba(79,42,186,0.5);
 }
 
-.c4 {
+.c3 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -356,6 +324,16 @@ exports[`ToggleSwitch that is disabled 1`] = `
   vertical-align: middle;
 }
 
+.c0 input {
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
 .c0 input:focus + div {
   box-shadow: 0 0 0 0.2rem rgba(79,42,186,0.4);
 }
@@ -366,20 +344,22 @@ exports[`ToggleSwitch that is disabled 1`] = `
   <input
     aria-checked={true}
     checked={true}
-    className="c1"
     disabled={true}
     role="switch"
     type="checkbox"
   />
   <div
-    className="c2"
+    className="c1"
   >
     <div
-      className="c3"
+      className="c2"
+      disabled={true}
+      on={true}
+      size={20}
     />
   </div>
   <div
-    className="c4"
+    className="c3"
     size={20}
   />
 </div>

--- a/packages/components/src/Form/Label/Label.tsx
+++ b/packages/components/src/Form/Label/Label.tsx
@@ -27,7 +27,6 @@
 import styled from 'styled-components'
 import {
   CompatibleHTMLProps,
-  CustomizableAttributes,
   color,
   ColorProps,
   reset,
@@ -41,12 +40,6 @@ import {
   TypographyProps,
 } from '@looker/design-tokens'
 
-export const CustomizableLabelAttributes: CustomizableAttributes = {
-  color: 'palette.charcoal700',
-  fontSize: 'xsmall',
-  fontWeight: 'semiBold',
-}
-
 export interface LabelProps
   extends ColorProps,
     SpaceProps,
@@ -55,11 +48,7 @@ export interface LabelProps
     TypographyProps,
     CompatibleHTMLProps<HTMLLabelElement> {}
 
-export const Label = styled.label.attrs((props: LabelProps) => ({
-  color: props.color || CustomizableLabelAttributes.color,
-  fontSize: props.fontSize || CustomizableLabelAttributes.fontSize,
-  fontWeight: props.fontWeight || CustomizableLabelAttributes.fontWeight,
-}))<LabelProps>`
+export const Label = styled.label<LabelProps>`
   ${reset}
   ${color};
   ${space};
@@ -69,3 +58,9 @@ export const Label = styled.label.attrs((props: LabelProps) => ({
 
   display: inline-block; /* Ensure that applied padding/margin actually works */
 `
+
+Label.defaultProps = {
+  color: 'palette.charcoal700',
+  fontSize: 'xsmall',
+  fontWeight: 'semiBold',
+}

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -81,11 +81,11 @@ exports[`Form with one child 1`] = `
 }
 
 .c6 {
-  border-radius: 0.25rem;
   border: solid 1px;
   border-color: #DEE1E5;
-  width: 100%;
+  border-radius: 0.25rem;
   height: 36px;
+  width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0rem;

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -102,20 +102,21 @@ exports[`Form with one child 1`] = `
 }
 
 .c1 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  width: 100%;
   -webkit-align-items: left;
   -webkit-box-align: left;
   -ms-flex-align: left;
   align-items: left;
-  display: grid;
-  grid-template-areas: "label detail" "input input" "messages messages";
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 100%;
+  margin-bottom: 0.5rem;
+  display: grid;
+  grid-template-areas: "label detail" "input input" "messages messages";
 }
 
 .c1 .c4 {

--- a/packages/components/src/Modal/ModalPortal.tsx
+++ b/packages/components/src/Modal/ModalPortal.tsx
@@ -34,9 +34,7 @@ export interface CustomizableModalAttributes extends CustomizableAttributes {
   zIndex?: number
 }
 
-export const CustomizableModalAttributes: CustomizableModalAttributes = {
-  backdrop: { backgroundColor: 'palette.charcoal200', opacity: 0.6 },
-}
+export const CustomizableModalAttributes: CustomizableModalAttributes = {}
 
 export const ModalPortal = forwardRef(
   ({ children }: { children: ReactNode }, ref: Ref<HTMLDivElement>) => {

--- a/packages/playground/src/Form/FieldsDemo.tsx
+++ b/packages/playground/src/Form/FieldsDemo.tsx
@@ -52,6 +52,7 @@ export const FieldsDemo: FC = () => {
           <FieldText label="Text Input" prefix="$" placeholder="Money" />
           <FieldText label="Text Input" prefix="$" placeholder="MONEY!!!" />
         </Form>
+        <Form>Placeholder</Form>
         <FieldText disabled label="Text Input" placeholder="placeholder" />
         <FieldText
           disabled


### PR DESCRIPTION
### :sparkles: Changes

- Removing support for `Customizable*` overrides in preparation for improved theming flexibility.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [-] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
