### PR TITLE
Fix ToggleSwitch React warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GitBranch`, `ViewColumn`, `SectionDrop` icons
 
+### Fixed
+
+- `ToggleSwitch` React warning
+
 ## [0.7.29] - 2020-04-24
 
 ### Changed

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -109,7 +109,6 @@ exports[`A FieldToggleSwitch 1`] = `
       >
         <div
           className="c6"
-          size={20}
         />
       </div>
     </div>
@@ -235,8 +234,6 @@ exports[`A FieldToggleSwitch turned on 1`] = `
       >
         <div
           className="c6"
-          on={true}
-          size={20}
         />
       </div>
     </div>

--- a/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
@@ -35,7 +35,7 @@ export interface KnobProps {
   on?: boolean
 }
 
-const Knob = styled.div<KnobProps>`
+const Knob = styled(({ className }) => <div className={className} />)`
   transform: ${({ on, size }) => (on ? `translateX(${rem(size * 0.75)})` : '')};
   transition: ${({ theme }) => theme.transitions.durationModerate};
   position: absolute;

--- a/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -61,7 +61,6 @@ exports[`Big ToggleSwitch 1`] = `
   >
     <div
       className="c2"
-      size={60}
     />
   </div>
 </div>
@@ -128,7 +127,6 @@ exports[`ToggleSwitch default 1`] = `
   >
     <div
       className="c2"
-      size={20}
     />
   </div>
 </div>
@@ -197,8 +195,6 @@ exports[`ToggleSwitch on set to false 1`] = `
   >
     <div
       className="c2"
-      on={false}
-      size={20}
     />
   </div>
 </div>
@@ -270,8 +266,6 @@ exports[`ToggleSwitch on set to true 1`] = `
   >
     <div
       className="c2"
-      on={true}
-      size={20}
     />
   </div>
 </div>
@@ -358,9 +352,6 @@ exports[`ToggleSwitch that is disabled 1`] = `
   >
     <div
       className="c2"
-      disabled={true}
-      on={true}
-      size={20}
     />
   </div>
   <div


### PR DESCRIPTION
### :sparkles: Changes

- After a [recent change](https://github.com/looker-open-source/components/pull/802), `Knob` in `ToggleSwitch` is passing `on` down to a `div`, causing a React warning
- Changed/reverted `Knob` to only pass down `className`

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] Updated CHANGELOG
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![](https://files.slack.com/files-pri/T024F428S-F012SDBCK4J/image.png)
