### PR TITLE
Correct labels in example (flipped)

### DIFF
--- a/packages/www/src/documentation/components/forms/demos/FormValidationDemo.tsx
+++ b/packages/www/src/documentation/components/forms/demos/FormValidationDemo.tsx
@@ -81,13 +81,13 @@ export class FormValidationDemo extends Component<{}, FormValidationState> {
         <FieldText
           name="val1"
           value={this.state.val1}
-          label="A Field requiring more than 5 characters"
+          label="A Field requiring less than 5 characters"
           onChange={this.changeHandler.bind(this, 'val1')}
         />
         <FieldText
           name="val2"
           value={this.state.val2}
-          label="A Field requiring less than 5 characters"
+          label="A Field requiring more than 5 characters"
           onChange={this.changeHandler.bind(this, 'val2')}
         />
       </Form>


### PR DESCRIPTION
### :sparkles: Changes

- Labels were mixed up in documentation...

Before: 
![image](https://user-images.githubusercontent.com/34253496/81373500-bb0ca280-90b1-11ea-964f-78440c769d9b.png)

After: 
![image](https://user-images.githubusercontent.com/34253496/81373556-d7a8da80-90b1-11ea-8170-e1229ff52ee3.png)



### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
