### PR TITLE
Action List Item Action: Remove color prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ToggleSwitch` React warning
 - add placeholder attribute to InlineInputText
 
+### Removed
+
+- `ActionListItemAction` no longer supports the `color` prop
+
 ## [0.7.29] - 2020-04-24
 
 ### Changed

--- a/packages/components/src/ActionList/ActionListItemAction.tsx
+++ b/packages/components/src/ActionList/ActionListItemAction.tsx
@@ -32,7 +32,6 @@ import { MenuItem, MenuContext } from '../Menu'
 export interface ActionListItemActionProps
   extends CompatibleHTMLProps<HTMLElement> {
   children?: ReactNode
-  color?: 'danger'
   detail?: ReactNode
   icon?: IconNames
   role?: 'button' | 'link'
@@ -50,11 +49,5 @@ export const ActionListItemAction = (props: ActionListItemActionProps) => {
     setOpen && setOpen(false)
     props.onClick && props.onClick(event)
   }
-  return (
-    <MenuItem
-      {...props}
-      color={props.color === 'danger' ? 'palette.red500' : undefined}
-      onClick={handleActionClick}
-    />
-  )
+  return <MenuItem {...props} onClick={handleActionClick} />
 }

--- a/packages/playground/src/ActionList/ActionListDemo.tsx
+++ b/packages/playground/src/ActionList/ActionListDemo.tsx
@@ -109,7 +109,7 @@ const columns: ActionListColumns = [
 
 const MyActions = () => (
   <>
-    <ActionListItemAction color="danger" onClick={() => alert(`Go to LookML!`)}>
+    <ActionListItemAction onClick={() => alert(`Go to LookML!`)}>
       Go to LookML
     </ActionListItemAction>
     <ActionListItemAction onClick={() => alert(`PDT Details!`)}>


### PR DESCRIPTION
### 🔍 Context

We previously added a minor `color` prop to `ActionListItemAction` that could accept the string "danger". Doing so would make the text of the `ActionListItemAction` red.

This was done to support a use case in helltool, but this functionality is no longer needed by the original requesters. 

### :sparkles: Changes

- Removed color prop from `ActionListItemAction`

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] Updated CHANGELOG
- [x] PR is ideally < ~400LOC
