### PR TITLE
WWW: Remove tabIndex from live code editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- WWW site keyboard navigation improvement
 - `Menu` closes by default on `MenuItem` click
 - Provide `@types/styled-system` as a package dependency
 - `TextArea` only supports vertical resizing now

--- a/packages/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/packages/www/src/MDX/Pre/CodeSandbox.tsx
@@ -26,7 +26,7 @@
 
 import { Icon, IconButton, IconNames, Tooltip } from '@looker/components'
 import { PrismTheme, Language } from 'prism-react-renderer'
-import React, { FC, ReactNode, useState } from 'react'
+import React, { FC, ReactNode, useState, useCallback } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import {
   LiveProvider,
@@ -66,6 +66,18 @@ const CodeSandbox = ({
     setShowEditor(!showEditor)
   }
 
+  const liveEditorRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (showEditor && node) {
+        const liveEditorInput = node.querySelector('textarea')
+        if (liveEditorInput) {
+          liveEditorInput.tabIndex = -1
+        }
+      }
+    },
+    [showEditor]
+  )
+
   return (
     <SandboxWrapper>
       <LiveProvider
@@ -98,7 +110,7 @@ const CodeSandbox = ({
             )}
           </LiveConsumer>
         </LivePreviewWrapper>
-        <EditorWrapper>
+        <EditorWrapper ref={liveEditorRef}>
           {showEditor && <LiveEditor />}
           <ActionLayout editorIsVisible={showEditor}>
             <ToggleCodeButton


### PR DESCRIPTION
### :sparkles: Changes

UX Improvement to make it easier to use keyboard navigation in the www components website. Tabbing will now skip over live code editors.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots

![keyboard-nav-www](https://user-images.githubusercontent.com/238293/80263327-2764bc00-8645-11ea-9279-6211a621ff5c.gif)
