### PR TITLE
Update spacing on fields to be more explicit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MenuItem` renders an empty Box with the same size as the icon(s) of sibling `MenuItem's (if any)
 - `MenuList`, `MenuGroup` contain piece of state the tracks the size of the preserved icon space
 - Labels in `FieldInline` and `ButtonItem` now include the `for` attribute
-- Fields have more explicit line-heights to enforce more consistent layout.
+- Fields have more explicit line-heights to enforce consistent layout.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MenuList`, `MenuGroup` contain piece of state the tracks the size of the preserved icon space
 - Labels in `FieldInline` and `ButtonItem` now include the `for` attribute
 - Fields have more explicit line-heights to enforce consistent layout.
+- `Fieldset` default spacing switched from `xsmall` to `small` to improve visual relationship with their `Input*`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MenuItem` renders an empty Box with the same size as the icon(s) of sibling `MenuItem's (if any)
 - `MenuList`, `MenuGroup` contain piece of state the tracks the size of the preserved icon space
 - Labels in `FieldInline` and `ButtonItem` now include the `for` attribute
+- Fields have more explicit line-heights to enforce more consistent layout.
 
 ### Fixed
 

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -162,6 +162,7 @@ const fieldLabelCSS = (inline?: boolean) =>
         padding-right: ${({ theme }) => theme.space.small};
       `
     : css`
+        line-height: ${({ theme }) => theme.lineHeights.xsmall};
         padding-bottom: ${({ theme }) => theme.space.xsmall};
       `
 

