### PR TITLE
Fix typo on Select documentation

### DIFF
--- a/packages/www/src/documentation/components/forms/select.mdx
+++ b/packages/www/src/documentation/components/forms/select.mdx
@@ -248,7 +248,7 @@ When you open the following list, `Mascarpone` will be highlighted and visible a
 ## Windowing
 
 Another feature for long lists. Because rendering hundreds of options results in poor performance,
-if there are 100 or more options, the option list will be "windowed", (a.k.a. "virtuaslized") and only the
+if there are 100 or more options, the option list will be "windowed", (a.k.a. "virtualized") and only the
 options visibile in the scroll area will be rendered, plus a buffer of 5 above and below. The `windowedOptions`
 prop can be used to override this – either by setting it to `true` for under 100 or `false` for over 100.
 

--- a/packages/www/src/documentation/components/forms/select.mdx
+++ b/packages/www/src/documentation/components/forms/select.mdx
@@ -248,7 +248,7 @@ When you open the following list, `Mascarpone` will be highlighted and visible a
 ## Windowing
 
 Another feature for long lists. Because rendering hundreds of options results in poor performance,
-if there are 100 or more options, the option list will be "windowed", (a.k.a. "virtuaslizerd") and only the
+if there are 100 or more options, the option list will be "windowed", (a.k.a. "virtuaslized") and only the
 options visibile in the scroll area will be rendered, plus a buffer of 5 above and below. The `windowedOptions`
 prop can be used to override this – either by setting it to `true` for under 100 or `false` for over 100.
 


### PR DESCRIPTION
### :sparkles: Changes

- "virtualizerd" to "virtualized'

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
