### PR TITLE
Support wrapping in ButtonGroup/Toggle

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "xxlarge",
     "xxsmall",
     "xxxlarge",
+    "xxxsmall",
     "xxxxlarge"
   ],
   "prettier.arrowParens": "always"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - now supports `around`, `between` and `evenly` as alternatives to `gap`
   - now supports `verticalAlign` property
 - `SpaceVertical` now supports `align` and `stretch` properties
-
-### Added
-
 - `Accordion`, `AccordionLabel`, `AccordionContent` components
+- `ButtonGroup` and `ButtonToggle` will now wrap if there are too many items for the container width
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - now supports `verticalAlign` property
 - `SpaceVertical` now supports `align` and `stretch` properties
 - `Accordion`, `AccordionLabel`, `AccordionContent` components
+- `ButtonToggle` now accepts `nullable`
 - `ButtonGroup` and `ButtonToggle` will now wrap if there are too many items for the container width
 
 ### Changed

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -67,31 +67,6 @@ exports[`Banner can be dismissed 1`] = `
   opacity: 0.25;
 }
 
-.c3 {
-  -webkit-flex: auto;
-  -ms-flex: auto;
-  flex: auto;
-}
-
-.c0 {
-  border-radius: 0.25rem;
-  background-color: #e0f2ff;
-  width: 100%;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  font-size: 0.875rem;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c5 {
   background: transparent;
   border: 1px solid transparent;
@@ -123,6 +98,31 @@ exports[`Banner can be dismissed 1`] = `
 .c5[disabled]:active,
 .c5[disabled]:focus {
   color: #939BA5;
+}
+
+.c3 {
+  -webkit-flex: auto;
+  -ms-flex: auto;
+  flex: auto;
+}
+
+.c0 {
+  border-radius: 0.25rem;
+  background-color: #e0f2ff;
+  width: 100%;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c2 {

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -24,28 +24,40 @@
 
  */
 
-import uniqueId from 'lodash/uniqueId'
 import xor from 'lodash/xor'
 import React, { ChangeEvent, forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { useControlWarn } from '../utils'
+import { useControlWarn, useID } from '../utils'
 import { ButtonItem, ButtonItemLabel } from './ButtonItem'
-import { ButtonGroupOrToggleProps, ButtonSet } from './ButtonSet'
+import { ButtonGroupOrToggleBaseProps, ButtonSet } from './ButtonSet'
+
+export interface ButtonGroupProps
+  extends Omit<ButtonGroupOrToggleBaseProps<string[]>, 'nullable'> {
+  /**
+   * Change callback for controlling the component
+   */
+  onChange?: (value: string[]) => void
+}
 
 const ButtonGroupFactory = forwardRef(
   (
-    { onChange, value, ...props }: ButtonGroupOrToggleProps<string[]>,
+    { onChange, value, ...props }: ButtonGroupProps,
     ref: Ref<HTMLDivElement>
   ) => {
+    const name = useID(props.name)
+
     const isControlled = useControlWarn({
       controllingProps: ['onChange', 'value'],
       isControlledCheck: () => onChange !== undefined,
       name: 'ButtonGroup',
     })
 
-    function handleChange(e: ChangeEvent<HTMLInputElement>) {
-      const newValue = xor(value, [e.target.value])
-      onChange && onChange(newValue)
+    function handleChange(e?: ChangeEvent<HTMLInputElement>) {
+      // event is only ever missing for nullable ButtonToggle
+      if (e) {
+        const newValue = xor(value, [e.target.value])
+        onChange && onChange(newValue)
+      }
     }
 
     return (
@@ -57,29 +69,21 @@ const ButtonGroupFactory = forwardRef(
               onChange: handleChange,
               value,
             }
-          : { name: props.name || uniqueId() })}
+          : { name })}
       />
     )
   }
 )
 
 export const ButtonGroup = styled(ButtonGroupFactory)`
-  margin: ${({
-    theme: {
-      space: { xxsmall },
-    },
-  }) => `0 -${xxsmall} -${xxsmall} 0`};
+  --spacing: ${({ theme }) => theme.space.xxsmall};
+  margin-bottom: calc(var(--spacing) * -1);
+  margin-right: calc(var(--spacing) * -1);
   ${ButtonItem} {
     height: 36px;
     border-radius: ${({ theme }) => theme.radii.medium};
-    margin: ${({
-      theme: {
-        space: { xxsmall },
-      },
-    }) => `0 ${xxsmall} ${xxsmall} 0`};
-    &:last-of-type {
-      margin-right: 0;
-    }
+    margin-bottom: var(--spacing);
+    margin-right: var(--spacing);
   }
 
   ${ButtonItemLabel} {

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -31,17 +31,13 @@ import { useControlWarn, useID } from '../utils'
 import { ButtonItem, ButtonItemLabel } from './ButtonItem'
 import { ButtonGroupOrToggleBaseProps, ButtonSet } from './ButtonSet'
 
-export interface ButtonGroupProps
-  extends Omit<ButtonGroupOrToggleBaseProps<string[]>, 'nullable'> {
-  /**
-   * Change callback for controlling the component
-   */
-  onChange?: (value: string[]) => void
-}
-
 const ButtonGroupLayout = forwardRef(
   (
-    { onChange, value, ...props }: ButtonGroupProps,
+    {
+      onChange,
+      value,
+      ...props
+    }: Omit<ButtonGroupOrToggleBaseProps<string[]>, 'nullable'>,
     ref: Ref<HTMLDivElement>
   ) => {
     const name = useID(props.name)

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -26,7 +26,7 @@
 
 import uniqueId from 'lodash/uniqueId'
 import xor from 'lodash/xor'
-import React, { ChangeEvent, FC, forwardRef, Ref } from 'react'
+import React, { ChangeEvent, forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import { useControlWarn } from '../utils'
 import { ButtonItem, ButtonItemLabel } from './ButtonItem'
@@ -63,13 +63,15 @@ const ButtonGroupFactory = forwardRef(
   }
 )
 
-export const ButtonGroup = styled<FC<ButtonGroupOrToggleProps<string[]>>>(
-  ButtonGroupFactory
-)`
-  margin-bottom: -${(props) => props.theme.space.xxsmall};
+export const ButtonGroup = styled(ButtonGroupFactory)`
+  margin: ${({
+    theme: {
+      space: { xxsmall },
+    },
+  }) => `0 -${xxsmall} -${xxsmall} 0`};
   ${ButtonItem} {
     height: 36px;
-    border-radius: 4px;
+    border-radius: ${({ theme }) => theme.radii.medium};
     margin: ${({
       theme: {
         space: { xxsmall },

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -66,12 +66,17 @@ const ButtonGroupFactory = forwardRef(
 export const ButtonGroup = styled<FC<ButtonGroupOrToggleProps<string[]>>>(
   ButtonGroupFactory
 )`
