### PR TITLE
Updated ViewColumn icon to better match keyline and guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Updated the `ViewColumn` icon to better match keylines and guides
 - `GitBranch`, `ViewColumn`, `SectionDrop` icons
 
 ### Changed

--- a/packages/icons/src/svg/ViewColumn.svg
+++ b/packages/icons/src/svg/ViewColumn.svg
@@ -1,3 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10 18H15V5H10V18ZM4 18H9V5H4V18ZM16 5V18H21V5H16Z" fill="#1C2125"/>
+<path d="M4 4H8V20H4V4Z" fill="#1C2125"/>
+<path d="M10 4H14V20H10V4Z" fill="#1C2125"/>
+<path d="M16 4H20V20H16V4Z" fill="#1C2125"/>
 </svg>


### PR DESCRIPTION
### :sparkles: Changes

<img width="736" alt="Screen Shot 2020-05-04 at 3 07 10 PM" src="https://user-images.githubusercontent.com/53451500/81019936-95b33680-8e1c-11ea-9478-129f1423308b.png">

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ X ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ X ] PR is ideally < ~400LOC

### :camera: Screenshots