--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -24,11 +24,9 @@ exports[`A FieldCheckbox 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c4 input {
@@ -78,6 +76,7 @@ exports[`A FieldCheckbox 1`] = `
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3,max-content);
+  line-height: 1.25rem;
 }
 
 .c0 .c3 {
@@ -175,11 +174,9 @@ exports[`A FieldCheckbox with checked value 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c4 input {
@@ -229,6 +226,7 @@ exports[`A FieldCheckbox with checked value 1`] = `
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3,max-content);
+  line-height: 1.25rem;
 }
 
 .c0 .c3 {

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -77,6 +77,7 @@ export const FieldInline = styled(FieldInlineLayout)`
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3, max-content);
+  line-height: ${({ theme }) => theme.lineHeights.small};
 
   ${InputArea} {
     grid-area: input;

--- a/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
@@ -26,11 +26,9 @@ exports[`A FieldRadio 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c4 input {
@@ -83,6 +81,7 @@ exports[`A FieldRadio 1`] = `
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3,max-content);
+  line-height: 1.25rem;
 }
 
 .c0 .c3 {
@@ -163,11 +162,9 @@ exports[`A FieldRadio checked 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c4 input {
@@ -220,6 +217,7 @@ exports[`A FieldRadio checked 1`] = `
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3,max-content);
+  line-height: 1.25rem;
 }
 
 .c0 .c3 {

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`A FieldSelect 1`] = `
 
 .c0 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 
@@ -422,6 +423,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
 
 .c0 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 
@@ -753,6 +755,7 @@ exports[`A required FieldSelect 1`] = `
 
 .c0 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 
@@ -1041,6 +1044,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
 
 .c0 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`A FieldText with default label 1`] = `
 
 .c0 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 
@@ -256,6 +257,7 @@ exports[`A FieldText with label inline 1`] = `
 
 .c7 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 

--- a/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`A FieldTextArea with default label 1`] = `
 
 .c0 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 
@@ -189,6 +190,7 @@ exports[`A FieldTextArea with label inline 1`] = `
 
 .c6 > .c1 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`A FieldToggleSwitch 1`] = `
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3,max-content);
+  line-height: 1.25rem;
 }
 
 .c0 .c3 {
@@ -187,6 +188,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   display: grid;
   grid-template-areas: 'input label' '. messages';
   grid-template-columns: repeat(3,max-content);
+  line-height: 1.25rem;
 }
 
 .c0 .c3 {

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -60,7 +60,7 @@ const FieldsetLayout = forwardRef(
     const content = (
       <LayoutComponent
         {...restProps}
-        gap={inline ? 'medium' : 'xsmall'}
+        gap={inline ? 'medium' : 'small'}
         className={className}
         ref={ref}
         role="group"

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`Fieldset 1`] = `
 
 .c3 > .c4 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Fieldset 1`] = `
 }
 
 .c2.c2 > * {
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
 }
 
 .c2.c2 > :first-child {

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -104,11 +104,9 @@ export const Checkbox = styled(CheckboxLayout)`
   ${reset}
   ${space}
 
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 
   input {
     cursor: ${({ readOnly, disabled }) =>

--- a/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -24,11 +24,9 @@ exports[`Checkbox checked set to mixed 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -155,11 +153,9 @@ exports[`Checkbox should accept disabled & checked 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -279,11 +275,9 @@ exports[`Checkbox should accept disabled & checked="mixed" 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -412,11 +406,9 @@ exports[`Checkbox should accept disabled 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -535,11 +527,9 @@ exports[`Checkbox should accept readOnly & checked 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -657,11 +647,9 @@ exports[`Checkbox should accept readOnly & checked="mixed" 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -788,11 +776,9 @@ exports[`Checkbox should accept readOnly 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -884,11 +870,9 @@ exports[`Checkbox with aria-describedby 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {

--- a/packages/components/src/Form/Inputs/Radio/Radio.tsx
+++ b/packages/components/src/Form/Inputs/Radio/Radio.tsx
@@ -57,12 +57,9 @@ export const Radio = styled(RadioLayout)`
   ${reset}
   ${space}
 
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
-
   input {
     background: ${(props) => props.theme.colors.palette.white};
     cursor: ${({ readOnly, disabled }) =>

--- a/packages/components/src/Form/Inputs/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Radio/__snapshots__/Radio.test.tsx.snap
@@ -26,11 +26,9 @@ exports[`Radio checked set to false 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -109,11 +107,9 @@ exports[`Radio checked set to true 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -192,11 +188,9 @@ exports[`Radio default 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -301,11 +295,9 @@ exports[`Radio should accept disabled 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -385,11 +377,9 @@ exports[`Radio with aria-describedby 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {
@@ -495,11 +485,9 @@ exports[`Radio with name and id 1`] = `
 }
 
 .c0 {
-  display: inline-block;
   height: 1rem;
   position: relative;
   width: 1rem;
-  vertical-align: middle;
 }
 
 .c0 input {

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`Form with one child 1`] = `
 
 .c1 > .c2 {
   grid-area: label;
+  line-height: 1rem;
   padding-bottom: 0.5rem;
 }
 

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -28,13 +28,13 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { ComponentsProvider } from '@looker/components'
 import { RangeSliderDemo } from './Form/RangeSliderDemo'
-import { SliderDemo } from './Form/SliderDemo'
+import { FieldsDemo } from './Form/FieldsDemo'
 
 const App: React.FC = () => {
   return (
     <ComponentsProvider>
       <RangeSliderDemo />
-      <SliderDemo />
+      <FieldsDemo />
     </ComponentsProvider>
   )
 }

--- a/packages/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/packages/www/src/MDX/Pre/CodeSandbox.tsx
@@ -235,7 +235,6 @@ const ActionLayout = styled.div<ActionProps>`
 const SandboxWrapper = styled.div`
   overflow: hidden;
   ${({ theme: { lineHeights, colors, radii } }) => `
-    line-height: ${lineHeights.medium};
     margin-bottom: ${lineHeights.medium};
     border: 1px solid ${colors.palette.charcoal200};
     border-radius: ${radii.medium};
@@ -251,6 +250,7 @@ const PreviewWrapper = styled.div`
 
 const EditorWrapper = styled.div`
   background: ${({ theme }) => theme.colors.palette.charcoal700};
+  line-height: ${({ theme }) => theme.lineHeights.medium};
   display: grid;
   grid-template-columns: 1fr auto;
   textarea,

--- a/packages/www/src/documentation/components/forms/fields.mdx
+++ b/packages/www/src/documentation/components/forms/fields.mdx
@@ -337,9 +337,11 @@ const options = [
 The `<FieldText />` component is composed of an `<InputText />` component and a `<Label />` component. Using `<FieldText />` allows for rendering validation messages. By default, the label will render directly above the input field, which is the recommended convention, however this is adjustable with the `alignLabel` property.
 
 ```jsx
-<FieldText name="firstName" label="First Name" />
-<FieldText name="lastName" label=" Last Name" alignLabel="left" />
-<FieldText name="requiredField" label="A required field" required />
+<SpaceVertical>
+  <FieldText name="firstName" label="First Name" />
+  <FieldText name="lastName" label=" Last Name" alignLabel="left" />
+  <FieldText name="requiredField" label="A required field" required />
+</SpaceVertical>
 ```
 
 ## FieldTextArea


### PR DESCRIPTION
### :sparkles: Changes

This PR is to address a bug in the spacing of our some of our form controls. A style set on our live editor was setting the line height to `1.5rem` that style was cascading to our form controls, introducing incorrect spacing. 

This PR moves the extra line spacing to just the interactive code editor, instead of the wrapper around the preview and code editor. It also sets explicit line heights on our fields so that external line-heights do not introduce the incorrect spacing.

---

## Before
Here is a few examples, notice extra spacing between label and text input, misalignment of checkbox/radios 
![image](https://user-images.githubusercontent.com/170681/81310023-72fd6980-9038-11ea-9d3a-f793d2c5775f.png)
![image](https://user-images.githubusercontent.com/170681/81310361-d6879700-9038-11ea-9482-1048f3275f6d.png)
![image](https://user-images.githubusercontent.com/170681/81310386-e010ff00-9038-11ea-92d3-a5a144202a32.png)
---
## After
![image](https://user-images.githubusercontent.com/170681/81310559-18b0d880-9039-11ea-9ac8-e4e2a1558605.png)
![image](https://user-images.githubusercontent.com/170681/81311041-bd331a80-9039-11ea-8158-81fcd3ad5335.png)
![image](https://user-images.githubusercontent.com/170681/81311101-d63bcb80-9039-11ea-9667-2e51d87922d7.png)


### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
