### PR TITLE
Fix Space issue w/ IconButton and add around, between & evenly support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Select` now accepts `listLayout` to control the layout of the list
 - `ComboboxList` now accepts properties from `LayoutProps`
-
-### Added
-
 - `Space`
   - now supports `around`, `between` and `evenly` as alternatives to `gap`
   - now supports `verticalAlign` property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Select` now accepts `listLayout` to control the layout of the list
 - `ComboboxList` now accepts properties from `LayoutProps`
 
+### Added
+
+- `Space`
+  - now supports `around`, `between` and `evenly` as alternatives to `gap`
+  - now supports `verticalAlign` property
+- `SpaceVertical` now supports `align` and `stretch` properties
+
 ### Changed
 
 - `useTooltip` includes a generated id (or passed-in prop value) for the resulting tooltip in the return object
   - Doing this means that tooltip trigger elements can now have an `aria-describedby` property with said id as the value
 - `MenuDisclosure`, `Banner`, `IconButton`, `ModalHeader` explicitly use their id props to either provide `useTooltip` with an id or to provide another component that uses `useTooltip` with an id to generate the tooltip's id
-- `Banner` fontSize adjusted and external margin removed
 - Use Babel for building Monorepo ES artifacts
   - Change build artifact path from `dist/` to `lib.`
   - No longer produces multiple artifact formats (`es` only)
@@ -28,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Confirm` corrected word wrapping when long strings without white-space are used
+- `IconButton` no longer generates spurious DOM outside of itself for `tooltip` (doesn't create funky layout bugs when `IconButton` is within `Space`)
 
 ## [0.7.31] - 2020-05-12
 

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -160,22 +160,20 @@ const IconButtonComponent = forwardRef(
     const actualRef = useForkedRef<HTMLButtonElement>(forwardRef, ref)
 
     return (
-      <>
+      <ButtonTransparent
+        aria-describedby={ariaDescribedBy}
+        ref={actualRef}
+        color={color}
+        p="none"
+        size={size}
+        width={buttonSizeMap[size]}
+        {...eventHandlers}
+        {...rest}
+      >
+        <VisuallyHidden>{label}</VisuallyHidden>
+        <Icon name={icon} size={buttonSizeMap[size] - 6} aria-hidden={true} />
         {tooltip}
-        <ButtonTransparent
-          aria-describedby={ariaDescribedBy}
-          ref={actualRef}
-          color={color}
-          p="none"
-          size={size}
-          width={buttonSizeMap[size]}
-          {...eventHandlers}
-          {...rest}
-        >
-          <VisuallyHidden>{label}</VisuallyHidden>
-          <Icon name={icon} size={buttonSizeMap[size] - 6} aria-hidden={true} />
-        </ButtonTransparent>
-      </>
+      </ButtonTransparent>
     )
   }
 )

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -2,49 +2,47 @@
 
 exports[`Fieldset 1`] = `
 .c0 {
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0.c0 > * {
-  width: 100%;
   margin-top: 1rem;
 }
 
-.c0.c0 > :first-child {
+.c0.c0 > *:first-child {
   margin-top: 0rem;
 }
 
 .c2 {
-  width: 100%;
   padding: 0rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c2.c2 > * {
-  width: 100%;
   margin-top: 0.75rem;
 }
 
-.c2.c2 > :first-child {
+.c2.c2 > *:first-child {
   margin-top: 0rem;
 }
 
@@ -183,7 +181,6 @@ exports[`Fieldset 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <legend
     className="c1"
@@ -196,7 +193,6 @@ exports[`Fieldset 1`] = `
   <div
     className="c2 "
     role="group"
-    width="100%"
   >
     <div
       className="c3 "

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -7,10 +7,6 @@ exports[`Fieldset 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -35,10 +31,6 @@ exports[`Fieldset 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Fieldset 1`] = `
 }
 
 .c0.c0 > * {
+  width: 100%;
   margin-top: 1rem;
 }
 
@@ -47,6 +48,7 @@ exports[`Fieldset 1`] = `
 }
 
 .c2.c2 > * {
+  width: 100%;
   margin-top: 0.75rem;
 }
 

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Form with one child 1`] = `
 }
 
 .c0.c0 > * {
+  width: 100%;
   margin-top: 1rem;
 }
 

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -7,10 +7,6 @@ exports[`Form with one child 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -2,25 +2,24 @@
 
 exports[`Form with one child 1`] = `
 .c0 {
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0.c0 > * {
-  width: 100%;
   margin-top: 1rem;
 }
 
-.c0.c0 > :first-child {
+.c0.c0 > *:first-child {
   margin-top: 0rem;
 }
 
@@ -152,7 +151,6 @@ exports[`Form with one child 1`] = `
 
 <form
   className="c0"
-  width="100%"
 >
   <div
     className="c1 "

--- a/packages/components/src/Layout/Space/Space.test.tsx
+++ b/packages/components/src/Layout/Space/Space.test.tsx
@@ -61,3 +61,47 @@ test('Space reversed', () => {
     </Space>
   )
 })
+
+test('Space around + gap (all you get is around)', () => {
+  assertSnapshot(
+    <Space around gap="xxlarge">
+      <div>🥑</div>
+      <div>🐛</div>
+      <div>🦜</div>
+      <div>🐈</div>
+    </Space>
+  )
+})
+
+test('Space around', () => {
+  assertSnapshot(
+    <Space around>
+      <div>🥑</div>
+      <div>🐛</div>
+      <div>🦜</div>
+      <div>🐈</div>
+    </Space>
+  )
+})
+
+test('Space between', () => {
+  assertSnapshot(
+    <Space between>
+      <div>🥑</div>
+      <div>🐛</div>
+      <div>🦜</div>
+      <div>🐈</div>
+    </Space>
+  )
+})
+
+test('Space evenly', () => {
+  assertSnapshot(
+    <Space evenly>
+      <div>🥑</div>
+      <div>🐛</div>
+      <div>🦜</div>
+      <div>🐈</div>
+    </Space>
+  )
+})

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -25,6 +25,7 @@
  */
 
 import styled, { css } from 'styled-components'
+import { variant } from 'styled-system'
 import { SpacingSizes, flexbox, FlexboxProps } from '@looker/design-tokens'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../utils/simple'
 
@@ -66,6 +67,14 @@ export interface SpaceHelperProps extends SimpleLayoutProps, FlexboxProps {
   reverse?: boolean
 }
 
+interface SpaceProps extends SpaceHelperProps {
+  /**
+   * Align items vertically within `Space`
+   * @default 'center'
+   */
+  verticalAlign?: 'start' | 'center' | 'end'
+}
+
 export const defaultSpaceSize = 'medium'
 
 export const spaceCSS = css`
@@ -75,7 +84,7 @@ export const spaceCSS = css`
   display: flex;
 `
 
-const fauxFlexGap = (space: SpaceHelperProps) => css`
+const fauxFlexGap = (space: SpaceProps) => css`
   && > * {
     margin-left: ${({ theme }) => theme.space[space.gap || defaultSpaceSize]};
   }
@@ -86,8 +95,25 @@ const fauxFlexGap = (space: SpaceHelperProps) => css`
       : `&& > *:first-child { margin-left: ${theme.space.none}; }`}
 `
 
-export const Space = styled.div<SpaceHelperProps>`
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+const verticalAlign = variant({
+  prop: 'verticalAlign',
+  variants: {
+    start: {
+      alignItems: 'flex-start',
+    },
+    center: {
+      alignItems: 'center',
+    },
+    end: {
+      alignItems: 'flex-end',
+    },
+  },
+})
+
+export const Space = styled.div<SpaceProps>`
   ${spaceCSS}
+  ${verticalAlign}
   flex-direction: ${({ reverse }) => (reverse ? 'row-reverse' : 'row')};
 
   ${({ around }) => around && 'justify-content: space-around;'}
@@ -97,4 +123,4 @@ export const Space = styled.div<SpaceHelperProps>`
     !around && !between && !evenly && fauxFlexGap}
 `
 
-Space.defaultProps = { alignItems: 'center', width: '100%' }
+Space.defaultProps = { alignItems: 'center' }

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -34,7 +34,7 @@ export interface SpaceHelperProps extends SimpleLayoutProps, FlexboxProps {
    * Amount of space between grid cells
    * @default 'medium'
    */
-  gap?: SpacingSizes | 'between' | 'evenly'
+  gap?: SpacingSizes
 
   /**
    * The spacing between each pair of adjacent items is the same. The empty space before the

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -65,14 +65,17 @@ export interface SpaceHelperProps extends SimpleLayoutProps, FlexboxProps {
    * @default false
    */
   reverse?: boolean
-}
-
-interface SpaceProps extends SpaceHelperProps {
   /**
    * Align items vertically within `Space`
    * @default 'center'
    */
-  verticalAlign?: 'start' | 'center' | 'end'
+  align?: 'start' | 'center' | 'end'
+
+  /**
+   * Stretch items full width of space
+   * @default false
+   */
+  stretch?: boolean
 }
 
 export const defaultSpaceSize = 'medium'
@@ -84,7 +87,7 @@ export const spaceCSS = css`
   display: flex;
 `
 
-const fauxFlexGap = (space: SpaceProps) => css`
+const fauxFlexGap = (space: SpaceHelperProps) => css`
   && > * {
     margin-left: ${({ theme }) => theme.space[space.gap || defaultSpaceSize]};
   }
@@ -95,25 +98,24 @@ const fauxFlexGap = (space: SpaceProps) => css`
       : `&& > *:first-child { margin-left: ${theme.space.none}; }`}
 `
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 const verticalAlign = variant({
-  prop: 'verticalAlign',
+  prop: 'align',
   variants: {
-    start: {
-      alignItems: 'flex-start',
-    },
     center: {
       alignItems: 'center',
     },
     end: {
       alignItems: 'flex-end',
     },
+    start: {
+      alignItems: 'flex-start',
+    },
   },
 })
 
-export const Space = styled.div<SpaceProps>`
+export const Space = styled.div<SpaceHelperProps>`
   ${spaceCSS}
-  ${verticalAlign}
+  ${({ stretch }) => !stretch && verticalAlign}
   flex-direction: ${({ reverse }) => (reverse ? 'row-reverse' : 'row')};
 
   ${({ around }) => around && 'justify-content: space-around;'}

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -33,7 +33,31 @@ export interface SpaceHelperProps extends SimpleLayoutProps {
    * Amount of space between grid cells
    * @default 'medium'
    */
-  gap?: SpacingSizes
+  gap?: SpacingSizes | 'between' | 'evenly'
+
+  /**
+   * The spacing between each pair of adjacent items is the same. The empty space before the
+   * first and after the last item equals half of the space between each pair of adjacent items.
+   * (citation: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
+   * @default false
+   */
+  around?: boolean
+
+  /**
+   * The spacing between each pair of adjacent items is the same. The first item is flush with
+   * the main-start edge, and the last item is flush with the main-end edge.
+   * (citation: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
+   * @default false
+   */
+  between?: boolean
+
+  /**
+   * The spacing between each pair of adjacent items, the main-start edge and the first item,
+   * and the main-end edge and the last item, are all exactly the same.
+   * (citation: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
+   * @default false
+   */
+  evenly?: boolean
 
   /**
    * reverse direction of content
@@ -51,18 +75,27 @@ export const spaceCSS = css`
   align-items: flex-start;
 `
 
+const fauxFlexGap = (space: SpaceHelperProps) => css`
+  && > * {
+    margin-left: ${({ theme }) => theme.space[space.gap || defaultSpaceSize]};
+  }
+
+  ${({ theme }) =>
+    space.reverse
+      ? `&& > *:last-child { margin-left: ${theme.space.none}; }`
+      : `&& > *:first-child { margin-left: ${theme.space.none}; }`}
+`
+
 export const Space = styled.div<SpaceHelperProps>`
   ${spaceCSS}
   flex-direction: ${({ reverse }) => (reverse ? 'row-reverse' : 'row')};
