### PR TITLE
Remove requirement that package consumers add @types/styled-system as…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Menu` closes by default on `MenuItem` click
+- Provide `@types/styled-system` as a package dependency
 
 ## [0.7.28] - 2020-04-20
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,6 +41,7 @@
     "react-hotkeys": "^2.0.0",
     "react-resize-detector": "^4.2.3",
     "react-transition-group": "^4.3.0",
+    "@types/styled-system": "^5.1.9",
     "styled-system": "^5.1.5",
     "uuid": "^7.0.3"
   },
@@ -57,7 +58,6 @@
     "@types/react-resize-detector": "^4.2.0",
     "@types/react-transition-group": "^4.2.4",
     "@types/styled-components": "^4.4.1",
-    "@types/styled-system": "^5.1.9",
     "@types/uuid": "^7.0.2",
     "csstype": "^2.6.10",
     "jest-styled-components": "^6.3.4",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -25,6 +25,7 @@
     "develop": "yarn build:es --watch --verbose & yarn declaration --watch"
   },
   "dependencies": {
+    "@types/styled-system": "^5.1.9",
     "lodash": "^4.17.15",
     "polished": "^3.5.1",
     "styled-system": "^5.1.5"
@@ -32,7 +33,6 @@
   "devDependencies": {
     "@types/lodash": "^4.14.149",
     "@types/styled-components": "^4.4.1",
-    "@types/styled-system": "^5.1.9",
     "csstype": "^2.6.10",
     "lodash": "^4.17.15",
     "react": "^16.13.1",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -25,15 +25,16 @@
     "develop": "yarn build:es --watch --verbose & yarn declaration --watch"
   },
   "dependencies": {
-    "@looker/design-tokens": "^0.7.28",
-    "styled-components": "^4.4.1"
+    "@looker/design-tokens": "^0.7.28"
   },
   "devDependencies": {
     "@types/react": "^16.9.34",
     "@types/styled-components": "^4.4.1",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.9.0",
+    "styled-components": "^4.3.2"
   }
 }


### PR DESCRIPTION
### :sparkles: Changes

- Remove requirement that package consumers add @types/styled-system as implicit peerDependency

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
