### PR TITLE
Close Menu on MenuItem click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Changed
+
+- `Menu` closes by default on `MenuItem` click
+
 ## [0.7.28] - 2020-04-20
 
 ### Added

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -26,11 +26,11 @@
 
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent } from '@testing-library/react'
-import React, { useContext, useRef } from 'react'
+import React, { useRef } from 'react'
 
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Button } from '../Button'
-import { Menu, MenuContext, MenuDisclosure, MenuItem, MenuList } from './'
+import { Menu, MenuDisclosure, MenuItem, MenuList } from './'
 
 const menu = (
   <Menu>
@@ -74,42 +74,42 @@ describe('<Menu />', () => {
     expect(queryByText('Select your favorite kind')).toBeInTheDocument()
   })
 
-  test('Use context to close menu', () => {
+  test('closes on MenuItem click', () => {
     const Closable = () => {
-      const { setOpen } = useContext(MenuContext)
-      const handleClick = () => setOpen && setOpen(false)
+      function handleClick(e: React.MouseEvent<HTMLLIElement>) {
+        e.preventDefault()
+      }
       return (
-        <>
+        <Menu>
           <MenuDisclosure tooltip="Select your favorite kind">
             <Button>Cheese</Button>
           </MenuDisclosure>
           <MenuList>
             <MenuItem icon="FavoriteOutline" onClick={handleClick}>
-              Swiss
+              Gouda
             </MenuItem>
+            <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
           </MenuList>
-        </>
+        </Menu>
       )
     }
-    const menu2 = (
-      <Menu>
-        <Closable />
-      </Menu>
-    )
-    const { getByText, queryByText } = renderWithTheme(menu2)
+    const { getByText } = renderWithTheme(<Closable />)
 
     const button = getByText('Cheese')
-
-    expect(queryByText('Swiss')).not.toBeInTheDocument()
-
     fireEvent.click(button)
 
-    expect(queryByText('Swiss')).toBeInTheDocument()
+    const defaultPreventedItem = getByText('Gouda')
+    const item = getByText('Swiss')
 
-    const fancyItem = getByText('Swiss')
-    fireEvent.click(fancyItem)
+    fireEvent.click(defaultPreventedItem)
 
-    expect(fancyItem).not.toBeInTheDocument()
+    expect(defaultPreventedItem).toBeInTheDocument()
+    expect(item).toBeInTheDocument()
+
+    fireEvent.click(item)
+
+    expect(defaultPreventedItem).not.toBeInTheDocument()
+    expect(item).not.toBeInTheDocument()
   })
 
   test('Disabled Menu does not open when clicked and has disabled prop', () => {

--- a/packages/components/src/Menu/MenuItem/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem/MenuItem.tsx
@@ -35,7 +35,7 @@ import {
 import { IconNames } from '@looker/icons'
 import React, { FC, ReactNode, useContext, useState } from 'react'
 import { Icon } from '../../Icon'
-import { MenuItemStyleContext } from '../MenuContext'
+import { MenuContext, MenuItemStyleContext } from '../MenuContext'
 import { MenuItemButton } from './MenuItemButton'
 import {
   MenuItemCustomization,
@@ -176,9 +176,14 @@ export const MenuItem: FC<MenuItemProps> = (props) => {
     onBlur && onBlur(event)
   }
 
+  const { setOpen } = useContext(MenuContext)
   const handleOnClick = (event: React.MouseEvent<HTMLLIElement>) => {
     setFocusVisible(false)
     onClick && onClick(event)
+    // Close the Menu (unless event has preventDefault in onClick)
+    if (setOpen && !event.defaultPrevented) {
+      setOpen(false)
+    }
   }
 
   const { customizationProps, compact } = useMenuItemStyleContext({

--- a/packages/www/src/documentation/components/overlays/menu.mdx
+++ b/packages/www/src/documentation/components/overlays/menu.mdx
@@ -60,40 +60,25 @@ The `escapeWithReference` and `pin` props allow you to enforce the placement to 
 
 ## Controlled Menu
 
-Control the state of the menu React's `useState` hook,
-and access the `setOpen` function via `MenuContext` from deep within the menu.
-(The latter works on both controlled and uncontrolled usage.)
+Control the state of the menu with React's `useState` hook.
 
 ```jsx
 ;() => {
-  const ExportList = () => {
-    const { setOpen } = React.useContext(MenuContext)
-    handleClick = () => setOpen && setOpen(false)
-    return (
-      <MenuList onClick={handleClick}>
-        <MenuItem icon="Mail">Email</MenuItem>
-        <MenuItem icon="Table">Spreadsheet</MenuItem>
-      </MenuList>
-    )
-  }
-
-  const ExportMenu = () => {
-    const [isOpen, setOpen] = React.useState(false)
-    return (
-      <>
-        <Paragraph pb="medium">
-          {isOpen ? 'Menu Open' : 'Menu Closed'}
-        </Paragraph>
-        <Menu isOpen={isOpen} setOpen={setOpen}>
-          <MenuDisclosure tooltip="Select export format">
-            <Button>Export</Button>
-          </MenuDisclosure>
-          <ExportList />
-        </Menu>
-      </>
-    )
-  }
-  return <ExportMenu />
+  const [isOpen, setOpen] = React.useState(false)
+  return (
+    <>
+      <Menu isOpen={isOpen} setOpen={setOpen}>
+        <MenuDisclosure tooltip="Select export format">
+          <Button mr="medium">Export</Button>
+        </MenuDisclosure>
+        <MenuList>
+          <MenuItem icon="Mail">Email</MenuItem>
+          <MenuItem icon="Table">Spreadsheet</MenuItem>
+        </MenuList>
+      </Menu>
+      {isOpen ? 'Menu Open' : 'Menu Closed'}
+    </>
+  )
 }
 ```
 
@@ -217,19 +202,25 @@ For accessibility reasons, if you want your `MenuItem` to link somewhere then yo
 
 An icon can optionally be assigned to each item via the `icon` property.
 
+**Note:** The `Menu` will close by default when `MenuItem` is clicked, after the `onClick` handler, if there is one. Any component, such as a `Modal`, that is meant to be conditionally shown on click, should not be nested inside `MenuList` since it will be removed.
+
 ```jsx
-<MenuList>
-  <MenuItem>Home</MenuItem>
-  <MenuItem icon="Home">Home</MenuItem>
-  <MenuItem
-    itemRole="link"
-    target="_blank"
-    icon="Public"
-    href="https://google.com"
-  >
-    Away
-  </MenuItem>
-</MenuList>
+<Menu>
+  <MenuDisclosure>
+    <Button>Places</Button>
+  </MenuDisclosure>
+  <MenuList>
+    <MenuItem icon="Home">Home</MenuItem>
+    <MenuItem
+      itemRole="link"
+      target="_blank"
+      icon="Public"
+      href="https://google.com"
+    >
+      Away
+    </MenuItem>
+  </MenuList>
+</Menu>
 ```
 
 ### Icon Support


### PR DESCRIPTION
### :sparkles: Changes

- Close `Menu` in `MenuItem`'s click handler
- Remove test and docs example that implement `useContext(ModalContext)` since it's built-in now
- Add test for on-click close
- Add note in docs that items intended to mount after `MenuItem` is clicked should not be nested inside `MenuList`

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC
