### PR TITLE
Label for attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `menuItemStyleContext` in `MenuContext` uses a new interface which contains "preserved icon space"-related properties
 - `MenuItem` renders an empty Box with the same size as the icon(s) of sibling `MenuItem's (if any)
 - `MenuList`, `MenuGroup` contain piece of state the tracks the size of the preserved icon space
+- Labels in `FieldInline` and `ButtonItem` now include the `for` attribute
 
 ### Fixed
 

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -34,6 +34,7 @@ import {
   typography,
   TypographyProps,
 } from '@looker/design-tokens'
+import { useID } from '../utils'
 
 export interface ButtonItemProps
   extends SpaceProps,
@@ -116,6 +117,7 @@ const ButtonItemComponent = forwardRef(
     {
       children,
       disabled,
+      id: propsID,
       isControlled,
       name,
       onChange,
@@ -126,6 +128,7 @@ const ButtonItemComponent = forwardRef(
     ref: Ref<HTMLInputElement>
   ) => {
     const [uncontrolledSelected, setUncontrolledSelected] = useState(selected)
+    const id = useID(propsID)
 
     function handleChange(e: ChangeEvent<HTMLInputElement>) {
       if (onChange) {
@@ -141,6 +144,7 @@ const ButtonItemComponent = forwardRef(
     return (
       <ButtonItemLabel
         disabled={disabled}
+        htmlFor={id}
         fontFamily="brand"
         py="small"
         selected={showSelected}
@@ -150,6 +154,7 @@ const ButtonItemComponent = forwardRef(
           type={props.type}
           disabled={disabled}
           name={name}
+          id={id}
           onChange={handleChange}
           checked={showSelected}
           value={value}

--- a/packages/components/src/Form/Fields/FieldCheckbox/FieldCheckbox.tsx
+++ b/packages/components/src/Form/Fields/FieldCheckbox/FieldCheckbox.tsx
@@ -26,7 +26,7 @@
 
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import { Checkbox, CheckboxProps } from '../../Inputs/Checkbox/Checkbox'
 import { omitFieldProps, pickFieldProps } from '../Field'
@@ -38,7 +38,7 @@ export interface FieldCheckboxProps extends CheckboxProps, FieldBaseProps {}
 const FieldCheckboxLayout = forwardRef(
   (props: FieldCheckboxProps, ref: Ref<HTMLInputElement>) => {
     const validationMessage = useFormContext(props)
-    const { id = uuid() } = props
+    const id = useID(props.id)
     return (
       <FieldInline
         {...pickFieldProps(props)}

--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`A FieldCheckbox 1`] = `
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
+    htmlFor="FieldCheckboxID"
   >
     👍
   </span>
@@ -254,6 +255,7 @@ exports[`A FieldCheckbox with checked value 1`] = `
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
+    htmlFor="FieldCheckboxID"
   >
     👍
   </span>

--- a/packages/components/src/Form/Fields/FieldCheckboxGroup/FieldCheckboxGroup.tsx
+++ b/packages/components/src/Form/Fields/FieldCheckboxGroup/FieldCheckboxGroup.tsx
@@ -26,7 +26,7 @@
 
 import React, { FC } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import { CheckboxGroup, CheckboxGroupProps } from '../../Inputs'
 import { Field, FieldProps, omitFieldProps, pickFieldProps } from '../Field'
@@ -36,12 +36,13 @@ export interface FieldCheckboxGroupProps
     Omit<FieldProps, 'detail'> {}
 
 const FieldCheckboxGroupLayout: FC<FieldCheckboxGroupProps> = ({
-  id = uuid(),
+  id: propsID,
   options,
   value,
   ...props
 }) => {
   const validationMessage = useFormContext(props)
+  const id = useID(propsID)
 
   return (
     <Field

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -55,7 +55,7 @@ const FieldInlineLayout: FC<Omit<
 }) => {
   return (
     <label className={className}>
-      <Label as="span" fontSize={labelFontSize}>
+      <Label as="span" fontSize={labelFontSize} htmlFor={id}>
         {label}
         {required && <RequiredStar />}
       </Label>

--- a/packages/components/src/Form/Fields/FieldRadio/FieldRadio.tsx
+++ b/packages/components/src/Form/Fields/FieldRadio/FieldRadio.tsx
@@ -26,7 +26,7 @@
 
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { Radio, RadioProps } from '../../Inputs/Radio/Radio'
 import { omitFieldProps, pickFieldProps } from '../Field'
 import { FieldInline } from '../FieldInline'
@@ -38,7 +38,7 @@ export interface FieldRadioProps
 
 const FieldRadioLayout = forwardRef(
   (props: FieldRadioProps, ref: Ref<HTMLInputElement>) => {
-    const { id = uuid() } = props
+    const id = useID(props.id)
     return (
       <FieldInline {...pickFieldProps(props)} id={id}>
         <Radio

--- a/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
@@ -109,6 +109,7 @@ exports[`A FieldRadio 1`] = `
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
+    htmlFor="FieldRadioID"
   >
     👍
   </span>
@@ -245,6 +246,7 @@ exports[`A FieldRadio checked 1`] = `
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
+    htmlFor="FieldRadioID"
   >
     👍
   </span>

--- a/packages/components/src/Form/Fields/FieldRadioGroup/FieldRadioGroup.tsx
+++ b/packages/components/src/Form/Fields/FieldRadioGroup/FieldRadioGroup.tsx
@@ -26,7 +26,7 @@
 
 import React, { FC } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import { Field, FieldProps, omitFieldProps, pickFieldProps } from '../Field'
 import { RadioGroup, RadioGroupProps } from '../../Inputs/OptionsGroup'
@@ -36,11 +36,12 @@ export interface FieldRadioGroupProps
     Omit<FieldProps, 'detail'> {}
 
 const FieldRadioGroupLayout: FC<FieldRadioGroupProps> = ({
-  id = uuid(),
+  id: propsID,
   options,
   ...props
 }) => {
   const validationMessage = useFormContext(props)
+  const id = useID(propsID)
 
   return (
     <Field

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.tsx
@@ -26,7 +26,7 @@
 
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import { Select, SelectProps } from '../../Inputs/Select/Select'
 import { Field, FieldProps, omitFieldProps, pickFieldProps } from '../Field'
@@ -36,7 +36,7 @@ export interface FieldSelectProps extends FieldProps, SelectProps {}
 const FieldSelectComponent = forwardRef(
   (props: FieldSelectProps, ref: Ref<HTMLInputElement>) => {
     const validationMessage = useFormContext(props)
-    const { id = uuid() } = props
+    const id = useID(props.id)
     return (
       <Field
         {...pickFieldProps(props)}

--- a/packages/components/src/Form/Fields/FieldText/FieldText.tsx
+++ b/packages/components/src/Form/Fields/FieldText/FieldText.tsx
@@ -26,7 +26,7 @@
 
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import { InputText, InputTextProps } from '../../Inputs/InputText/InputText'
 import { Field, FieldProps, omitFieldProps, pickFieldProps } from '../Field'
@@ -35,7 +35,7 @@ export interface FieldTextProps extends FieldProps, InputTextProps {}
 
 const FieldTextComponent = forwardRef(
   (props: FieldTextProps, ref: Ref<HTMLInputElement>) => {
-    const { id = uuid() } = props
+    const id = useID(props.id)
     const validationMessage = useFormContext(props)
     return (
       <Field

--- a/packages/components/src/Form/Fields/FieldTextArea/FieldTextArea.tsx
+++ b/packages/components/src/Form/Fields/FieldTextArea/FieldTextArea.tsx
@@ -26,7 +26,7 @@
 
 import React, { FC } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import { TextArea, TextAreaProps } from '../../Inputs/TextArea'
 import { Field, FieldProps, omitFieldProps, pickFieldProps } from '../Field'
@@ -34,7 +34,7 @@ import { Field, FieldProps, omitFieldProps, pickFieldProps } from '../Field'
 export interface FieldTextAreaProps extends FieldProps, TextAreaProps {}
 
 const FieldTextAreaComponent: FC<FieldTextAreaProps> = ({ ...props }) => {
-  const { id = uuid() } = props
+  const id = useID(props.id)
   const validationMessage = useFormContext(props)
   return (
     <Field

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.tsx
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.tsx
@@ -26,7 +26,7 @@
 
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
+import { useID } from '../../../utils'
 import { useFormContext } from '../../Form'
 import {
   ToggleSwitch,
@@ -43,7 +43,7 @@ export interface FieldToggleSwitchProps
 const FieldToggleSwitchLayout = forwardRef(
   (props: FieldToggleSwitchProps, ref: Ref<HTMLInputElement>) => {
     const validationMessage = useFormContext(props)
-    const { id = uuid() } = props
+    const id = useID(props.id)
     return (
       <FieldInline
         {...pickFieldProps(props)}

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`A FieldToggleSwitch 1`] = `
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
+    htmlFor="FieldToggleSwitchID"
   >
     👍
   </span>
@@ -212,6 +213,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
+    htmlFor="FieldToggleSwitchID"
   >
     👍
   </span>


### PR DESCRIPTION
### :sparkles: Changes

- Add `for` attribute to labels in `FieldInline` and `ButtonItem` (core product CI can't find custom-styled inputs without it)
- Convert `id = uuid()` to `id = useID` for consistent value over re-renders (see screenshot below)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### With `id = uuid()` the value was changing every render:
![id-change](https://user-images.githubusercontent.com/53451193/81112808-141edf80-8ed4-11ea-8f33-ec2047e7268e.gif)