+  align-items: center;
 
-  && > * {
-    margin-left: ${({ theme, gap }) => theme.space[gap || defaultSpaceSize]};
-  }
-
-  ${({ theme, reverse }) =>
-    reverse
-      ? `&& > :last-child { margin-left: ${theme.space.none}; }`
-      : `&& > :first-child { margin-left: ${theme.space.none}; }`}
+  ${({ around }) => around && 'justify-content: space-around;'}
+  ${({ between }) => between && 'justify-content: space-between;'}
+  ${({ evenly }) => evenly && 'justify-content: space-evenly;'}
+  ${({ around, between, evenly }) =>
+    !around && !between && !evenly && fauxFlexGap}
 `
 
 Space.defaultProps = { width: '100%' }

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -25,10 +25,10 @@
  */
 
 import styled, { css } from 'styled-components'
-import { SpacingSizes } from '@looker/design-tokens'
+import { SpacingSizes, flexbox, FlexboxProps } from '@looker/design-tokens'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../utils/simple'
 
-export interface SpaceHelperProps extends SimpleLayoutProps {
+export interface SpaceHelperProps extends SimpleLayoutProps, FlexboxProps {
   /**
    * Amount of space between grid cells
    * @default 'medium'
@@ -70,9 +70,9 @@ export const defaultSpaceSize = 'medium'
 
 export const spaceCSS = css`
   ${simpleLayoutCSS}
+  ${flexbox}
 
   display: flex;
-  align-items: flex-start;
 `
 
 const fauxFlexGap = (space: SpaceHelperProps) => css`
@@ -89,7 +89,6 @@ const fauxFlexGap = (space: SpaceHelperProps) => css`
 export const Space = styled.div<SpaceHelperProps>`
   ${spaceCSS}
   flex-direction: ${({ reverse }) => (reverse ? 'row-reverse' : 'row')};
-  align-items: center;
 
   ${({ around }) => around && 'justify-content: space-around;'}
   ${({ between }) => between && 'justify-content: space-between;'}
@@ -98,4 +97,4 @@ export const Space = styled.div<SpaceHelperProps>`
     !around && !between && !evenly && fauxFlexGap}
 `
 
-Space.defaultProps = { width: '100%' }
+Space.defaultProps = { alignItems: 'center', width: '100%' }

--- a/packages/components/src/Layout/Space/SpaceVertical.tsx
+++ b/packages/components/src/Layout/Space/SpaceVertical.tsx
@@ -34,6 +34,7 @@ export const SpaceVertical = styled.div<SpaceHelperProps>`
   flex-shrink: 1;
 
   && > * {
+    width: 100%;
     margin-top: ${({ theme, gap }) => theme.space[gap || defaultSpaceSize]};
   }
 

--- a/packages/components/src/Layout/Space/SpaceVertical.tsx
+++ b/packages/components/src/Layout/Space/SpaceVertical.tsx
@@ -25,23 +25,52 @@
  */
 
 import styled from 'styled-components'
+import { variant } from 'styled-system'
 import { defaultSpaceSize, spaceCSS, SpaceHelperProps } from './Space'
 
-export const SpaceVertical = styled.div<SpaceHelperProps>`
-  ${spaceCSS}
+interface SpaceVerticalProps extends SpaceHelperProps {
+  /**
+   * Align items vertically within `Space`
+   * @default 'start'
+   */
+  align?: 'start' | 'center' | 'end'
 
+  /**
+   * Stretch items full width of space
+   * @default false
+   */
+  stretch?: boolean
+}
+
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+const align = variant({
+  prop: 'align',
+  variants: {
+    start: {
+      alignItems: 'flex-start',
+    },
+    center: {
+      alignItems: 'center',
+    },
+    end: {
+      alignItems: 'flex-end',
+    },
+  },
+})
+
+export const SpaceVertical = styled.div<SpaceVerticalProps>`
+  ${spaceCSS}
+  ${({ stretch }) => !stretch && align}
   flex-direction: ${({ reverse }) => (reverse ? 'column-reverse' : 'column')};
-  flex-shrink: 1;
 
   && > * {
-    width: 100%;
     margin-top: ${({ theme, gap }) => theme.space[gap || defaultSpaceSize]};
   }
 
   ${({ theme, reverse }) =>
     reverse
-      ? `&& > :last-child { margin-top: ${theme.space.none}; }`
-      : `&& > :first-child { margin-top: ${theme.space.none}; }`}
+      ? `&& > *:last-child { margin-top: ${theme.space.none}; }`
+      : `&& > *:first-child { margin-top: ${theme.space.none}; }`}
 `
 
-SpaceVertical.defaultProps = { width: '100%' }
+SpaceVertical.defaultProps = { align: 'start' }

--- a/packages/components/src/Layout/Space/SpaceVertical.tsx
+++ b/packages/components/src/Layout/Space/SpaceVertical.tsx
@@ -42,18 +42,17 @@ interface SpaceVerticalProps extends SpaceHelperProps {
   stretch?: boolean
 }
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 const align = variant({
   prop: 'align',
   variants: {
-    start: {
-      alignItems: 'flex-start',
-    },
     center: {
       alignItems: 'center',
     },
     end: {
       alignItems: 'flex-end',
+    },
+    start: {
+      alignItems: 'flex-start',
     },
   },
 })

