### PR TITLE
Change default height of ActionListManager for better empty state behavior

### DIFF
--- a/packages/components/src/ActionList/ActionListManager.tsx
+++ b/packages/components/src/ActionList/ActionListManager.tsx
@@ -61,7 +61,7 @@ const centerItemStates = css`
   align-items: center;
   display: flex;
   justify-content: center;
-  height: 100%;
+  min-height: 8rem;
 `
 
 export const ActionListManager = styled(ActionListManagerLayout)`


### PR DESCRIPTION
Per designer specification the "empty state" should sit approximately where the first item would appear.

### :sparkles: Changes

- Change default height of ActionListManager for better empty state behavior

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots

Before

![Screen Shot 2020-04-24 at 9 12 38 AM](https://user-images.githubusercontent.com/34253496/80233739-d4bade00-860b-11ea-875b-917e8f2dcf63.png)

After

![Screen Shot 2020-04-24 at 9 12 21 AM](https://user-images.githubusercontent.com/34253496/80233746-d5ec0b00-860b-11ea-8f39-bc9472ee540a.png)
