### PR TITLE
InlineInputText no longer collapses when value is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InlineInputText` no longer collapses when value is empty
 - `Confirm` corrected word wrapping when long strings without white-space are used
 - `IconButton` no longer generates spurious DOM outside of itself for `tooltip` (doesn't create funky layout bugs when `IconButton` is within `Space`)
 

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -60,6 +60,10 @@ export const InlineInputTextInternal = forwardRef(
 
     const handleChange = isFunction(onChange) ? onChange : handleValueChange
 
+    /**
+     * &#8203; is a zero-width space – ensures that visibleText gets accurate line-height applied
+     */
+
     return (
       <div className={className} data-testid="inlineInputText">
         <Input
@@ -70,7 +74,7 @@ export const InlineInputTextInternal = forwardRef(
           {...pick(props, inputPropKeys)}
         />
         <VisibleText displayValue={displayValue}>
-          {displayValue || placeholder}
+          {displayValue || placeholder}&#8203;
         </VisibleText>
       </div>
     )
@@ -119,7 +123,6 @@ export const InlineInputText = styled(InlineInputTextInternal)`
   justify-content: center;
   position: relative;
   min-width: 2rem;
-  min-height: ${(props) => props.theme.lineHeights.medium};
 
   :focus,
   :hover {

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
   justify-content: center;
   position: relative;
   min-width: 2rem;
-  min-height: 1.5rem;
 }
 
 .c0:focus,
@@ -66,6 +65,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
     className="c2"
   >
     this is the placeholder
+    ​
   </div>
 </div>
 `;
@@ -108,7 +108,6 @@ exports[`InlineInputText renders an input with no value 1`] = `
   justify-content: center;
   position: relative;
   min-width: 2rem;
-  min-height: 1.5rem;
 }
 
 .c0:focus,
@@ -134,7 +133,9 @@ exports[`InlineInputText renders an input with no value 1`] = `
   />
   <div
     className="c2"
-  />
+  >
+    ​
+  </div>
 </div>
 `;
 
@@ -176,7 +177,6 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
   justify-content: center;
   position: relative;
   min-width: 2rem;
-  min-height: 1.5rem;
 }
 
 .c0:focus,
@@ -204,6 +204,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
     className="c2"
   >
     type here...
+    ​
   </div>
 </div>
 `;


### PR DESCRIPTION
### :sparkles: Changes

- InlineInputText no longer collapses when value is empty

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
