### PR TITLE
Add body overflow hidden to useScrollLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ActionListItem` no longer have shadow and cursor: pointer without an onClick
 - `ActionListItemColumn` aligns with header columns
+- `useScrollLock` no longer jitters on attempted scroll (used in modals and overlays)
 
 ## [0.7.28] - 2020-04-20
 

--- a/packages/playground/src/Popovers/Testing.tsx
+++ b/packages/playground/src/Popovers/Testing.tsx
@@ -110,6 +110,19 @@ function PopoverFocusTrap() {
               aria-label="Fruits"
               defaultValue="1"
             />
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
+            <Paragraph>Long text</Paragraph>
           </PopoverContent>
         }
       >
@@ -136,18 +149,20 @@ function MenuOpenDialog() {
             Open Menu
           </Button>
         </MenuDisclosure>
-        <MenuList>
-          <DialogManager
-            content={
-              <ModalContent>
-                <Paragraph>Some content inside the Dialog</Paragraph>
-                <Button onClick={openAlert}>Open Alert</Button>
-              </ModalContent>
-            }
-          >
-            {(onClick) => <MenuItem onClick={onClick}>Open Modal</MenuItem>}
-          </DialogManager>
-        </MenuList>
+        <DialogManager
+          content={
+            <ModalContent>
+              <Paragraph>Some content inside the Dialog</Paragraph>
+              <Button onClick={openAlert}>Open Alert</Button>
+            </ModalContent>
+          }
+        >
+          {(onClick) => (
+            <MenuList>
+              <MenuItem onClick={onClick}>Open Modal</MenuItem>
+            </MenuList>
+          )}
+        </DialogManager>
       </Menu>
     </Box>
   )
@@ -343,7 +358,7 @@ function MovingTarget() {
 
 export function TestPopovers() {
   return (
-    <Box m="large" display="flex">
+    <Box m="large" display="flex" height={1500}>
       <Box>
         <MenuOpenDialog />
         <Divider my="large" />

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -27,12 +27,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { ComponentsProvider } from '@looker/components'
-import { ActionListDemo } from './ActionList/ActionListDemo'
+import { TestPopovers } from './Popovers/Testing'
 
 const App: React.FC = () => {
   return (
     <ComponentsProvider>
-      <ActionListDemo />
+      <TestPopovers />
     </ComponentsProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- `useScrollLock` wasn't using `overflow: hidden` on `body` because often some other ancestor (or potentially multiple ancestors) of the trigger element is/are scrollable, so instead it simply cancels the window scroll event.
- However, there was still a "jitter" effect on attempted scroll, which adding `overflow: hidden` on `body` resolves, at least when the scrolling element is, in fact, the `body`.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes (manual testing in for now)
- [x] Build and tests are passing
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue
I![scroll-lock](https://user-images.githubusercontent.com/53451193/80173772-a9050d00-85a5-11ea-800b-54853dbe4e0d.gif)

#### Fix
![scroll-lock-fix](https://user-images.githubusercontent.com/53451193/80173788-b5896580-85a5-11ea-90a3-3c34c7f01720.gif)