+  margin-bottom: -${(props) => props.theme.space.xxsmall};
   ${ButtonItem} {
     height: 36px;
     border-radius: 4px;
-
-    + ${ButtonItem} {
-      margin-left: ${(props) => props.theme.space.xxsmall};
+    margin: ${({
+      theme: {
+        space: { xxsmall },
+      },
+    }) => `0 ${xxsmall} ${xxsmall} 0`};
+    &:last-of-type {
+      margin-right: 0;
     }
   }
 

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -72,14 +72,12 @@ const ButtonGroupLayout = forwardRef(
 )
 
 export const ButtonGroup = styled(ButtonGroupLayout)`
-  --spacing: ${({ theme }) => theme.space.xxsmall};
-  margin-bottom: calc(var(--spacing) * -1);
-  margin-right: calc(var(--spacing) * -1);
+  margin: -${({ theme }) => theme.space.xxxsmall};
+
   ${ButtonItem} {
-    height: 36px;
     border-radius: ${({ theme }) => theme.radii.medium};
-    margin-bottom: var(--spacing);
-    margin-right: var(--spacing);
+    height: 36px;
+    margin: ${({ theme }) => theme.space.xxxsmall};
   }
 
   ${ButtonItemLabel} {

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -39,7 +39,7 @@ export interface ButtonGroupProps
   onChange?: (value: string[]) => void
 }
 
-const ButtonGroupFactory = forwardRef(
+const ButtonGroupLayout = forwardRef(
   (
     { onChange, value, ...props }: ButtonGroupProps,
     ref: Ref<HTMLDivElement>
@@ -75,7 +75,7 @@ const ButtonGroupFactory = forwardRef(
   }
 )
 
-export const ButtonGroup = styled(ButtonGroupFactory)`
+export const ButtonGroup = styled(ButtonGroupLayout)`
   --spacing: ${({ theme }) => theme.space.xxsmall};
   margin-bottom: calc(var(--spacing) * -1);
   margin-right: calc(var(--spacing) * -1);

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -52,9 +52,10 @@ export const ButtonItemLabel = styled.label<ButtonItemProps>`
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  padding: 0 ${(props) => props.theme.space.small};
+  text-align: center;
+  padding: 0 ${({ theme }) => theme.space.small};
   user-select: none;
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.radii.medium};
   background: ${(props) =>
     props.selected
       ? `hsla(${

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -34,13 +34,16 @@ import React, {
   ReactNode,
   Ref,
 } from 'react'
+import styled from 'styled-components'
 import {
   CompatibleHTMLProps,
+  border,
   BorderProps,
+  position,
   PositionProps,
+  space,
   SpaceProps,
 } from '@looker/design-tokens'
-import { Box } from '../Layout'
 import { ButtonItemProps } from './ButtonItem'
 
 export interface ButtonGroupOrToggleProps<
@@ -78,7 +81,7 @@ export type ButtonSetType<
   T extends string | string[] = string[]
 > = ForwardRefExoticComponent<ButtonSetProps<T> & { ref: Ref<HTMLDivElement> }>
 
-export const ButtonSet = forwardRef(
+export const ButtonSetInternal = forwardRef(
   (
     {
       children,
@@ -125,18 +128,22 @@ export const ButtonSet = forwardRef(
     })
 
     return (
-      <Box
-        alignItems="center"
-        display="inline-flex"
-        textAlign="center"
-        fontSize="small"
-        ref={ref}
-        {...props}
-      >
+      <div ref={ref} {...props}>
         {clonedChildren}
-      </Box>
+      </div>
     )
   }
 )
 
-ButtonSet.displayName = 'ButtonSet'
+ButtonSetInternal.displayName = 'ButtonSetInternal'
+
+export const ButtonSet = styled(ButtonSetInternal)`
+  ${border}
+  ${position}
+  ${space}
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: wrap;
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  text-align: center;
+`

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -59,9 +59,11 @@ interface ButtonSetProps<ValueType extends string | string[] = string[]>
   nullable?: boolean
 }
 
-export type ButtonGroupOrToggleBaseProps<
+export interface ButtonGroupOrToggleBaseProps<
   ValueType extends string | string[] = string[]
-> = Omit<ButtonSetProps<ValueType>, 'isToggle' | 'onChange'>
+> extends Omit<ButtonSetProps<ValueType>, 'isToggle' | 'onChange'> {
+  onChange?: (value: ValueType) => void
+}
 
 export type ButtonSetType<
   T extends string | string[] = string[]

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -35,23 +35,14 @@ import React, {
   Ref,
 } from 'react'
 import styled from 'styled-components'
-import {
-  CompatibleHTMLProps,
-  border,
-  BorderProps,
-  position,
-  PositionProps,
-  space,
-  SpaceProps,
-} from '@looker/design-tokens'
+import { CompatibleHTMLProps } from '@looker/design-tokens'
+import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
 import { ButtonItemProps } from './ButtonItem'
 
 export interface ButtonGroupOrToggleProps<
   ValueType extends string | string[] = string[]
 >
-  extends PositionProps,
-    BorderProps,
-    SpaceProps,
+  extends SimpleLayoutProps,
     Omit<CompatibleHTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   /**
    * Internal use only
@@ -81,7 +72,7 @@ export type ButtonSetType<
   T extends string | string[] = string[]
 > = ForwardRefExoticComponent<ButtonSetProps<T> & { ref: Ref<HTMLDivElement> }>
 
-export const ButtonSetInternal = forwardRef(
+export const ButtonSetLayout = forwardRef(
   (
     {
       children,
@@ -135,12 +126,10 @@ export const ButtonSetInternal = forwardRef(
   }
 )
 
-ButtonSetInternal.displayName = 'ButtonSetInternal'
+ButtonSetLayout.displayName = 'ButtonSetLayout'
 
-export const ButtonSet = styled(ButtonSetInternal)`
-  ${border}
-  ${position}
-  ${space}
+export const ButtonSet = styled(ButtonSetLayout)`
+  ${simpleLayoutCSS}
   align-items: center;
   display: inline-flex;
   flex-wrap: wrap;

--- a/packages/components/src/Button/ButtonToggle.test.tsx
+++ b/packages/components/src/Button/ButtonToggle.test.tsx
@@ -24,55 +24,75 @@
 
  */
 
-import '@testing-library/jest-dom/extend-expect'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { fireEvent } from '@testing-library/react'
 import React from 'react'
 import { Simulate } from 'react-dom/test-utils'
 
-import { renderWithTheme } from '@looker/components-test-utils'
 import { ButtonItem } from './ButtonItem'
 import { ButtonToggle } from './ButtonToggle'
 
-const requiredProps = {
-  message: 'Foo',
-  onConfirm: jest.fn(),
-  title: 'Bar',
-}
+describe('ButtonToggle', () => {
+  const requiredProps = {
+    message: 'Foo',
+    onConfirm: jest.fn(),
+    title: 'Bar',
+  }
 
-const optionalProps = {
-  cancelLabel: 'Dont Delete',
-  confirmLabel: 'Delete',
-  message: 'This is permanent',
-  onCancel: jest.fn(),
-  title: 'Delete the thing?',
-}
+  const optionalProps = {
+    cancelLabel: 'Dont Delete',
+    confirmLabel: 'Delete',
+    message: 'This is permanent',
+    onCancel: jest.fn(),
+    title: 'Delete the thing?',
+  }
 
-afterEach(() => {
-  requiredProps.onConfirm.mockClear()
-  optionalProps.onCancel.mockClear()
-})
+  afterEach(() => {
+    requiredProps.onConfirm.mockClear()
+    optionalProps.onCancel.mockClear()
+  })
 
-test('<ButtonToggle/> controlled', () => {
-  const onChangeMock = jest.fn()
-  const { getByLabelText } = renderWithTheme(
-    <ButtonToggle value="Bananas" onChange={onChangeMock}>
-      <ButtonItem>Apples</ButtonItem>
-      <ButtonItem>Oranges</ButtonItem>
-      <ButtonItem>Bananas</ButtonItem>
-    </ButtonToggle>
-  )
+  test('controlled', () => {
+    const onChangeMock = jest.fn()
+    const { getByLabelText } = renderWithTheme(
+      <ButtonToggle value="Bananas" onChange={onChangeMock}>
+        <ButtonItem>Apples</ButtonItem>
+        <ButtonItem>Oranges</ButtonItem>
+        <ButtonItem>Bananas</ButtonItem>
+      </ButtonToggle>
+    )
 
-  const apples = getByLabelText('Apples')
-  const bananas = getByLabelText('Bananas')
-  const oranges = getByLabelText('Oranges')
+    const apples = getByLabelText('Apples')
+    const bananas = getByLabelText('Bananas')
+    const oranges = getByLabelText('Oranges')
 
-  expect(bananas).toHaveAttribute('checked')
-  expect(oranges).not.toHaveAttribute('checked')
+    expect(bananas).toHaveAttribute('checked')
+    expect(oranges).not.toHaveAttribute('checked')
 
-  Simulate.change(apples)
-  Simulate.change(bananas)
-  Simulate.change(oranges)
-  expect(onChangeMock).toHaveBeenCalledTimes(3)
-  expect(onChangeMock.mock.calls[0][0]).toEqual('Apples')
-  expect(onChangeMock.mock.calls[1][0]).toEqual('Bananas')
-  expect(onChangeMock.mock.calls[2][0]).toEqual('Oranges')
+    Simulate.change(apples)
+    Simulate.change(bananas)
+    Simulate.change(oranges)
+
+    expect(onChangeMock).toHaveBeenCalledTimes(3)
+    expect(onChangeMock.mock.calls[0][0]).toEqual('Apples')
+    expect(onChangeMock.mock.calls[1][0]).toEqual('Bananas')
+    expect(onChangeMock.mock.calls[2][0]).toEqual('Oranges')
+  })
+
+  test('nullable', () => {
+    const { getByLabelText } = renderWithTheme(
+      <ButtonToggle nullable>
+        <ButtonItem>Apples</ButtonItem>
+        <ButtonItem selected data-testid="oranges">
+          Oranges
+        </ButtonItem>
+        <ButtonItem>Bananas</ButtonItem>
+      </ButtonToggle>
+    )
+    const orangesInput = getByLabelText('Oranges')
+    expect(orangesInput).toBeChecked()
+
+    fireEvent.click(orangesInput)
+    expect(orangesInput).not.toBeChecked()
+  })
 })

--- a/packages/components/src/Button/ButtonToggle.tsx
+++ b/packages/components/src/Button/ButtonToggle.tsx
@@ -34,19 +34,15 @@ import {
   ButtonSetType,
 } from './ButtonSet'
 
-export interface ButtonToggleProps
-  extends ButtonGroupOrToggleBaseProps<string> {
-  /**
-   * Change callback for controlling the component
-   */
-  onChange?: (value: string) => void
-}
-
 const ButtonToggleComponent = (ButtonSet as unknown) as ButtonSetType<string>
 
 const ButtonToggleLayout = forwardRef(
   (
-    { onChange, value: controlledValue, ...props }: ButtonToggleProps,
+    {
+      onChange,
+      value: controlledValue,
+      ...props
+    }: ButtonGroupOrToggleBaseProps<string>,
     ref: Ref<HTMLDivElement>
   ) => {
     //

--- a/packages/components/src/Button/ButtonToggle.tsx
+++ b/packages/components/src/Button/ButtonToggle.tsx
@@ -24,24 +24,34 @@
 
  */
 
-import uniqueId from 'lodash/uniqueId'
 import React, { forwardRef, Ref, useState, ChangeEvent } from 'react'
 import styled from 'styled-components'
-import { useControlWarn } from '../utils'
+import { useControlWarn, useID } from '../utils'
 import { ButtonItemLabel } from './ButtonItem'
-import { ButtonGroupOrToggleProps, ButtonSet, ButtonSetType } from './ButtonSet'
+import {
+  ButtonGroupOrToggleBaseProps,
+  ButtonSet,
+  ButtonSetType,
+} from './ButtonSet'
+
+export interface ButtonToggleProps
+  extends ButtonGroupOrToggleBaseProps<string> {
+  /**
+   * Change callback for controlling the component
+   */
+  onChange?: (value: string) => void
+}
 
 const ButtonToggleComponent = (ButtonSet as unknown) as ButtonSetType<string>
 
 const ButtonToggleFactory = forwardRef(
   (
-    {
-      onChange,
-      value: controlledValue,
-      ...props
-    }: ButtonGroupOrToggleProps<string>,
+    { onChange, value: controlledValue, ...props }: ButtonToggleProps,
     ref: Ref<HTMLDivElement>
   ) => {
+    //
+    const name = useID(props.name)
+
     const isControlled = useControlWarn({
       controllingProps: ['onChange', 'value'],
       isControlledCheck: () => onChange !== undefined,
@@ -50,11 +60,12 @@ const ButtonToggleFactory = forwardRef(
 
     const [value, setValue] = useState<string>()
 
-    function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    function handleChange(e?: ChangeEvent<HTMLInputElement>) {
+      const newValue = e ? e.target.value : ''
       if (onChange) {
-        onChange(e.target.value)
+        onChange(newValue)
       } else {
-        setValue(e.target.value)
+        setValue(newValue)
       }
     }
     return (
@@ -65,10 +76,12 @@ const ButtonToggleFactory = forwardRef(
         ref={ref}
         {...(isControlled
           ? {
-              name: props.name || uniqueId(),
               value: controlledValue,
             }
-          : { value })}
+          : {
+              name,
+              value,
+            })}
       />
     )
   }

--- a/packages/components/src/Button/ButtonToggle.tsx
+++ b/packages/components/src/Button/ButtonToggle.tsx
@@ -60,7 +60,6 @@ const ButtonToggleFactory = forwardRef(
     return (
       <ButtonToggleComponent
         {...props}
-        borderRadius="4px"
         onChange={handleChange}
         isToggle
         ref={ref}
@@ -78,24 +77,29 @@ const ButtonToggleFactory = forwardRef(
 export const ButtonToggle = styled<FC<ButtonGroupOrToggleProps<string>>>(
   ButtonToggleFactory
 )`
-  border: solid 1px ${(props) => props.theme.colors.palette.charcoal200};
+  border-radius: 4px;
 
   ${ButtonItemLabel} {
     position: relative;
     height: 36px;
+    border: 1px solid ${(props) => props.theme.colors.palette.charcoal200};
+    border-left-width: 0;
+    border-right-width: 0;
     border-radius: 0;
 
     &:first-child {
       border-top-left-radius: 4px;
       border-bottom-left-radius: 4px;
+      border-left-width: 1px;
     }
     &:last-child {
       border-top-right-radius: 4px;
       border-bottom-right-radius: 4px;
+      border-right-width: 1px;
     }
 
     /* stylelint-disable */
-    & + ${ButtonItemLabel} {
+    &:not(:last-child) {
       &::after {
         content: '';
         display: block;
@@ -103,7 +107,7 @@ export const ButtonToggle = styled<FC<ButtonGroupOrToggleProps<string>>>(
         width: 1px;
         background: ${(props) => props.theme.colors.palette.charcoal200};
         position: absolute;
-        left: 0;
+        right: 0;
         top: 8px;
       }
     }

--- a/packages/components/src/Button/ButtonToggle.tsx
+++ b/packages/components/src/Button/ButtonToggle.tsx
@@ -25,7 +25,7 @@
  */
 
 import uniqueId from 'lodash/uniqueId'
-import React, { forwardRef, Ref, useState, ChangeEvent, FC } from 'react'
+import React, { forwardRef, Ref, useState, ChangeEvent } from 'react'
 import styled from 'styled-components'
 import { useControlWarn } from '../utils'
 import { ButtonItemLabel } from './ButtonItem'
@@ -74,43 +74,52 @@ const ButtonToggleFactory = forwardRef(
   }
 )
 
-export const ButtonToggle = styled<FC<ButtonGroupOrToggleProps<string>>>(
-  ButtonToggleFactory
-)`
-  border-radius: 4px;
+export const ButtonToggle = styled(ButtonToggleFactory)`
+  border: solid 1px ${({ theme }) => theme.colors.palette.charcoal200};
+  border-radius: ${({ theme }) => theme.radii.medium};
+
+  /* prevents items in the last row from growing */
+  &::after {
+    content: '';
+    flex-grow: 100;
+  }
 
   ${ButtonItemLabel} {
+    /* In a wrapping scenario we want items in complete rows
+    to fill the full width evenly */
+    flex-grow: 1;
     position: relative;
     height: 36px;
-    border: 1px solid ${(props) => props.theme.colors.palette.charcoal200};
-    border-left-width: 0;
-    border-right-width: 0;
     border-radius: 0;
 
     &:first-child {
-      border-top-left-radius: 4px;
-      border-bottom-left-radius: 4px;
-      border-left-width: 1px;
+      border-top-left-radius: ${({ theme }) => theme.radii.medium};
+      border-bottom-left-radius: ${({ theme }) => theme.radii.medium};
     }
     &:last-child {
-      border-top-right-radius: 4px;
-      border-bottom-right-radius: 4px;
-      border-right-width: 1px;
+      border-top-right-radius: ${({ theme }) => theme.radii.medium};
+      border-bottom-right-radius: ${({ theme }) => theme.radii.medium};
     }
 
-    /* stylelint-disable */
-    &:not(:last-child) {
-      &::after {
-        content: '';
-        display: block;
-        height: 20px;
-        width: 1px;
-        background: ${(props) => props.theme.colors.palette.charcoal200};
-        position: absolute;
-        right: 0;
-        top: 8px;
-      }
+    &::before,
+    &::after {
+      content: '';
+      display: block;
+      background: ${(props) => props.theme.colors.palette.charcoal200};
+      position: absolute;
+      z-index: 1;
     }
-    /* stylelint-enable */
+    &::before {
+      height: 1px;
+      width: 100%;
+      left: 0;
+      bottom: -1px;
+    }
+    &::after {
+      height: 100%;
+      width: 1px;
+      right: -1px;
+      top: 0;
+    }
   }
 `

--- a/packages/components/src/Button/ButtonToggle.tsx
+++ b/packages/components/src/Button/ButtonToggle.tsx
@@ -44,7 +44,7 @@ export interface ButtonToggleProps
 
 const ButtonToggleComponent = (ButtonSet as unknown) as ButtonSetType<string>
 
-const ButtonToggleFactory = forwardRef(
+const ButtonToggleLayout = forwardRef(
   (
     { onChange, value: controlledValue, ...props }: ButtonToggleProps,
     ref: Ref<HTMLDivElement>
@@ -87,7 +87,7 @@ const ButtonToggleFactory = forwardRef(
   }
 )
 
-export const ButtonToggle = styled(ButtonToggleFactory)`
+export const ButtonToggle = styled(ButtonToggleLayout)`
   border: solid 1px ${({ theme }) => theme.colors.palette.charcoal200};
   border-radius: ${({ theme }) => theme.radii.medium};
 

--- a/packages/design-tokens/src/system/space.ts
+++ b/packages/design-tokens/src/system/space.ts
@@ -25,6 +25,7 @@
  */
 
 export type SizeNone = 'none'
+export type SizeXXXSmall = 'xxxsmall'
 export type SizeXXSmall = 'xxsmall'
 export type SizeXSmall = 'xsmall'
 export type SizeSmall = 'small'
@@ -37,6 +38,7 @@ export type SizeXXXXLarge = 'xxxxlarge'
 
 export type SpacingSizes =
   | SizeNone
+  | SizeXXXSmall
   | SizeXXSmall
   | SizeXSmall
   | SizeSmall

--- a/packages/design-tokens/src/tokens/space.ts
+++ b/packages/design-tokens/src/tokens/space.ts
@@ -30,6 +30,7 @@ import { SpaceRamp } from '../system'
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 export const space: SpaceRamp = {
   none: rem(0),
+  xxxsmall: rem(2),
   xxsmall: rem(4),
   xsmall: rem(8),
   small: rem(12),

--- a/packages/playground/src/Actions/ButtonSetDemo.tsx
+++ b/packages/playground/src/Actions/ButtonSetDemo.tsx
@@ -39,6 +39,7 @@ import React, { FormEvent, useState } from 'react'
 
 function ButtonGroupDemo() {
   const [value, setValue] = useState<string[]>([])
+  const [value2, setValue2] = useState<string[]>(['CA', 'AK'])
 
   return (
     <Box p="large" flex={1}>
@@ -52,6 +53,24 @@ function ButtonGroupDemo() {
       <Divider />
       <Paragraph>Controlled</Paragraph>
       <ButtonGroup value={value} onChange={setValue}>
+        <ButtonItem value="CA">California</ButtonItem>
+        <ButtonItem value="AK">Alaska</ButtonItem>
+        <ButtonItem value="UT">Utah</ButtonItem>
+      </ButtonGroup>
+      <Divider />
+      <Paragraph>Uncontrolled with items selected</Paragraph>
+      <ButtonGroup>
+        <ButtonItem value="CA" selected>
+          California
+        </ButtonItem>
+        <ButtonItem value="AK" selected>
+          Alaska
+        </ButtonItem>
+        <ButtonItem value="UT">Utah</ButtonItem>
+      </ButtonGroup>
+      <Divider />
+      <Paragraph>Controlled with initial values</Paragraph>
+      <ButtonGroup value={value2} onChange={setValue2}>
         <ButtonItem value="CA">California</ButtonItem>
         <ButtonItem value="AK">Alaska</ButtonItem>
         <ButtonItem value="UT">Utah</ButtonItem>

--- a/packages/playground/src/Actions/ButtonSetDemo.tsx
+++ b/packages/playground/src/Actions/ButtonSetDemo.tsx
@@ -30,59 +30,182 @@ import {
   ButtonItem,
   ButtonToggle,
   Divider,
+  Paragraph,
+  Space,
+  Heading,
+  FieldToggleSwitch,
 } from '@looker/components'
-import React from 'react'
+import React, { FormEvent, useState } from 'react'
+
+function ButtonGroupDemo() {
+  const [value, setValue] = useState<string[]>([])
+
+  return (
+    <Box p="large" flex={1}>
+      <Heading>Button Group State</Heading>
+      <Paragraph>Uncontrolled</Paragraph>
+      <ButtonGroup>
+        <ButtonItem value="CA">California</ButtonItem>
+        <ButtonItem value="AK">Alaska</ButtonItem>
+        <ButtonItem value="UT">Utah</ButtonItem>
+      </ButtonGroup>
+      <Divider />
+      <Paragraph>Controlled</Paragraph>
+      <ButtonGroup value={value} onChange={setValue}>
+        <ButtonItem value="CA">California</ButtonItem>
+        <ButtonItem value="AK">Alaska</ButtonItem>
+        <ButtonItem value="UT">Utah</ButtonItem>
+      </ButtonGroup>
+      <Divider />
+    </Box>
+  )
+}
+function ButtonToggleDemo() {
+  const [toggle, setToggle] = useState<string>()
+  function handleChange(value: string) {
+    setToggle(value)
+  }
+  const [toggle2, setToggle2] = useState('Ruby')
+  function handleChange2(value: string) {
+    setToggle2(value)
+  }
+  const [toggle3, setToggle3] = useState<string>()
+  function handleChange3(value: string) {
+    setToggle3(value)
+  }
+  const [toggle4, setToggle4] = useState('Ruby')
+  function handleChange4(value: string) {
+    setToggle4(value)
+  }
+
+  return (
+    <Box p="large" flex={1}>
+      <Heading>Button Toggle State</Heading>
+      <Paragraph>Uncontrolled</Paragraph>
+      <ButtonToggle>
+        <ButtonItem>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Controlled</Paragraph>
+      <ButtonToggle value={toggle} onChange={handleChange}>
+        <ButtonItem>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Uncontrolled with item selected</Paragraph>
+      <ButtonToggle>
+        <ButtonItem selected>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Controlled with initial value</Paragraph>
+      <ButtonToggle value={toggle2} onChange={handleChange2}>
+        <ButtonItem>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Nullable Uncontrolled</Paragraph>
+      <ButtonToggle nullable>
+        <ButtonItem>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Nullable Controlled</Paragraph>
+      <ButtonToggle nullable value={toggle3} onChange={handleChange3}>
+        <ButtonItem>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Nullable Uncontrolled with item selected</Paragraph>
+      <ButtonToggle nullable>
+        <ButtonItem selected>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      <Divider />
+      <Paragraph>Nullable Controlled with initial value</Paragraph>
+      <ButtonToggle nullable value={toggle4} onChange={handleChange4}>
+        <ButtonItem>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+    </Box>
+  )
+}
 
 export function ButtonSetDemo() {
+  const [border, setBorder] = useState(true)
+  function handleChange(e: FormEvent<HTMLInputElement>) {
+    setBorder(e.currentTarget.checked)
+  }
   return (
-    <Box m="xlarge" width={400} border="1px solid">
-      <ButtonGroup>
-        <ButtonItem value="CA" selected>
-          California
-        </ButtonItem>
-        <ButtonItem value="AK">Alaska</ButtonItem>
-        <ButtonItem value="UT">Utah</ButtonItem>
-      </ButtonGroup>
-      Inline text
-      <Divider />
-      <ButtonToggle>
-        <ButtonItem selected>Ruby</ButtonItem>
-        <ButtonItem>TypeScript</ButtonItem>
-        <ButtonItem>Python</ButtonItem>
-      </ButtonToggle>
-      Inline text
-      <Divider />
-      <ButtonGroup>
-        <ButtonItem value="CA" selected>
-          California
-        </ButtonItem>
-        <ButtonItem value="AK">Alaska</ButtonItem>
-        <ButtonItem value="UT">Utah</ButtonItem>
-        <ButtonItem value="CO">Colorado</ButtonItem>
-        <ButtonItem value="MS">Missouri</ButtonItem>
-        <ButtonItem value="MI">Mississippi</ButtonItem>
-        <ButtonItem value="MA">Massachusets</ButtonItem>
-        <ButtonItem value="VT">Vermont</ButtonItem>
-        <ButtonItem value="NH">New Hampshire</ButtonItem>
-        <ButtonItem value="DE">Delaware</ButtonItem>
-        <ButtonItem value="ME">Maine</ButtonItem>
-        <ButtonItem value="WA">Washington</ButtonItem>
-        <ButtonItem value="OR">Oregon</ButtonItem>
-      </ButtonGroup>
-      Inline text
-      <Divider />
-      <ButtonToggle>
-        <ButtonItem selected>Ruby</ButtonItem>
-        <ButtonItem>TypeScript</ButtonItem>
-        <ButtonItem>Python</ButtonItem>
-        <ButtonItem>Java</ButtonItem>
-        <ButtonItem>Kotlin</ButtonItem>
-        <ButtonItem>Go</ButtonItem>
-        <ButtonItem>C++</ButtonItem>
-        <ButtonItem>Clojure</ButtonItem>
-        <ButtonItem>Perl</ButtonItem>
-      </ButtonToggle>
-      Inline text
-    </Box>
+    <Space width="100%">
+      <ButtonToggleDemo />
+      <ButtonGroupDemo />
+      <Box flex={1} m="xlarge" border={border ? '1px solid' : 'none'}>
+        <Heading>Wrapping</Heading>
+        <FieldToggleSwitch
+          label="Show border"
+          on={border}
+          onChange={handleChange}
+        />
+        <Divider />
+        <ButtonGroup>
+          <ButtonItem value="CA" selected>
+            California
+          </ButtonItem>
+          <ButtonItem value="AK">Alaska</ButtonItem>
+          <ButtonItem value="UT">Utah</ButtonItem>
+        </ButtonGroup>
+        Inline text
+        <Divider />
+        <ButtonToggle>
+          <ButtonItem selected>Ruby</ButtonItem>
+          <ButtonItem>TypeScript</ButtonItem>
+          <ButtonItem>Python</ButtonItem>
+        </ButtonToggle>
+        Inline text
+        <Divider />
+        <ButtonGroup>
+          <ButtonItem value="CA" selected>
+            California
+          </ButtonItem>
+          <ButtonItem value="AK">Alaska</ButtonItem>
+          <ButtonItem value="UT">Utah</ButtonItem>
+          <ButtonItem value="CO">Colorado</ButtonItem>
+          <ButtonItem value="MS">Missouri</ButtonItem>
+          <ButtonItem value="MI">Mississippi</ButtonItem>
+          <ButtonItem value="MA">Massachusets</ButtonItem>
+          <ButtonItem value="VT">Vermont</ButtonItem>
+          <ButtonItem value="NH">New Hampshire</ButtonItem>
+          <ButtonItem value="DE">Delaware</ButtonItem>
+          <ButtonItem value="ME">Maine</ButtonItem>
+          <ButtonItem value="WA">Washington</ButtonItem>
+          <ButtonItem value="OR">Oregon</ButtonItem>
+        </ButtonGroup>
+        Inline text
+        <Divider />
+        <ButtonToggle>
+          <ButtonItem selected>Ruby</ButtonItem>
+          <ButtonItem>TypeScript</ButtonItem>
+          <ButtonItem>Python</ButtonItem>
+          <ButtonItem>Java</ButtonItem>
+          <ButtonItem>Kotlin</ButtonItem>
+          <ButtonItem>Go</ButtonItem>
+          <ButtonItem>C++</ButtonItem>
+          <ButtonItem>Clojure</ButtonItem>
+          <ButtonItem>Perl</ButtonItem>
+          <ButtonItem>Scala</ButtonItem>
+        </ButtonToggle>
+        Inline text
+      </Box>
+    </Space>
   )
 }

--- a/packages/playground/src/Actions/ButtonSetDemo.tsx
+++ b/packages/playground/src/Actions/ButtonSetDemo.tsx
@@ -50,7 +50,7 @@ function ButtonGroupDemo() {
         <ButtonItem value="AK">Alaska</ButtonItem>
         <ButtonItem value="UT">Utah</ButtonItem>
       </ButtonGroup>
-      <Divider />
+      <Divider m="none" />
       <Paragraph>Controlled</Paragraph>
       <ButtonGroup value={value} onChange={setValue}>
         <ButtonItem value="CA">California</ButtonItem>
@@ -106,35 +106,35 @@ function ButtonToggleDemo() {
         <ButtonItem>TypeScript</ButtonItem>
         <ButtonItem>Python</ButtonItem>
       </ButtonToggle>
-      <Divider />
+      <Divider m="none" />
       <Paragraph>Controlled</Paragraph>
       <ButtonToggle value={toggle} onChange={handleChange}>
         <ButtonItem>Ruby</ButtonItem>
         <ButtonItem>TypeScript</ButtonItem>
         <ButtonItem>Python</ButtonItem>
       </ButtonToggle>
-      <Divider />
+      <Divider m="none" />
       <Paragraph>Uncontrolled with item selected</Paragraph>
       <ButtonToggle>
         <ButtonItem selected>Ruby</ButtonItem>
         <ButtonItem>TypeScript</ButtonItem>
         <ButtonItem>Python</ButtonItem>
       </ButtonToggle>
-      <Divider />
+      <Divider m="none" />
       <Paragraph>Controlled with initial value</Paragraph>
       <ButtonToggle value={toggle2} onChange={handleChange2}>
         <ButtonItem>Ruby</ButtonItem>
         <ButtonItem>TypeScript</ButtonItem>
         <ButtonItem>Python</ButtonItem>
       </ButtonToggle>
-      <Divider />
+      <Divider m="none" />
       <Paragraph>Nullable Uncontrolled</Paragraph>
       <ButtonToggle nullable>
         <ButtonItem>Ruby</ButtonItem>
         <ButtonItem>TypeScript</ButtonItem>
         <ButtonItem>Python</ButtonItem>
       </ButtonToggle>
-      <Divider />
+      <Divider m="none" />
       <Paragraph>Nullable Controlled</Paragraph>
       <ButtonToggle nullable value={toggle3} onChange={handleChange3}>
         <ButtonItem>Ruby</ButtonItem>
@@ -175,7 +175,7 @@ export function ButtonSetDemo() {
           on={border}
           onChange={handleChange}
         />
-        <Divider />
+        <Divider m="none" />
         <ButtonGroup>
           <ButtonItem value="CA" selected>
             California
@@ -184,14 +184,14 @@ export function ButtonSetDemo() {
           <ButtonItem value="UT">Utah</ButtonItem>
         </ButtonGroup>
         Inline text
-        <Divider />
+        <Divider m="none" />
         <ButtonToggle>
           <ButtonItem selected>Ruby</ButtonItem>
           <ButtonItem>TypeScript</ButtonItem>
           <ButtonItem>Python</ButtonItem>
         </ButtonToggle>
         Inline text
-        <Divider />
+        <Divider m="none" />
         <ButtonGroup>
           <ButtonItem value="CA" selected>
             California
@@ -210,7 +210,7 @@ export function ButtonSetDemo() {
           <ButtonItem value="OR">Oregon</ButtonItem>
         </ButtonGroup>
         Inline text
-        <Divider />
+        <Divider m="none" />
         <ButtonToggle>
           <ButtonItem selected>Ruby</ButtonItem>
           <ButtonItem>TypeScript</ButtonItem>

--- a/packages/playground/src/Actions/ButtonSetDemo.tsx
+++ b/packages/playground/src/Actions/ButtonSetDemo.tsx
@@ -1,0 +1,88 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import {
+  Box,
+  ButtonGroup,
+  ButtonItem,
+  ButtonToggle,
+  Divider,
+} from '@looker/components'
+import React from 'react'
+
+export function ButtonSetDemo() {
+  return (
+    <Box m="xlarge" width={400} border="1px solid">
+      <ButtonGroup>
+        <ButtonItem value="CA" selected>
+          California
+        </ButtonItem>
+        <ButtonItem value="AK">Alaska</ButtonItem>
+        <ButtonItem value="UT">Utah</ButtonItem>
+      </ButtonGroup>
+      Inline text
+      <Divider />
+      <ButtonToggle>
+        <ButtonItem selected>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+      </ButtonToggle>
+      Inline text
+      <Divider />
+      <ButtonGroup>
+        <ButtonItem value="CA" selected>
+          California
+        </ButtonItem>
+        <ButtonItem value="AK">Alaska</ButtonItem>
+        <ButtonItem value="UT">Utah</ButtonItem>
+        <ButtonItem value="CO">Colorado</ButtonItem>
+        <ButtonItem value="MS">Missouri</ButtonItem>
+        <ButtonItem value="MI">Mississippi</ButtonItem>
+        <ButtonItem value="MA">Massachusets</ButtonItem>
+        <ButtonItem value="VT">Vermont</ButtonItem>
+        <ButtonItem value="NH">New Hampshire</ButtonItem>
+        <ButtonItem value="DE">Delaware</ButtonItem>
+        <ButtonItem value="ME">Maine</ButtonItem>
+        <ButtonItem value="WA">Washington</ButtonItem>
+        <ButtonItem value="OR">Oregon</ButtonItem>
+      </ButtonGroup>
+      Inline text
+      <Divider />
+      <ButtonToggle>
+        <ButtonItem selected>Ruby</ButtonItem>
+        <ButtonItem>TypeScript</ButtonItem>
+        <ButtonItem>Python</ButtonItem>
+        <ButtonItem>Java</ButtonItem>
+        <ButtonItem>Kotlin</ButtonItem>
+        <ButtonItem>Go</ButtonItem>
+        <ButtonItem>C++</ButtonItem>
+        <ButtonItem>Clojure</ButtonItem>
+        <ButtonItem>Perl</ButtonItem>
+      </ButtonToggle>
+      Inline text
+    </Box>
+  )
+}

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -26,14 +26,12 @@
 import React, { FC } from 'react'
 import { render } from 'react-dom'
 import { ComponentsProvider } from '@looker/components'
-import { FieldTimeDemo } from './Form/FieldTimeDemo'
-import { FieldTimeSelectDemo } from './Form/FieldTimeSelectDemo'
+import { ButtonSetDemo } from './Actions/ButtonSetDemo'
 
 const App: FC = () => {
   return (
     <ComponentsProvider>
-      <FieldTimeDemo />
-      <FieldTimeSelectDemo />
+      <ButtonSetDemo />
     </ComponentsProvider>
   )
 }

--- a/packages/www/src/documentation/components/actions/button-group.mdx
+++ b/packages/www/src/documentation/components/actions/button-group.mdx
@@ -74,3 +74,15 @@ Use uncontrolled when you want to get the value by inspecting the underlying rad
   <ButtonItem>Bananas</ButtonItem>
 </ButtonToggle>
 ```
+
+### Nullable
+
+Use tghe `nullable` if the user should be able to click the selected item to de-select it.
+
+```jsx
+<ButtonToggle name="fruits" nullable>
+  <ButtonItem>Apples</ButtonItem>
+  <ButtonItem>Oranges</ButtonItem>
+  <ButtonItem>Bananas</ButtonItem>
+</ButtonToggle>
+```

--- a/packages/www/src/documentation/components/actions/button-group.mdx
+++ b/packages/www/src/documentation/components/actions/button-group.mdx
@@ -77,7 +77,7 @@ Use uncontrolled when you want to get the value by inspecting the underlying rad
 
 ### Nullable
 
-Use tghe `nullable` if the user should be able to click the selected item to de-select it.
+Use the `nullable` if the user should be able to click the selected item to de-select it.
 
 ```jsx
 <ButtonToggle name="fruits" nullable>


### PR DESCRIPTION
### :sparkles: Changes

- Minor changes to css in `ButtonGroup`, `ButtonToggle` and `ButtonSet` (the common component they share) to allow wrapping.
- To see it in action, go to http://localhost:8000/components/actions/button-group/ and copy/paste the last item a bunch of times.

### :white_check_mark: Requirements

- [x] Build and tests are passing
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/53451193/82097457-c9f9e300-96b7-11ea-9186-7e31c85beb6d.png)