--- a/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
@@ -14,13 +14,17 @@ exports[`Space default 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c0.c0 > * {
   margin-left: 1rem;
 }
 
-.c0.c0 > :first-child {
+.c0.c0 > *:first-child {
   margin-left: 0rem;
 }
 
@@ -57,13 +61,17 @@ exports[`Space reversed 1`] = `
   -webkit-flex-direction: row-reverse;
   -ms-flex-direction: row-reverse;
   flex-direction: row-reverse;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c0.c0 > * {
   margin-left: 1rem;
 }
 
-.c0.c0 > :last-child {
+.c0.c0 > *:last-child {
   margin-left: 0rem;
 }
 
@@ -100,13 +108,17 @@ exports[`Space with specified gap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c0.c0 > * {
   margin-left: 2rem;
 }
 
-.c0.c0 > :first-child {
+.c0.c0 > *:first-child {
   margin-left: 0rem;
 }
 

--- a/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
@@ -1,5 +1,134 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Space around + gap (all you get is around) 1`] = `
+.c0 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="c0"
+  width="100%"
+>
+  <div>
+    🥑
+  </div>
+  <div>
+    🐛
+  </div>
+  <div>
+    🦜
+  </div>
+  <div>
+    🐈
+  </div>
+</div>
+`;
+
+exports[`Space around 1`] = `
+.c0 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+<div
+  className="c0"
+  width="100%"
+>
+  <div>
+    🥑
+  </div>
+  <div>
+    🐛
+  </div>
+  <div>
+    🦜
+  </div>
+  <div>
+    🐈
+  </div>
+</div>
+`;
+
+exports[`Space between 1`] = `
+.c0 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+<div
+  className="c0"
+  width="100%"
+>
+  <div>
+    🥑
+  </div>
+  <div>
+    🐛
+  </div>
+  <div>
+    🦜
+  </div>
+  <div>
+    🐈
+  </div>
+</div>
+`;
+
 exports[`Space default 1`] = `
 .c0 {
   width: 100%;
@@ -26,6 +155,49 @@ exports[`Space default 1`] = `
 
 .c0.c0 > *:first-child {
   margin-left: 0rem;
+}
+
+<div
+  className="c0"
+  width="100%"
+>
+  <div>
+    🥑
+  </div>
+  <div>
+    🐛
+  </div>
+  <div>
+    🦜
+  </div>
+  <div>
+    🐈
+  </div>
+</div>
+`;
+
+exports[`Space evenly 1`] = `
+.c0 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
 }
 
 <div

--- a/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Space around + gap (all you get is around) 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14,10 +13,6 @@ exports[`Space around + gap (all you get is around) 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   -webkit-box-pack: space-around;
   -webkit-justify-content: space-around;
   -ms-flex-pack: space-around;
@@ -26,7 +21,6 @@ exports[`Space around + gap (all you get is around) 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -45,7 +39,6 @@ exports[`Space around + gap (all you get is around) 1`] = `
 
 exports[`Space around 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -57,10 +50,6 @@ exports[`Space around 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   -webkit-box-pack: space-around;
   -webkit-justify-content: space-around;
   -ms-flex-pack: space-around;
@@ -69,7 +58,6 @@ exports[`Space around 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -88,7 +76,6 @@ exports[`Space around 1`] = `
 
 exports[`Space between 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -100,10 +87,6 @@ exports[`Space between 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -112,7 +95,6 @@ exports[`Space between 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -131,7 +113,6 @@ exports[`Space between 1`] = `
 
 exports[`Space default 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -143,10 +124,6 @@ exports[`Space default 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c0.c0 > * {
@@ -159,7 +136,6 @@ exports[`Space default 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -178,7 +154,6 @@ exports[`Space default 1`] = `
 
 exports[`Space evenly 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -190,10 +165,6 @@ exports[`Space evenly 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   -webkit-box-pack: space-evenly;
   -webkit-justify-content: space-evenly;
   -ms-flex-pack: space-evenly;
@@ -202,7 +173,6 @@ exports[`Space evenly 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -221,7 +191,6 @@ exports[`Space evenly 1`] = `
 
 exports[`Space reversed 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -233,10 +202,6 @@ exports[`Space reversed 1`] = `
   -webkit-flex-direction: row-reverse;
   -ms-flex-direction: row-reverse;
   flex-direction: row-reverse;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c0.c0 > * {
@@ -249,7 +214,6 @@ exports[`Space reversed 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -268,7 +232,6 @@ exports[`Space reversed 1`] = `
 
 exports[`Space with specified gap 1`] = `
 .c0 {
-  width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -280,10 +243,6 @@ exports[`Space with specified gap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c0.c0 > * {
@@ -296,7 +255,6 @@ exports[`Space with specified gap 1`] = `
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑

--- a/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Space around + gap (all you get is around) 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -46,14 +46,14 @@ exports[`Space around + gap (all you get is around) 1`] = `
 exports[`Space around 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -89,14 +89,14 @@ exports[`Space around 1`] = `
 exports[`Space between 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -132,14 +132,14 @@ exports[`Space between 1`] = `
 exports[`Space default 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -179,14 +179,14 @@ exports[`Space default 1`] = `
 exports[`Space evenly 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -222,14 +222,14 @@ exports[`Space evenly 1`] = `
 exports[`Space reversed 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row-reverse;
   -ms-flex-direction: row-reverse;
   flex-direction: row-reverse;
@@ -269,14 +269,14 @@ exports[`Space reversed 1`] = `
 exports[`Space with specified gap 1`] = `
 .c0 {
   width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;

--- a/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
@@ -2,31 +2,29 @@
 
 exports[`SpaceVertical default 1`] = `
 .c0 {
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0.c0 > * {
-  width: 100%;
   margin-top: 1rem;
 }
 
-.c0.c0 > :first-child {
+.c0.c0 > *:first-child {
   margin-top: 0rem;
 }
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -45,31 +43,29 @@ exports[`SpaceVertical default 1`] = `
 
 exports[`SpaceVertical reversed 1`] = `
 .c0 {
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: column-reverse;
   -ms-flex-direction: column-reverse;
   flex-direction: column-reverse;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0.c0 > * {
-  width: 100%;
   margin-top: 1rem;
 }
 
-.c0.c0 > :last-child {
+.c0.c0 > *:last-child {
   margin-top: 0rem;
 }
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑
@@ -88,31 +84,29 @@ exports[`SpaceVertical reversed 1`] = `
 
 exports[`SpaceVertical with specified gap 1`] = `
 .c0 {
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
 }
 
 .c0.c0 > * {
-  width: 100%;
   margin-top: 2rem;
 }
 
-.c0.c0 > :first-child {
+.c0.c0 > *:first-child {
   margin-top: 0rem;
 }
 
 <div
   className="c0"
-  width="100%"
 >
   <div>
     🥑

--- a/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`SpaceVertical default 1`] = `
 }
 
 .c0.c0 > * {
+  width: 100%;
   margin-top: 1rem;
 }
 
@@ -66,6 +67,7 @@ exports[`SpaceVertical reversed 1`] = `
 }
 
 .c0.c0 > * {
+  width: 100%;
   margin-top: 1rem;
 }
 
@@ -112,6 +114,7 @@ exports[`SpaceVertical with specified gap 1`] = `
 }
 
 .c0.c0 > * {
+  width: 100%;
   margin-top: 2rem;
 }
 

--- a/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
@@ -7,10 +7,6 @@ exports[`SpaceVertical default 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -54,10 +50,6 @@ exports[`SpaceVertical reversed 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column-reverse;
   -ms-flex-direction: column-reverse;
   flex-direction: column-reverse;
@@ -101,10 +93,6 @@ exports[`SpaceVertical with specified gap 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;

--- a/packages/www/src/documentation/components/actions/button.mdx
+++ b/packages/www/src/documentation/components/actions/button.mdx
@@ -19,10 +19,12 @@ Use a primary button for the most frequently used action or most important actio
 #### Primary states
 
 ```jsx
-<Button mr="xsmall">Primary Idle</Button>
-<Button mr="xsmall" className="hover">Primary Hover</Button>
-<Button mr="xsmall" className="active">Primary Active</Button>
-<Button disabled>Disabled</Button>
+<Space>
+  <Button>Primary Idle</Button>
+  <Button className="hover">Primary Hover</Button>
+  <Button className="active">Primary Active</Button>
+  <Button disabled>Disabled</Button>
+</Space>
 ```
 
 ### ButtonOutline
@@ -36,11 +38,13 @@ Use an outline button alongside a primary button to provide alternative actions 
 #### Outline states
 
 ```jsx
-<ButtonOutline m="xsmall">Outline Idle</ButtonOutline>
-<ButtonOutline m="xsmall" className="hover">Outline Hover</ButtonOutline>
-<ButtonOutline m="xsmall" className="active">Outline Active</ButtonOutline>
-<ButtonOutline m="xsmall" color="danger">Outline Danger</ButtonOutline>
-<ButtonOutline disabled>Outline Disabled</ButtonOutline>
+<Space wrap>
+  <ButtonOutline>Idle</ButtonOutline>
+  <ButtonOutline className="hover">Hover</ButtonOutline>
+  <ButtonOutline className="active">Active</ButtonOutline>
+  <ButtonOutline color="danger">Danger</ButtonOutline>
+  <ButtonOutline disabled>Disabled</ButtonOutline>
+</Space>
 ```
 
 ### ButtonTransparent
@@ -54,11 +58,13 @@ Use a transparent button as a tertiary action on a screen, they are often used a
 #### Transparent states
 
 ```jsx
-<ButtonTransparent m="xsmall"> Transparent Idle </ButtonTransparent>
-<ButtonTransparent m="xsmall" className="hover"> Transparent Hover </ButtonTransparent>
-<ButtonTransparent m="xsmall" className="active"> Transparent Active </ButtonTransparent>
-<ButtonTransparent m="xsmall" color="danger"> Transparent Danger </ButtonTransparent>
-<ButtonTransparent disabled> Transparent Disabled </ButtonTransparent>
+<Space wrap>
+  <ButtonTransparent>Idle</ButtonTransparent>
+  <ButtonTransparent className="hover">Hover</ButtonTransparent>
+  <ButtonTransparent className="active">Active</ButtonTransparent>
+  <ButtonTransparent color="danger">Danger</ButtonTransparent>
+  <ButtonTransparent disabled>Disabled</ButtonTransparent>
+</Space>
 ```
 
 ## Colors
@@ -74,10 +80,18 @@ Danger Buttons are to be used in situations where you need to convey some very i
 #### Danger States
 
 ```jsx
-<Button mr="xsmall" color="danger">Danger Idle</Button>
-<Button mr="xsmall" color="danger" className="hover">Danger Hover</Button>
-<Button mr="xsmall" color="danger" className="active">Danger Active</Button>
-<Button color="danger" disabled>Danger Disabled</Button>
+<Space>
+  <Button color="danger">Danger Idle</Button>
+  <Button color="danger" className="hover">
+    Danger Hover
+  </Button>
+  <Button color="danger" className="active">
+    Danger Active
+  </Button>
+  <Button color="danger" disabled>
+    Danger Disabled
+  </Button>
+</Space>
 ```
 
 ## Size
@@ -85,10 +99,12 @@ Danger Buttons are to be used in situations where you need to convey some very i
 Use the size property on a `<Button />` to modify the size the button rendered. You can combine it with the `mode` property to get the correct style and size of button you need.
 
 ```jsx
-<Button size="xsmall" mr="xsmall"> Xsmall Button </Button>
-<Button size="small" mr="xsmall"> Small Button </Button>
-<Button mr="xsmall">Medium (default) Button</Button>
-<Button size="large">Large Button</Button>
+<Space>
+  <Button size="xsmall">Xsmall Button</Button>
+  <Button size="small">Small Button</Button>
+  <Button>Medium (default) Button</Button>
+  <Button size="large">Large Button</Button>
+</Space>
 ```
 
 ## Full Width
@@ -121,14 +137,10 @@ Buttons can have an icon before or after their content, using the `iconBefore` a
 When a call to action requires additional steps, include an ellipsis at the end of the button text as a visual clue. This helps reinforce that there are additional steps that can take place before the action takes effect.
 
 ```jsx
-<List>
-  <ListItem>
-    <Button color="danger">Move to Trash...</Button>
-  </ListItem>
-  <ListItem>
-    <Button>Print...</Button>
-  </ListItem>
-</List>
+<Space>
+  <Button color="danger">Move to Trash...</Button>
+  <Button>Print...</Button>
+</Space>
 ```
 
 ## Extending Button
@@ -141,8 +153,4 @@ Sometimes you may want to extend the Button defaults to create a specific stylin
 const RoundButton = styled(Button)`
   border-radius: 2rem;
 `
-
-render(
-  <RoundButton>
-)
 ```

--- a/packages/www/src/documentation/components/actions/button.mdx
+++ b/packages/www/src/documentation/components/actions/button.mdx
@@ -38,7 +38,7 @@ Use an outline button alongside a primary button to provide alternative actions 
 #### Outline states
 
 ```jsx
-<Space wrap>
+<Space>
   <ButtonOutline>Idle</ButtonOutline>
   <ButtonOutline className="hover">Hover</ButtonOutline>
   <ButtonOutline className="active">Active</ButtonOutline>
@@ -58,7 +58,7 @@ Use a transparent button as a tertiary action on a screen, they are often used a
 #### Transparent states
 
 ```jsx
-<Space wrap>
+<Space>
   <ButtonTransparent>Idle</ButtonTransparent>
   <ButtonTransparent className="hover">Hover</ButtonTransparent>
   <ButtonTransparent className="active">Active</ButtonTransparent>

--- a/packages/www/src/documentation/components/actions/button.mdx
+++ b/packages/www/src/documentation/components/actions/button.mdx
@@ -128,8 +128,12 @@ Use a disabled button to indicate to the user what action will be possible on a 
 Buttons can have an icon before or after their content, using the `iconBefore` and `iconAfter` property. Each property accepts the [name of an icon](/#!/Icons)
 
 ```jsx
-<Button iconBefore="CircleAdd" mr="large">Add To Cart</Button>
-<Button iconAfter="Trash" color="danger">Delete</Button>
+<Space>
+  <Button iconBefore="CircleAdd">Add To Cart</Button>
+  <Button iconAfter="Trash" color="danger">
+    Delete
+  </Button>
+</Space>
 ```
 
 ## Additional Action Considerations

--- a/packages/www/src/documentation/components/actions/icon-button.mdx
+++ b/packages/www/src/documentation/components/actions/icon-button.mdx
@@ -9,7 +9,7 @@ It require a `label` that describes it's action. The `label` should be descripti
 If you need an icon for purely decorative purposes use an `<Icon />` instead.
 
 ```jsx
-<Space>
+<Space evenly>
   <IconButton icon="Plus" label="Add Something Neat" />
   <IconButton icon="Gear" label="Settings" />
   <IconButton icon="Trash" label="Trash It" />
@@ -25,7 +25,7 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 - `xxsmall` | `xsmall` (default) | `small` | `medium` | `large`
 
 ```jsx
-<Space>
+<Space evenly>
   <IconButton icon="Favorite" label="Add to Favorites" size="xxsmall" />
   <IconButton icon="Favorite" label="Add to Favorites" />
   <IconButton icon="Favorite" label="Add to Favorites" size="small" />
@@ -39,7 +39,7 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 - `round` | `square` (default)
 
 ```jsx
-<Space>
+<Space evenly>
   <IconButton
     icon="Trash"
     label="Trash it"
@@ -62,7 +62,7 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 - `danger` | `neutral` (default) | `primary` | `secondary`
 
 ```jsx
-<Space>
+<Space evenly>
   <IconButton color="danger" icon="Gear" label="Settings" size="large" />
   <IconButton color="neutral" icon="Gear" label="Settings" size="large" />
   <IconButton color="primary" icon="Gear" label="Settings" size="large" />

--- a/packages/www/src/documentation/components/actions/icon-button.mdx
+++ b/packages/www/src/documentation/components/actions/icon-button.mdx
@@ -82,15 +82,7 @@ Create the styled rules desired and wrap the `IconButton` component on it.
       transform: rotate(45deg);
     }
   `
-  return (
-    <HoverVariantButton
-      label="Close"
-      icon="Close"
-      size="large"
-      outline
-      mr="small"
-    />
-  )
+  return <HoverVariantButton label="Close" icon="Close" size="large" outline />
 }
 ```
 

--- a/packages/www/src/documentation/components/actions/icon-button.mdx
+++ b/packages/www/src/documentation/components/actions/icon-button.mdx
@@ -9,25 +9,13 @@ It require a `label` that describes it's action. The `label` should be descripti
 If you need an icon for purely decorative purposes use an `<Icon />` instead.
 
 ```jsx
-;() => {
-  const ButtonCollection = styled.div`
-    display: grid;
-    grid-auto-flow: column;
-    grid-gap: ${({ theme }) => theme.space.medium};
-    justify-items: center;
-    align-items: center;
-  `
-
-  return (
-    <ButtonCollection>
-      <IconButton icon="Plus" label="Add Something Neat" />
-      <IconButton icon="Gear" label="Settings" />
-      <IconButton icon="Trash" label="Trash It" />
-      <IconButton icon="Close" label="Close" />
-      <IconButton icon="Favorite" label="Add to Favorites" />
-    </ButtonCollection>
-  )
-}
+<Space>
+  <IconButton icon="Plus" label="Add Something Neat" />
+  <IconButton icon="Gear" label="Settings" />
+  <IconButton icon="Trash" label="Trash It" />
+  <IconButton icon="Close" label="Close" />
+  <IconButton icon="Favorite" label="Add to Favorites" />
+</Space>
 ```
 
 ### IconButton Options
@@ -37,24 +25,13 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 - `xxsmall` | `xsmall` (default) | `small` | `medium` | `large`
 
 ```jsx
-;() => {
-  const ButtonCollection = styled.div`
-    display: grid;
-    grid-auto-flow: column;
-    grid-gap: ${({ theme }) => theme.space.medium};
-    justify-items: center;
-    align-items: center;
-  `
-  return (
-    <ButtonCollection>
-      <IconButton icon="Favorite" label="Add to Favorites" size="xxsmall" />
-      <IconButton icon="Favorite" label="Add to Favorites" />
-      <IconButton icon="Favorite" label="Add to Favorites" size="small" />
-      <IconButton icon="Favorite" label="Add to Favorites" size="medium" />
-      <IconButton icon="Favorite" label="Add to Favorites" size="large" />
-    </ButtonCollection>
-  )
-}
+<Space>
+  <IconButton icon="Favorite" label="Add to Favorites" size="xxsmall" />
+  <IconButton icon="Favorite" label="Add to Favorites" />
+  <IconButton icon="Favorite" label="Add to Favorites" size="small" />
+  <IconButton icon="Favorite" label="Add to Favorites" size="medium" />
+  <IconButton icon="Favorite" label="Add to Favorites" size="large" />
+</Space>
 ```
 
 ## Shapes
@@ -62,34 +39,22 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 - `round` | `square` (default)
 
 ```jsx
-;() => {
-  const ButtonCollection = styled.div`
-    display: grid;
-    grid-auto-flow: column;
-    grid-gap: ${({ theme }) => theme.space.medium};
-    justify-items: center;
-    align-items: center;
-  `
-
-  return (
-    <ButtonCollection>
-      <IconButton
-        icon="Trash"
-        label="Trash it"
-        outline
-        shape="round"
-        size="xxsmall"
-      />
-      <IconButton
-        icon="Trash"
-        label="Trash it"
-        outline
-        shape="round"
-        size="large"
-      />
-    </ButtonCollection>
-  )
-}
+<Space>
+  <IconButton
+    icon="Trash"
+    label="Trash it"
+    outline
+    shape="round"
+    size="xxsmall"
+  />
+  <IconButton
+    icon="Trash"
+    label="Trash it"
+    outline
+    shape="round"
+    size="large"
+  />
+</Space>
 ```
 
 ## Color
@@ -97,24 +62,12 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 - `danger` | `neutral` (default) | `primary` | `secondary`
 
 ```jsx
-;() => {
-  const ButtonCollection = styled.div`
-    display: grid;
-    grid-auto-flow: column;
-    grid-gap: ${({ theme }) => theme.space.medium};
-    justify-items: center;
-    align-items: center;
-  `
-
-  return (
-    <ButtonCollection>
-      <IconButton color="danger" icon="Gear" label="Settings" size="large" />
-      <IconButton color="neutral" icon="Gear" label="Settings" size="large" />
-      <IconButton color="primary" icon="Gear" label="Settings" size="large" />
-      <IconButton color="secondary" icon="Gear" label="Settings" size="large" />
-    </ButtonCollection>
-  )
-}
+<Space>
+  <IconButton color="danger" icon="Gear" label="Settings" size="large" />
+  <IconButton color="neutral" icon="Gear" label="Settings" size="large" />
+  <IconButton color="primary" icon="Gear" label="Settings" size="large" />
+  <IconButton color="secondary" icon="Gear" label="Settings" size="large" />
+</Space>
 ```
 
 ## Animation

--- a/packages/www/src/documentation/components/content/banner.mdx
+++ b/packages/www/src/documentation/components/content/banner.mdx
@@ -7,7 +7,7 @@ github: Banner
 The `<Banner />` component is used to alert the user with `warning`, `error`, `info`, or `confirmation` messages, settable via the `intent` property.
 
 ```jsx
-<SpaceVertical>
+<SpaceVertical gap="xsmall">
   <Banner intent="warning">Warning</Banner>
   <Banner intent="error">Error</Banner>
   <Banner intent="info">Info</Banner>

--- a/packages/www/src/documentation/components/content/card.mdx
+++ b/packages/www/src/documentation/components/content/card.mdx
@@ -60,83 +60,70 @@ The `CardMedia` component accepts and `image` property that will render the imag
 A few common patterns for `Cards` are displaying them in groups and using images to reinforce the content of the card.
 
 ```jsx
-<Flex>
-  <FlexItem width="33%" mr="small">
-    <Card raised>
-      <CardMedia
-        image="https://placeimg.com/640/480/nature"
-        title="Summer Nature"
-      />
-      <CardContent>
-        <Text
-          fontSize="xsmall"
-          textTransform="uppercase"
-          fontWeight="semiBold"
-          variant="subdued"
-        >
-          Summer
-        </Text>
-        <Heading as="h4" fontSize="medium" fontWeight="semiBold" truncate>
-          Life in The Great Outdoors
-        </Heading>
-        <div>
-          <Text fontSize="small">
-            10 reasons to get off the couch and head outside this summer.
-          </Text>
-        </div>
-      </CardContent>
-    </Card>
-  </FlexItem>
-  <FlexItem width="33%" mr="small">
-    <Card raised>
-      <CardMedia
-        image="https://placeimg.com/630/480/nature"
-        title="A Scenic Valley"
-      />
-      <CardContent>
-        <Text
-          fontSize="xsmall"
-          textTransform="uppercase"
-          fontWeight="semiBold"
-          variant="subdued"
-        >
-          Explore
-        </Text>
-        <Heading as="h4" fontSize="medium" fontWeight="semiBold" truncate>
-          Best Scenic Hikes
-        </Heading>
-        <div mt="xs">
-          <Text fontSize="small">
-            Looking for a new place to trailblaze? Make sure it has a great
-            view!
-          </Text>
-        </div>
-      </CardContent>
-    </Card>
-  </FlexItem>
-  <FlexItem width="33%">
-    <Card raised>
-      <CardMedia
-        image="https://placeimg.com/620/480/nature"
-        title="Relaxing Views"
-      />
-      <CardContent>
-        <Text
-          fontSize="xsmall"
-          textTransform="uppercase"
-          fontWeight="semiBold"
-          variant="subdued"
-        >
-          Relax
-        </Text>
-        <Heading as="h4" fontSize="large" fontWeight="semiBold" truncate>
-          Mindfull Wilderness
-        </Heading>
-        <div mt="xs">
-          <Text fontSize="small">Find a place to find your self.</Text>
-        </div>
-      </CardContent>
-    </Card>
-  </FlexItem>
-</Flex>
+<Grid columns={3}>
+  <Card raised>
+    <CardMedia
+      image="https://placeimg.com/640/480/nature"
+      title="Summer Nature"
+    />
+    <CardContent>
+      <Text
+        fontSize="xsmall"
+        textTransform="uppercase"
+        fontWeight="semiBold"
+        variant="subdued"
+      >
+        Summer
+      </Text>
+      <Heading as="h4" fontSize="medium" fontWeight="semiBold" truncate>
+        Life in The Great Outdoors
+      </Heading>
+      <Paragraph fontSize="small">
+        10 reasons to get off the couch and head outside this summer.
+      </Paragraph>
+    </CardContent>
+  </Card>
+  <Card raised>
+    <CardMedia
+      image="https://placeimg.com/630/480/nature"
+      title="A Scenic Valley"
+    />
+    <CardContent>
+      <Text
+        fontSize="xsmall"
+        textTransform="uppercase"
+        fontWeight="semiBold"
+        variant="subdued"
+      >
+        Explore
+      </Text>
+      <Heading as="h4" fontSize="medium" fontWeight="semiBold" truncate>
+        Best Scenic Hikes
+      </Heading>
+      <Paragraph fontSize="small">
+        Looking for a new place to trailblaze? Make sure it has a great view!
+      </Paragraph>
+    </CardContent>
+  </Card>
+  <Card raised>
+    <CardMedia
+      image="https://placeimg.com/620/480/nature"
+      title="Relaxing Views"
+    />
+    <CardContent>
+      <Text
+        fontSize="xsmall"
+        textTransform="uppercase"
+        fontWeight="semiBold"
+        variant="subdued"
+      >
+        Relax
+      </Text>
+      <Heading as="h4" fontSize="large" fontWeight="semiBold" truncate>
+        Mindfull Wilderness
+      </Heading>
+      <Paragraph fontSize="small">Find a place to find your self.</Paragraph>
+    </CardContent>
+  </Card>
+</Grid>
 ```

--- a/packages/www/src/documentation/components/content/divider.mdx
+++ b/packages/www/src/documentation/components/content/divider.mdx
@@ -8,12 +8,12 @@ propsOf: Divider
 Dividers accept all the spacing props from `<Box />`, which gives you the ability to easily put spacing around your dividers. By default a divider's background color will be `charcoal300`
 
 ```jsx
-<Flex justifyContent="space-around">
-  <Box bg="white" p="xlarge" mr="large">
+<Space around>
+  <Box bg="white" p="xlarge">
     On White
     <Divider mt="medium" />
   </Box>
-  <Box bg="palette.charcoal000" p="xlarge" mr="large">
+  <Box bg="palette.charcoal000" p="xlarge">
     On Charcoal000
     <Divider mt="medium" />
   </Box>
@@ -21,7 +21,7 @@ Dividers accept all the spacing props from `<Box />`, which gives you the abilit
     On Charcoal100
     <Divider mt="medium" />
   </Box>
-</Flex>
+</Space>
 ```
 
 ## Divider Appearance
@@ -29,12 +29,12 @@ Dividers accept all the spacing props from `<Box />`, which gives you the abilit
 There are three divider appearances `light`, `dark` and `onDark`.
 
 ```jsx
-<Flex justifyContent="space-around">
-  <Box bg="white " p="xlarge" mr="large">
+<Space around>
+  <Box bg="white " p="xlarge">
     light appearance
     <Divider mt="medium" appearance="light" />
   </Box>
-  <Box bg="palette.charcoal000" p="xlarge" mr="large">
+  <Box bg="palette.charcoal000" p="xlarge">
     dark appearance
     <Divider mt="medium" appearance="dark" />
   </Box>
@@ -42,7 +42,7 @@ There are three divider appearances `light`, `dark` and `onDark`.
     onDark appearance
     <Divider mt="medium" appearance="onDark" />
   </Box>
-</Flex>
+</Space>
 ```
 
 ## Custom Divider
@@ -50,8 +50,6 @@ There are three divider appearances `light`, `dark` and `onDark`.
 You can adjust the dividers height and supply a custom color if needed
 
 ```jsx
-<Box p="xlarge">
   Custom Divider
   <Divider size="8px" customColor="turquoise" mt="large" borderRadius="100px" />
-</Box>
 ```

--- a/packages/www/src/documentation/components/forms/checkbox.mdx
+++ b/packages/www/src/documentation/components/forms/checkbox.mdx
@@ -66,45 +66,30 @@ This may not be sufficient for your own use case, but it may provide a good star
   return (
     <List>
       <ListItem>
-        <Label htmlFor="fruit-parent" fontSize="medium">
-          <Checkbox
-            id="fruit-parent"
-            name="fruit"
-            value="all-fruit"
-            onChange={handleParentChange}
-            checked={parentState}
-            mr="xsmall"
-          />
-          All Fruit
-        </Label>
+        <FieldCheckbox
+          label="All Fruit"
+          value="all-fruit"
+          onChange={handleParentChange}
+          checked={parentState}
+        />
       </ListItem>
       <ListItem>
         <List pl="large">
           <ListItem>
-            <Label htmlFor="fruit-apple" fontSize="large">
-              <Checkbox
-                id="fruit-apple"
-                name="fruit"
-                value="apple"
-                onChange={handleAppleChange}
-                checked={appleState}
-                mr="xsmall"
-              />
-              🍏
-            </Label>
+            <FieldCheckbox
+              label="🍏"
+              value="apple"
+              onChange={handleAppleChange}
+              checked={appleState}
+            />
           </ListItem>
           <ListItem>
-            <Label htmlFor="fruit-banana" fontSize="large">
-              <Checkbox
-                id="fruit-banana"
-                name="fruit"
-                value="apple"
-                onChange={handleBananaChange}
-                checked={bananaState}
-                mr="xsmall"
-              />
-              🍌
-            </Label>
+            <FieldCheckbox
+              value="apple"
+              onChange={handleBananaChange}
+              checked={bananaState}
+              label="🍌"
+            />
           </ListItem>
         </List>
       </ListItem>
@@ -167,30 +152,10 @@ In most cases we emulate the HTML specification where it has an existing decisio
 - **Always** include a `<Label>` with a `for` property that matches the checkbox `id`.
 
 ```jsx
-<Label htmlFor="email-optin">
-  <Checkbox id="email-optin" value="confirm" />
-  Subscribe to our email list
-</Label>
+<FieldCheckbox label="Subscribe to our email list" value="confirm" />
 ```
 
-- Groups of checkboxes **must be** wrapped in a `<fieldset>` and have `<legend>` that describes the group
-
-```jsx
-<Fieldset legend="Pick your favorite emojis">
-  <Label>
-    <Checkbox name="emoji" value="pizza" mr="xsmall" />
-    🍕
-  </Label>
-  <Label htmlFor="avocado">
-    <Checkbox id="avocado" name="emoji" value="avocado" mr="xsmall" />
-    🥑
-  </Label>
-  <Label htmlFor="grapes">
-    <Checkbox id="grapes" name="emoji" value="grapes" mr="xsmall" />
-    🍇
-  </Label>
-</Fieldset>
-```
+- Groups of checkboxes **must be** wrapped in a `<fieldset>` and have `<legend>` that describes the group. We recommend utilizing `CheckboxGroup` for these use cases.
 
 ## Focus Expectations
 
@@ -210,17 +175,15 @@ In most cases we emulate the HTML specification where it has an existing decisio
 Use this to provide a detailed descriptions of a field that contains errors.
 
 ```jsx
-<>
-  <Label>
-    <Checkbox
-      id="approve"
-      aria-describedby="confirm-error-message"
-      mr="xsmall"
-    />
-    Approve Changes
-  </Label>
-  <p id="confirm-error-message">Confirm you approve these changes</p>
-</>
+<FieldCheckbox
+  id="approve"
+  aria-describedby="confirm-error-message"
+  label="Approve Changes"
+  validationMessage={{
+    type: 'error',
+    message: 'Confirm you approve these changes',
+  }}
+/>
 ```
 
-This would announce "Approve, unchecked checkbox. Confirm you approve these changes"
+This would announce "Approve, unchecked checkbox. Confirm you approve these changes."

--- a/packages/www/src/documentation/components/forms/input-date-range.mdx
+++ b/packages/www/src/documentation/components/forms/input-date-range.mdx
@@ -95,23 +95,19 @@ import { InputDateRangeLocales } from './demos'
   const textVariant = isValid ? 'default' : 'critical'
 
   return (
-    <>
-      <Box borderBottom="1px solid #ccc" pb="small" mb="large">
-        <Text variant="secondary">
-          INSTRUCTIONS: Try typing an invalid date string (ex:
-          'not/a/valid/date') and clicking or tabbing away to trigger blur
-          event.
-        </Text>
-        <Heading mt="medium">Result:</Heading>
-        <Text variant={textVariant}>{message}</Text>
-      </Box>
-      <div>
-        <InputDateRange
-          onChange={handleChange}
-          onValidationFail={handleValidationFail}
-        />
-      </div>
-    </>
+    <SpaceVertical>
+      <Text variant="secondary">
+        INSTRUCTIONS: Try typing an invalid date string (ex: 'not/a/valid/date')
+        and clicking or tabbing away to trigger blur event.
+      </Text>
+      <Heading>Result:</Heading>
+      <Text variant={textVariant}>{message}</Text>
+      <Divider />
+      <InputDateRange
+        onChange={handleChange}
+        onValidationFail={handleValidationFail}
+      />
+    </SpaceVertical>
   )
 }
 ```

--- a/packages/www/src/documentation/components/forms/input-date.mdx
+++ b/packages/www/src/documentation/components/forms/input-date.mdx
@@ -27,15 +27,15 @@ import { InputDateLocales } from './demos'
     setSelectedDate(date)
   }
   return (
-    <Flex>
+    <Space gap="xxlarge">
       <InputDate onChange={handleChange} defaultValue={selectedDate} />
-      <Box borderLeft="1px solid #ccc" pl="large">
-        <Heading mt="medium">Selected:</Heading>{' '}
+      <Box p="large" height="100%" borderLeft="1px solid #ccc">
+        <Heading>Selected:</Heading>
         <Text variant="secondary">
           <DateFormat>{selectedDate}</DateFormat>
         </Text>
       </Box>
-    </Flex>
+    </Space>
   )
 }
 ```
@@ -72,23 +72,21 @@ If you handle form validation externally (such as treating this date field as re
   const textVariant = isValid ? 'default' : 'critical'
 
   return (
-    <Flex>
-      <div>
-        <InputDate
-          onChange={handleChange}
-          onValidationFail={handleValidationFail}
-        />
-      </div>
-      <Box borderLeft="1px solid #ccc" pl="large">
-        <Text variant="secondary">
+    <Space gap="xxxlarge">
+      <InputDate
+        onChange={handleChange}
+        onValidationFail={handleValidationFail}
+      />
+      <SpaceVertical>
+        <Paragraph variant="secondary">
           INSTRUCTIONS: Try typing an invalid date string (ex:
           'not/a/valid/date') and clicking or tabbing away to trigger blur
           event.
-        </Text>
-        <Heading mt="medium">Result:</Heading>
+        </Paragraph>
+        <Heading>Result:</Heading>
         <Text variant={textVariant}>{message}</Text>
-      </Box>
-    </Flex>
+      </SpaceVertical>
+    </Space>
   )
 }
 ```

--- a/packages/www/src/documentation/components/forms/input-time-select.mdx
+++ b/packages/www/src/documentation/components/forms/input-time-select.mdx
@@ -17,22 +17,24 @@ The default implementation provides a dropdown list of times in 15-minute increm
 You can modify the list to increment time in 5, 10, 15, or 30 minute intervals.
 
 ```jsx
-<>
-  <Heading as="h3">5-minute</Heading>
-  <InputTimeSelect interval={5} />
-  <Heading as="h3" mt="small">
-    10-minute
-  </Heading>
-  <InputTimeSelect interval={10} />
-  <Heading as="h3" mt="small">
-    15-minute
-  </Heading>
-  <InputTimeSelect interval={15} />
-  <Heading as="h3" mt="small">
-    30-minute
-  </Heading>
-  <InputTimeSelect interval={30} />
-</>
+<Fieldset>
+  <SpaceVertical gap="xxsmall">
+    <Heading as="h4">5-minute</Heading>
+    <InputTimeSelect interval={5} />
+  </SpaceVertical>
+  <SpaceVertical gap="xxsmall">
+    <Heading as="h4">10-minute</Heading>
+    <InputTimeSelect interval={10} />
+  </SpaceVertical>
+  <SpaceVertical gap="xxsmall">
+    <Heading as="h4">15-minute</Heading>
+    <InputTimeSelect interval={15} />
+  </SpaceVertical>
+  <SpaceVertical gap="xxsmall">
+    <Heading as="h4">30-minute</Heading>
+    <InputTimeSelect interval={30} />
+  </SpaceVertical>
+</Fieldset>
 ```
 
 # 12- or 24-hour formatting
@@ -43,38 +45,22 @@ Depending on readability preference, the time picker can format the labels in ei
 ;() => {
   const [value, setValue] = useState('14:00')
   return (
-    <>
-      <Heading as="H3">12-hour</Heading>
-      <Flex>
-        <InputTimeSelect format="12h" value={value} onChange={setValue} />
-        <Text
-          variant="secondary"
-          fontWeight="bold"
-          mt="xsmall"
-          ml="small"
-          textTransform="uppercase"
-          fontSize="small"
-        >
-          Selected: {value}
-        </Text>
-      </Flex>
-      <Heading as="H3" mt="small">
-        24-hour
-      </Heading>
-      <Flex>
-        <InputTimeSelect format="24h" value={value} onChange={setValue} />
-        <Text
-          variant="secondary"
-          fontWeight="bold"
-          mt="xsmall"
-          ml="small"
-          textTransform="uppercase"
-          fontSize="small"
-        >
-          Selected: {value}
-        </Text>
-      </Flex>
-    </>
+    <Grid>
+      <SpaceVertical gap="xsmall">
+        <Heading as="h3">12-hour</Heading>
+        <Space>
+          <InputTimeSelect format="12h" value={value} onChange={setValue} />
+          <Text variant="secondary">{value}</Text>
+        </Space>
+      </SpaceVertical>
+      <SpaceVertical gap="xsmall">
+        <Heading as="h3">24-hour</Heading>
+        <Space>
+          <InputTimeSelect format="24h" value={value} onChange={setValue} />
+          <Text variant="secondary">{value}</Text>
+        </Space>
+      </SpaceVertical>
+    </Grid>
   )
 }
 ```
@@ -90,19 +76,10 @@ Consistent with all other inputs, `InputTimeSelect` accepts `value` and `onChang
 ;() => {
   const [value, setValue] = useState('14:00')
   return (
-    <Flex>
+    <Space>
       <InputTimeSelect value={value} onChange={setValue} />
-      <Text
-        variant="secondary"
-        fontWeight="bold"
-        mt="xsmall"
-        ml="small"
-        textTransform="uppercase"
-        fontSize="small"
-      >
-        Selected: {value}
-      </Text>
-    </Flex>
+      <Text variant="secondary">{value}</Text>
+    </Space>
   )
 }
 ```

--- a/packages/www/src/documentation/components/forms/input-time.mdx
+++ b/packages/www/src/documentation/components/forms/input-time.mdx
@@ -15,10 +15,10 @@ github: Form/Inputs/InputTime/InputTime.tsx
 `InputTime` can display either a 12-hour or 24-hour time selecting interface. If not specified, it defaults to 12-hour time.
 
 ```js
-<>
-  <InputTime format="12h" defaultValue="14:34" mr="small" />
+<Space>
+  <InputTime format="12h" defaultValue="14:34" />
   <InputTime format="24h" defaultValue="14:34" />
-</>
+</Space>
 ```
 
 ## Controlled Component
@@ -33,21 +33,13 @@ github: Form/Inputs/InputTime/InputTime.tsx
   const handle1632Click = () => setValue('16:32')
 
   return (
-    <>
-      <Button mr="small" onClick={handle1400Click}>
-        2:00pm
-      </Button>
-      <Button mr="small" onClick={handle1515Click}>
-        3:15pm
-      </Button>
-      <Button mr="small" onClick={handle1632Click}>
-        4:32pm
-      </Button>
-      <Flex mt="large" alignItems="center">
-        <InputTime value={value} mr="small" />
-        Selected: {value}
-      </Flex>
-    </>
+    <Space>
+      <Button onClick={handle1400Click}>2:00pm</Button>
+      <Button onClick={handle1515Click}>3:15pm</Button>
+      <Button onClick={handle1632Click}>4:32pm</Button>
+      <InputTime value={value} />
+      <span>Selected: {value}</span>
+    </Space>
   )
 }
 ```
@@ -81,10 +73,10 @@ As the name suggests, `readOnly` makes the text uneditable.
 You can combine the `id` prop with form label, so that when the label is clicked it will focus on the `hour` input.
 
 ```js
-<>
+<Space>
   <Label htmlFor="demo-id">Label Text</Label>
   <InputTime id="demo-id" />
-</>
+</Space>
 ```
 
 ## Focus & Blur
@@ -98,37 +90,10 @@ You can combine the `id` prop with form label, so that when the label is clicked
   const handleBlur = () => setIsFocused(false)
 
   return (
-    <>
+    <Space>
       <InputTime onFocus={handleFocus} onBlur={handleBlur} />
-      {isFocused && (
-        <Text color="green" ml="small">
-          FOCUSED!!
-        </Text>
-      )}
-    </>
-  )
-}
-```
-
-## Focus & Blur
-
-`onFocus` callback will fire when any of the three sub-fields (hour, minute, period) are focused. `onBlur` fires when the focus moves outside the component entirely.
-
-```js
-;() => {
-  const [isFocused, setIsFocused] = useState(false)
-  const handleFocus = () => setIsFocused(true)
-  const handleBlur = () => setIsFocused(false)
-
-  return (
-    <>
-      <InputTime onFocus={handleFocus} onBlur={handleBlur} />
-      {isFocused && (
-        <Text color="green" ml="small">
-          FOCUSED!!
-        </Text>
-      )}
-    </>
+      {isFocused && <Text color="green">FOCUSED!!</Text>}
+    </Space>
   )
 }
 ```
@@ -153,21 +118,19 @@ In addition, `InputTime` will automatically check whether the provided `value` p
     setValidationType('error')
   }
   return (
-    <>
+    <Space>
       <InputTime
         validationType={validationType}
         value={value}
         onValidationFail={handleValidationFail}
       />
       {validationType === 'error' && (
-        <Box mt="xsmall">
-          <Text color="red" fontSize="small" fontWeight="bold">
-            Error: <Code fontSize="small">{value}</Code> is not a valid 24-hour
-            time string
-          </Text>
-        </Box>
+        <Text variant="critical">
+          Error: <Code fontSize="small">{value}</Code> is not a valid 24-hour
+          time string
+        </Text>
       )}
-    </>
+    </Space>
   )
 }
 ```

--- a/packages/www/src/documentation/components/forms/range-slider.mdx
+++ b/packages/www/src/documentation/components/forms/range-slider.mdx
@@ -60,19 +60,17 @@ If you'd like to read and control the input value externally, `Slider` accepts a
 ;() => {
   const [sliderValue, setSliderValue] = useState([3, 7])
   return (
-    <CardContent>
+    <>
       <Heading>
         <strong>Value:</strong> {sliderValue[0]} &mdash; {sliderValue[1]}
       </Heading>
       <RangeSlider onChange={setSliderValue} value={sliderValue} />
-      <Button onClick={() => setSliderValue([0, 10])} mr="small">
-        0 &mdash; 10
-      </Button>
-      <Button onClick={() => setSliderValue([2, 8])} mr="small">
-        2 &mdash; 8
-      </Button>
-      <Button onClick={() => setSliderValue([4, 6])}>4 &mdash; 6</Button>
-    </CardContent>
+      <Space>
+        <Button onClick={() => setSliderValue([0, 10])}>0 &mdash; 10</Button>
+        <Button onClick={() => setSliderValue([2, 8])}>2 &mdash; 8</Button>
+        <Button onClick={() => setSliderValue([4, 6])}>4 &mdash; 6</Button>
+      </Space>
+    </>
   )
 }
 ```

--- a/packages/www/src/documentation/components/forms/select-multi.mdx
+++ b/packages/www/src/documentation/components/forms/select-multi.mdx
@@ -13,7 +13,7 @@ The `SelectMulti` component is an extension of the [`Select`](/components/forms/
 - Values can be cleared individually or all at once (does not use the `Select` component's `isClearable` prop)
 
 ```jsx
-<Flex justifyContent="space-between" alignItems="flex-start">
+<Space>
   <SelectMulti
     options={[
       { value: 'Cheddar' },
@@ -28,7 +28,6 @@ The `SelectMulti` component is an extension of the [`Select`](/components/forms/
     ]}
     placeholder="Cheeses"
     flex={1}
-    mr="medium"
   />
   <SelectMulti
     options={[
@@ -43,7 +42,7 @@ The `SelectMulti` component is an extension of the [`Select`](/components/forms/
     defaultValues={['1']}
     flex={1}
   />
-</Flex>
+</Space>
 ```
 
 ## showCreate

--- a/packages/www/src/documentation/components/forms/select.mdx
+++ b/packages/www/src/documentation/components/forms/select.mdx
@@ -8,14 +8,13 @@ propsOf: Select
 The `<Select />` component renders a single menu on the page, with no accompanying label. It is generally used to construct higher-order components like the `<FieldText />`. If you are building a form, you probably want to use `<FieldSelect />` instead as it provides label and validation support.
 
 ```jsx
-<Flex justifyContent="space-between">
+<Space>
   <Select
     options={[
       { value: 'cheddar', label: 'Cheddar' },
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
-    mr="small"
   />
   <Select
     options={[
@@ -24,9 +23,8 @@ The `<Select />` component renders a single menu on the page, with no accompanyi
       { value: 'swiss', label: 'Swiss' },
     ]}
     defaultValue="gouda"
-    mr="small"
   />
-  <Select placeholder="awesome!" mr="small" />
+  <Select placeholder="awesome!" />
   <Select
     defaultValue="Some Value"
     options={[
@@ -35,7 +33,7 @@ The `<Select />` component renders a single menu on the page, with no accompanyi
       { value: '2', label: 'other' },
     ]}
   />
-</Flex>
+</Space>
 ```
 
 ## Filtering
@@ -153,7 +151,7 @@ Options can have a `description` property.
 Use the disable property to make an input field uneditable.
 
 ```jsx
-<Flex justifyContent="space-between">
+<Space>
   <Select
     disabled
     options={[
@@ -161,7 +159,6 @@ Use the disable property to make an input field uneditable.
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
-    flex={1}
   />
   <Select
     defaultValue="gouda"
@@ -171,10 +168,8 @@ Use the disable property to make an input field uneditable.
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
-    ml="large"
-    flex={1}
   />
-</Flex>
+</Space>
 ```
 
 ## Placeholder
@@ -183,7 +178,7 @@ Placeholders are used to give a hint to the user of the expected value for the i
 To allow the user to clear the `Select`'s value, add the `isClearable` prop.
 
 ```jsx
-<Flex justifyContent="space-between">
+<Space>
   <Select
     placeholder="Select your cheese of choice..."
     options={[
@@ -191,7 +186,6 @@ To allow the user to clear the `Select`'s value, add the `isClearable` prop.
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
-    flex={1}
   />
   <Select
     placeholder="Value can be cleared"
@@ -201,10 +195,8 @@ To allow the user to clear the `Select`'s value, add the `isClearable` prop.
       { value: 'gouda', label: 'Gouda' },
       { value: 'swiss', label: 'Swiss' },
     ]}
-    ml="large"
-    flex={1}
   />
-</Flex>
+</Space>
 ```
 
 ## scrollIntoView for improved UX on a long list of options
@@ -214,35 +206,32 @@ If you're rendering a long list which scrolls beyond the max-height of the list,
 When you open the following list, `Mascarpone` will be highlighted and visible at the bottom of the menu:
 
 ```jsx
-<Flex justifyContent="space-between">
-  <Select
-    placeholder="Select your cheese of choice..."
-    options={[
-      { value: 'cheddar', label: 'Cheddar' },
-      { value: 'gouda', label: 'Gouda' },
-      { value: 'swiss', label: 'Swiss' },
-      { value: 'string', label: 'String' },
-      { value: 'parmesan', label: 'Parmigiano Reggiano' },
-      { value: 'roquefort', label: 'Roquefort' },
-      { value: 'brie', label: 'Brie' },
-      { value: 'gruyere', label: 'Gruyere' },
-      { value: 'feta', label: 'Feta' },
-      { value: 'mozzarella', label: 'Mozzarella' },
-      { value: 'manchego', label: 'Manchego' },
-      { value: 'gorgonzola', label: 'Gorgonzola' },
-      { value: 'epoisses', label: 'Epoisses' },
-      { value: 'monterey-jack', label: 'Monterey Jack' },
-      { value: 'muenster', label: 'Muenster' },
-      { value: 'provolone', label: 'Provolone' },
-      { value: 'blue', label: 'Blue' },
-      { value: 'camembert', label: 'Camembert' },
-      { value: 'havarti', label: 'Havarti' },
-      { value: 'ricotta', label: 'Ricotta' },
-      { value: 'mascarpone', label: 'Mascarpone', scrollIntoView: true },
-    ]}
-    flex={1}
-  />
-</Flex>
+<Select
+  placeholder="Select your cheese of choice..."
+  options={[
+    { value: 'cheddar', label: 'Cheddar' },
+    { value: 'gouda', label: 'Gouda' },
+    { value: 'swiss', label: 'Swiss' },
+    { value: 'string', label: 'String' },
+    { value: 'parmesan', label: 'Parmigiano Reggiano' },
+    { value: 'roquefort', label: 'Roquefort' },
+    { value: 'brie', label: 'Brie' },
+    { value: 'gruyere', label: 'Gruyere' },
+    { value: 'feta', label: 'Feta' },
+    { value: 'mozzarella', label: 'Mozzarella' },
+    { value: 'manchego', label: 'Manchego' },
+    { value: 'gorgonzola', label: 'Gorgonzola' },
+    { value: 'epoisses', label: 'Epoisses' },
+    { value: 'monterey-jack', label: 'Monterey Jack' },
+    { value: 'muenster', label: 'Muenster' },
+    { value: 'provolone', label: 'Provolone' },
+    { value: 'blue', label: 'Blue' },
+    { value: 'camembert', label: 'Camembert' },
+    { value: 'havarti', label: 'Havarti' },
+    { value: 'ricotta', label: 'Ricotta' },
+    { value: 'mascarpone', label: 'Mascarpone', scrollIntoView: true },
+  ]}
+/>
 ```
 
 ## Windowing

--- a/packages/www/src/documentation/components/layout/space.mdx
+++ b/packages/www/src/documentation/components/layout/space.mdx
@@ -47,6 +47,42 @@ Specify the width of the gap between items:
 </SpaceVertical>
 ```
 
+## Between
+
+The spacing between each pair of adjacent items is the same. The first item is flush with the main-start edge, and the last item is flush with the main-end edge. (citation: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
+
+```jsx
+<Space between>
+  <Button>Button A</Button>
+  <Button>Button B</Button>
+  <Button>Button C</Button>
+</Space>
+```
+
+## Around
+
+The spacing between each pair of adjacent items is the same. The empty space before the first and after the last item equals half of the space between each pair of adjacent items. (citation: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
+
+```jsx
+<Space around>
+  <Button>Button A</Button>
+  <Button>Button B</Button>
+  <Button>Button C</Button>
+</Space>
+```
+
+## Evenly
+
+The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same. (citation: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
+
+```jsx
+<Space evenly>
+  <Button>Button A</Button>
+  <Button>Button B</Button>
+  <Button>Button C</Button>
+</Space>
+```
+
 ## Reverse
 
 Reverse the order of the items in the space.

--- a/packages/www/src/documentation/components/layout/space.mdx
+++ b/packages/www/src/documentation/components/layout/space.mdx
@@ -29,7 +29,7 @@ github: Layout/Space
 
 # Alignment
 
-`Space` supports `verticalAlign` (defaults to `center`) while `SpaceVertical` supports `align` (defaults to `start`)
+`Space` & `SpaceVertical` support `align`. `Space` defaults to `center` while `SpaceVertical` defaults to `start`
 
 ```jsx
 <SpaceVertical>
@@ -38,12 +38,12 @@ github: Layout/Space
     <Button size="small">Button B</Button>
     <Button size="large">Button C</Button>
   </Space>
-  <Space verticalAlign="start">
+  <Space align="start">
     <Button>Button A</Button>
     <Button size="small">Button B</Button>
     <Button size="large">Button C</Button>
   </Space>
-  <Space verticalAlign="end">
+  <Space align="end">
     <Button>Button A</Button>
     <Button size="small">Button B</Button>
     <Button size="large">Button C</Button>

--- a/packages/www/src/documentation/components/layout/space.mdx
+++ b/packages/www/src/documentation/components/layout/space.mdx
@@ -27,6 +27,50 @@ github: Layout/Space
 1. Margin (`m`, `mx`, `ml`, etc...)
 2. Padding (`p`, `px`, `pl`, etc...)
 
+# Alignment
+
+`Space` supports `verticalAlign` (defaults to `center`) while `SpaceVertical` supports `align` (defaults to `start`)
+
+```jsx
+<SpaceVertical>
+  <Space>
+    <Button>Button A</Button>
+    <Button size="small">Button B</Button>
+    <Button size="large">Button C</Button>
+  </Space>
+  <Space verticalAlign="start">
+    <Button>Button A</Button>
+    <Button size="small">Button B</Button>
+    <Button size="large">Button C</Button>
+  </Space>
+  <Space verticalAlign="end">
+    <Button>Button A</Button>
+    <Button size="small">Button B</Button>
+    <Button size="large">Button C</Button>
+  </Space>
+</SpaceVertical>
+```
+
+```jsx
+<Space>
+  <SpaceVertical>
+    <Button>Button A</Button>
+    <Button size="small">Button B</Button>
+    <Button size="large">Button C</Button>
+  </SpaceVertical>
+  <SpaceVertical align="center">
+    <Button>Button A</Button>
+    <Button size="small">Button B</Button>
+    <Button size="large">Button C</Button>
+  </SpaceVertical>
+  <SpaceVertical align="end">
+    <Button>Button A</Button>
+    <Button size="small">Button B</Button>
+    <Button size="large">Button C</Button>
+  </SpaceVertical>
+</Space>
+```
+
 # Gap
 
 Specify the width of the gap between items:
@@ -100,5 +144,24 @@ Reverse the order of the items in the space.
   <Button>Button A</Button>
   <Button>Button B</Button>
   <Button>Button C</Button>
+</SpaceVertical>
+```
+
+# Stretch
+
+`SpaceVertical` supports an optional `stretch` property that will cause items within to stretch across the entire width of the container.
+
+```jsx
+<SpaceVertical>
+  <SpaceVertical>
+    <Button>Button A</Button>
+    <Button>Button B</Button>
+    <Button>Button C</Button>
+  </SpaceVertical>
+  <SpaceVertical stretch>
+    <Button>Button A</Button>
+    <Button>Button B</Button>
+    <Button>Button C</Button>
+  </SpaceVertical>
 </SpaceVertical>
 ```

--- a/packages/www/src/documentation/components/overlays/menu.mdx
+++ b/packages/www/src/documentation/components/overlays/menu.mdx
@@ -20,25 +20,27 @@ The entire menu can be disabled via the `disabled` prop.
 - `ref` - tooltip and popover placement
 
 ```jsx
-<Menu>
-  <MenuDisclosure tooltip="Select your favorite kind">
-    <Button mr="small">Cheese</Button>
-  </MenuDisclosure>
-  <MenuList>
-    <MenuItem icon="FavoriteOutline">Gouda</MenuItem>
-    <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
-  </MenuList>
-</Menu>
+<Space>
+  <Menu>
+    <MenuDisclosure tooltip="Select your favorite kind">
+      <Button>Cheese</Button>
+    </MenuDisclosure>
+    <MenuList>
+      <MenuItem icon="FavoriteOutline">Gouda</MenuItem>
+      <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
+    </MenuList>
+  </Menu>
 
-<Menu disabled>
-  <MenuDisclosure tooltip="Select your favorite kind">
-    <Button>Disabled Cheese</Button>
-  </MenuDisclosure>
-  <MenuList>
-    <MenuItem icon="FavoriteOutline">Gouda</MenuItem>
-    <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
-  </MenuList>
-</Menu>
+  <Menu disabled>
+    <MenuDisclosure tooltip="Select your favorite kind">
+      <Button>Disabled Cheese</Button>
+    </MenuDisclosure>
+    <MenuList>
+      <MenuItem icon="FavoriteOutline">Gouda</MenuItem>
+      <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
+    </MenuList>
+  </Menu>
+</Space>
 ```
 
 ## Menu Placement
@@ -66,18 +68,18 @@ Control the state of the menu with React's `useState` hook.
 ;() => {
   const [isOpen, setOpen] = React.useState(false)
   return (
-    <>
+    <Space>
       <Menu isOpen={isOpen} setOpen={setOpen}>
         <MenuDisclosure tooltip="Select export format">
-          <Button mr="medium">Export</Button>
+          <Button>Export</Button>
         </MenuDisclosure>
         <MenuList>
           <MenuItem icon="Mail">Email</MenuItem>
           <MenuItem icon="Table">Spreadsheet</MenuItem>
         </MenuList>
       </Menu>
-      {isOpen ? 'Menu Open' : 'Menu Closed'}
-    </>
+      <Text>{isOpen ? 'Menu Open' : 'Menu Closed'}</Text>
+    </Space>
   )
 }
 ```

--- a/packages/www/src/documentation/components/overlays/popover.mdx
+++ b/packages/www/src/documentation/components/overlays/popover.mdx
@@ -66,15 +66,14 @@ If you want to hide the popover arrow you can set the prop `arrow` prop to false
       onClick={onClick}
       ref={ref}
       className={className}
-      mr="xlarge"
     >
       {title}
     </Button>
   )
 
   return (
-    <>
-      <Box my="medium">
+    <SpaceVertical>
+      <Space between>
         <Popover content={popoverContent}>
           {(onClick, ref, className) =>
             button('Default', onClick, ref, className)
@@ -88,8 +87,8 @@ If you want to hide the popover arrow you can set the prop `arrow` prop to false
         <Popover content={popoverContent} placement="left">
           {(onClick, ref, className) => button('Left', onClick, ref, className)}
         </Popover>
-      </Box>
-      <Box my="medium">
+      </Space>
+      <Space>
         <Popover content={popoverContent} placement="bottom-start">
           {(onClick, ref, className) =>
             button('Bottom Start', onClick, ref, className)
@@ -105,8 +104,8 @@ If you want to hide the popover arrow you can set the prop `arrow` prop to false
             button('Top Start - No arrow', onClick, ref, className)
           }
         </Popover>
-      </Box>
-    </>
+      </Space>
+    </SpaceVertical>
   )
 }
 ```
@@ -128,13 +127,12 @@ To create a group, assigned a reference to an containing element and then assign
     </PopoverContent>
   )
   return (
-    <Box display="flex">
-      <Box
-        display="flex"
-        justifyContent="space-around"
+    <Space>
+      <Space
+        around
         ref={groupRef}
         p="large"
-        border="3px solid green"
+        style={{ border: '3px solid green' }}
       >
         <Popover content={content} groupedPopoversRef={groupRef}>
           {(onClick, ref, className) => (
@@ -173,7 +171,7 @@ To create a group, assigned a reference to an containing element and then assign
             </ButtonOutline>
           )}
         </Popover>
-      </Box>
+      </Space>
       <Popover content={content}>
         {(onClick, ref, className) => (
           <ButtonTransparent
@@ -188,7 +186,7 @@ To create a group, assigned a reference to an containing element and then assign
           </ButtonTransparent>
         )}
       </Popover>
-    </Box>
+    </Space>
   )
 }
 ```
@@ -200,24 +198,27 @@ To create a group, assigned a reference to an containing element and then assign
   const hoverRef = React.useRef()
   const content = <PopoverContent p="large">I'm in the popover</PopoverContent>
   return (
-    <Card ref={hoverRef} p="large">
-      <Flex justifyContent="space-between">
-        <Paragraph>
-          Hovering in this card will show the button that triggers the popover.
-        </Paragraph>
-        <Popover content={content} hoverDisclosureRef={hoverRef}>
-          {(onClick, ref, className) => (
-            <IconButton
-              icon="DotsVert"
-              aria-haspopup="true"
-              label="More Options"
-              onClick={onClick}
-              ref={ref}
-              className={className}
-            />
-          )}
-        </Popover>
-      </Flex>
+    <Card ref={hoverRef} raised>
+      <CardContent>
+        <Space between>
+          <Paragraph>
+            Hovering in this card will show the button that triggers the
+            popover.
+          </Paragraph>
+          <Popover content={content} hoverDisclosureRef={hoverRef}>
+            {(onClick, ref, className) => (
+              <IconButton
+                icon="DotsVert"
+                aria-haspopup="true"
+                label="More Options"
+                onClick={onClick}
+                ref={ref}
+                className={className}
+              />
+            )}
+          </Popover>
+        </Space>
+      </CardContent>
     </Card>
   )
 }

--- a/packages/www/src/documentation/getting-started/data-fetching.mdx
+++ b/packages/www/src/documentation/getting-started/data-fetching.mdx
@@ -30,24 +30,22 @@ To validate that the proxy server is configured correctly it's helpful to query 
     <>
       <Button onClick={fetchUser}>Fetch User Data</Button>
       {user && (
-        <List mt="large">
-          <>
-            <ListItem>
-              <strong>ID:</strong> {user.id}
-            </ListItem>
-            <ListItem>
-              <strong>Name:</strong> {user.display_name}
-            </ListItem>
-            <ListItem>
-              <strong>Email:</strong> {user.email}
-            </ListItem>
-            <ListItem>
-              <strong>Home Space:</strong> {user.home_space_id}
-            </ListItem>
-            <ListItem>
-              <strong>Role IDs:</strong> {JSON.stringify(user.role_ids)}
-            </ListItem>
-          </>
+        <List>
+          <ListItem>
+            <strong>ID:</strong> {user.id}
+          </ListItem>
+          <ListItem>
+            <strong>Name:</strong> {user.display_name}
+          </ListItem>
+          <ListItem>
+            <strong>Email:</strong> {user.email}
+          </ListItem>
+          <ListItem>
+            <strong>Home Space:</strong> {user.home_space_id}
+          </ListItem>
+          <ListItem>
+            <strong>Role IDs:</strong> {JSON.stringify(user.role_ids)}
+          </ListItem>
         </List>
       )}
     </>

--- a/packages/www/src/documentation/getting-started/theme.mdx
+++ b/packages/www/src/documentation/getting-started/theme.mdx
@@ -104,11 +104,13 @@ NOTE: You'll also see that `PrettyButton` in the example simply falls back to `B
 
   return (
     <ComponentsProvider>
-      <PrettyButton mr="large">Stock Theme</PrettyButton>
+      <Space>
+        <PrettyButton>Stock Theme</PrettyButton>
 
-      <ComponentsProvider theme={myTheme}>
-        <PrettyButton>Pretty Button with Custom Theme</PrettyButton>
-      </ComponentsProvider>
+        <ComponentsProvider theme={myTheme}>
+          <PrettyButton>Pretty Button with Custom Theme</PrettyButton>
+        </ComponentsProvider>
+      </Space>
     </ComponentsProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- Fix Space issue w/ IconButton 
- Add around, between & evenly support to Space
- Use `Space` for IconButton and Button documentation (POC of fixes)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
