### PR TITLE
Move htmlFor to correct label in FieldInline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- `FieldInline` `for` attribute moved to the correct `label`
+
 ## [0.7.30] - 2020-05-07
 
 ### Added

--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -97,13 +97,13 @@ exports[`A FieldCheckbox 1`] = `
 
 <label
   className="c0 "
+  htmlFor="FieldCheckboxID"
 >
   <span
     className="c1 c2"
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
-    htmlFor="FieldCheckboxID"
   >
     👍
   </span>
@@ -247,13 +247,13 @@ exports[`A FieldCheckbox with checked value 1`] = `
 
 <label
   className="c0 "
+  htmlFor="FieldCheckboxID"
 >
   <span
     className="c1 c2"
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
-    htmlFor="FieldCheckboxID"
   >
     👍
   </span>

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -54,8 +54,8 @@ const FieldInlineLayout: FC<Omit<
   validationMessage,
 }) => {
   return (
-    <label className={className}>
-      <Label as="span" fontSize={labelFontSize} htmlFor={id}>
+    <label className={className} htmlFor={id}>
+      <Label as="span" fontSize={labelFontSize}>
         {label}
         {required && <RequiredStar />}
       </Label>

--- a/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
@@ -102,13 +102,13 @@ exports[`A FieldRadio 1`] = `
 
 <label
   className="c0 "
+  htmlFor="FieldRadioID"
 >
   <span
     className="c1 c2"
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
-    htmlFor="FieldRadioID"
   >
     👍
   </span>
@@ -238,13 +238,13 @@ exports[`A FieldRadio checked 1`] = `
 
 <label
   className="c0 "
+  htmlFor="FieldRadioID"
 >
   <span
     className="c1 c2"
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
-    htmlFor="FieldRadioID"
   >
     👍
   </span>

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -84,13 +84,13 @@ exports[`A FieldToggleSwitch 1`] = `
 
 <label
   className="c0 "
+  htmlFor="FieldToggleSwitchID"
 >
   <span
     className="c1 c2"
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
-    htmlFor="FieldToggleSwitchID"
   >
     👍
   </span>
@@ -209,13 +209,13 @@ exports[`A FieldToggleSwitch turned on 1`] = `
 
 <label
   className="c0 "
+  htmlFor="FieldToggleSwitchID"
 >
   <span
     className="c1 c2"
     color="palette.charcoal700"
     fontSize="xsmall"
     fontWeight="semiBold"
-    htmlFor="FieldToggleSwitchID"
   >
     👍
   </span>


### PR DESCRIPTION
### :sparkles: Changes

- `htmlFor` was on the nested `<Label as="span">` instead of the outer `<label>` – which is where it is now.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/53451193/81728313-1b4b6d80-943f-11ea-990e-535d10941ab5.png)
