### PR TITLE
RenderProps-free Tooltip (and 0.7.32 changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,36 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [0.7.32] - 2020-05-19
 
 ### Added
 
+- `Accordion`, `AccordionLabel`, `AccordionContent` components
+- `ButtonGroup` and `ButtonToggle` will now wrap if there are too many items for the container width
+- `ButtonToggle` now accepts `nullable`
+- `ComboboxList` now accepts properties from `LayoutProps`
 - `ComponentsProvider` now accepts `ie11support` parameter to emit IE11 compatibility style
   - `IEGlobalStyle` component (underlying component used by `ComponentsProvider` for IE11)
 - `FieldSelectMulti` component
 - `FieldTime` component
 - `FieldTimeSelect` component
 - `Select` now accepts `listLayout` to control the layout of the list
-- `ComboboxList` now accepts properties from `LayoutProps`
 - `Space`
   - now supports `around`, `between` and `evenly` as alternatives to `gap`
   - now supports `verticalAlign` property
 - `SpaceVertical` now supports `align` and `stretch` properties
-- `Accordion`, `AccordionLabel`, `AccordionContent` components
-- `ButtonToggle` now accepts `nullable`
-- `ButtonGroup` and `ButtonToggle` will now wrap if there are too many items for the container width
 
 ### Changed
 
-- Horizontal padding on `Button` and `ButtonOutline` increased, decreased for `ButtonTransparent`
-- Icon used for error states in inputs changed to `CircleInfo`
+- `Banner` fontSize adjusted and external margin removed
+- `Button` and `ButtonOutline` horizontal padding on increased, decreased for `ButtonTransparent`
+- `DateTimeFormat` uses date-fns to format human-readable date string (rather than built-in browser default functionality)
 - `useTooltip` includes a generated id (or passed-in prop value) for the resulting tooltip in the return object
-  - Doing this means that tooltip trigger elements can now have an `aria-describedby` property with said id as the value
 - `MenuDisclosure`, `Banner`, `IconButton`, `ModalHeader` explicitly use their id props to either provide `useTooltip` with an id or to provide another component that uses `useTooltip` with an id to generate the tooltip's id
+- Icon used for error states in inputs changed to `CircleInfo`
+  - Doing this means that tooltip trigger elements can now have an `aria-describedby` property with said id as the value
 - Support Warning icon display on Select and SelectMulti inputs
 - Refactor use of InputSearch to support more flexible layouts
-- `Banner` fontSize adjusted and external margin removed
-- `DateTimeFormat` uses date-fns to format human-readable date string (rather than built-in browser default functionality)
 - Use Babel for building Monorepo ES artifacts
   - Change build artifact path from `dist/` to `lib.`
   - No longer produces multiple artifact formats (`es` only)
@@ -42,16 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `yarn playground` & `yarn gatsby` replace `yarn develop` - no need to pre-compile for local development now.
 - Updated artwork for `Download` icon
 
+### Fixed
+
+- `Confirm` corrected word wrapping when long strings without white-space are used
+- `IconButton` no longer generates spurious DOM outside of itself for `tooltip` (doesn't create funky layout bugs when `IconButton` is within `Space`)
+- `InlineInputText` no longer collapses when value is empty
+- `FieldTime` update width to be 100%
+
 ### Removed
 
 - Deleted `MenuSearch` component in favor of `InputSearch`
-
-### Fixed
-
-- `InlineInputText` no longer collapses when value is empty
-- `Confirm` corrected word wrapping when long strings without white-space are used
-- `IconButton` no longer generates spurious DOM outside of itself for `tooltip` (doesn't create funky layout bugs when `IconButton` is within `Space`)
-- FieldTime update width to be 100%
 
 ## [0.7.31] - 2020-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Banner` fontSize adjusted and external margin removed
 - `Button` and `ButtonOutline` horizontal padding on increased, decreased for `ButtonTransparent`
 - `DateTimeFormat` uses date-fns to format human-readable date string (rather than built-in browser default functionality)
-- `useTooltip` includes a generated id (or passed-in prop value) for the resulting tooltip in the return object
+- `Tooltip`
+  - Now offers a cloneElement version as well as the existing render props version
+  - Documentation update to reflect new `children` structure
+  - now supports `aria-describedby`
+  - `useTooltip` includes a generated id (or passed-in prop value) for the resulting tooltip in the return object
 - `MenuDisclosure`, `Banner`, `IconButton`, `ModalHeader` explicitly use their id props to either provide `useTooltip` with an id or to provide another component that uses `useTooltip` with an id to generate the tooltip's id
 - Icon used for error states in inputs changed to `CircleInfo`
-  - Doing this means that tooltip trigger elements can now have an `aria-describedby` property with said id as the value
 - Support Warning icon display on Select and SelectMulti inputs
 - Refactor use of InputSearch to support more flexible layouts
 - Use Babel for building Monorepo ES artifacts

--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -191,14 +191,7 @@ test('IconButton built-in tooltip defers to outer tooltip', () => {
   const label = 'Mark as my Favorite'
   const { container, getByText, getByTitle } = renderWithTheme(
     <Tooltip content={tooltip}>
-      {(tooltipProps) => (
-        <IconButton
-          tooltipDisabled
-          label={label}
-          icon="Favorite"
-          {...tooltipProps}
-        />
-      )}
+      <IconButton tooltipDisabled label={label} icon="Favorite" />
     </Tooltip>
   )
 

--- a/packages/components/src/Calendar/CalendarNav.tsx
+++ b/packages/components/src/Calendar/CalendarNav.tsx
@@ -92,17 +92,11 @@ export const CalendarNav: FC<NavbarElementProps> = ({
       </NextButtonWrapper>
 
       <Tooltip content="View Current Month">
-        {(tooltipProps) => (
-          <ButtonTransparent
-            {...tooltipProps}
-            onClick={handleLabelClick}
-            color="neutral"
-          >
-            <Heading as={headingSizeMap(size)} fontWeight="semiBold">
-              {localeUtils.formatMonthTitle(month, locale)}
-            </Heading>
-          </ButtonTransparent>
-        )}
+        <ButtonTransparent onClick={handleLabelClick} color="neutral">
+          <Heading as={headingSizeMap(size)} fontWeight="semiBold">
+            {localeUtils.formatMonthTitle(month, locale)}
+          </Heading>
+        </ButtonTransparent>
       </Tooltip>
 
       <PrevButtonWrapper>

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -55,7 +55,7 @@ describe('Tooltip', () => {
   test('snapshot', () => {
     assertSnapshotShallow(
       <Tooltip content="Hello world" isOpen>
-        {(tooltipProps) => <Button {...tooltipProps}>Example</Button>}
+        <Button>Example</Button>
       </Tooltip>
     )
   })
@@ -63,7 +63,7 @@ describe('Tooltip', () => {
   test('Tooltip can hide its arrow', () => {
     assertSnapshotShallow(
       <Tooltip content="Hello world" arrow={false} isOpen>
-        {(tooltipProps) => <Button {...tooltipProps}>Example</Button>}
+        <Button>Example</Button>
       </Tooltip>
     )
   })
@@ -71,7 +71,7 @@ describe('Tooltip', () => {
   test('trigger: open on mouseover, close on mouseout', () => {
     const tooltip = mountWithTheme(
       <Tooltip content="Hello world">
-        {(tooltipProps) => <Button {...tooltipProps}>Test</Button>}
+        <Button>Test</Button>
       </Tooltip>
     )
 
@@ -89,7 +89,7 @@ describe('Tooltip', () => {
   test('close on surface mouseout', () => {
     const tooltip = mountWithTheme(
       <Tooltip content="Hello world" isOpen>
-        {(tooltipProps) => <Button {...tooltipProps}>Test</Button>}
+        <Button>Test</Button>
       </Tooltip>
     )
 
@@ -104,7 +104,7 @@ describe('Tooltip', () => {
   test('contains content', () => {
     const tooltip = mountWithTheme(
       <Tooltip content="Hello world">
-        {(tooltipProps) => <Button {...tooltipProps}>Test</Button>}
+        <Button>Test</Button>
       </Tooltip>
     )
 
@@ -117,7 +117,7 @@ describe('Tooltip', () => {
   test('open initially, collapse on mouseout', () => {
     const tooltip = mountWithTheme(
       <Tooltip content="Hello world" isOpen>
-        {(tooltipProps) => <Button {...tooltipProps}>Test</Button>}
+        <Button>Test</Button>
       </Tooltip>
     )
 
@@ -134,7 +134,7 @@ describe('Tooltip', () => {
   test('supports styling props', () => {
     const tooltip = mountWithTheme(
       <Tooltip content="Hello world" width="20rem" textAlign="right">
-        {(tooltipProps) => <Button {...tooltipProps}>Test</Button>}
+        <Button>Test</Button>
       </Tooltip>
     )
 
@@ -153,9 +153,7 @@ describe('Tooltip', () => {
   test('tooltip can exceed bounds of containing overlay', () => {
     const tooltip = (
       <Tooltip content="Great knowledge here!" isOpen>
-        {(tooltipProps) => (
-          <Box {...tooltipProps}>I wish I knew more about this...</Box>
-        )}
+        <Box>I wish I knew more about this...</Box>
       </Tooltip>
     )
 
@@ -170,5 +168,41 @@ describe('Tooltip', () => {
     )
 
     assertSnapshotShallow(popover)
+  })
+
+  test('Render props version works', () => {
+    const tooltip = mountWithTheme(
+      <Tooltip content="Hello world">
+        {(props) => <Button {...props}>Test</Button>}
+      </Tooltip>
+    )
+
+    const trigger = tooltip.find(Button)
+
+    trigger.simulate('mouseover', mouseEventSimulator)
+    const surface = tooltip.find(OverlaySurface)
+    expect(surface.exists()).toBeTruthy()
+
+    trigger.simulate('mouseout', mouseEventSimulator)
+    const postMouseoutSurface = tooltip.find(OverlaySurface)
+    expect(postMouseoutSurface.exists()).toBeFalsy()
+  })
+
+  test('Render props version works', () => {
+    const tooltip = mountWithTheme(
+      <Tooltip content="Hello world">
+        {(props) => <Button {...props}>Test</Button>}
+      </Tooltip>
+    )
+
+    const trigger = tooltip.find(Button)
+
+    trigger.simulate('mouseover', mouseEventSimulator)
+    const surface = tooltip.find(OverlaySurface)
+    expect(surface.exists()).toBeTruthy()
+
+    trigger.simulate('mouseout', mouseEventSimulator)
+    const postMouseoutSurface = tooltip.find(OverlaySurface)
+    expect(postMouseoutSurface.exists()).toBeFalsy()
   })
 })

--- a/packages/playground/src/Tooltip/TooltipDemo.tsx
+++ b/packages/playground/src/Tooltip/TooltipDemo.tsx
@@ -25,16 +25,28 @@
  */
 
 import React from 'react'
-import { Box, IconButton, Tooltip } from '@looker/components'
+import { SpaceVertical, IconButton, Tooltip } from '@looker/components'
 
 export function TooltipDemo() {
   return (
-    <Box p="xxxlarge">
-      <Tooltip content="Start editing" placement="top">
-        {(tooltipProps) => (
-          <IconButton icon="Edit" label="Edit something" {...tooltipProps} />
-        )}
-      </Tooltip>
-    </Box>
+    <SpaceVertical m="xxxlarge">
+      <div>
+        <Tooltip content="I'm a little teapot">Some Text</Tooltip>
+      </div>
+
+      <div>
+        <Tooltip content="Start editing" placement="top">
+          {(tooltipProps) => (
+            <IconButton icon="Edit" label="Edit something" {...tooltipProps} />
+          )}
+        </Tooltip>
+      </div>
+
+      <div>
+        <Tooltip content="Start editing" placement="top">
+          <IconButton icon="Edit" label="Edit something" />
+        </Tooltip>
+      </div>
+    </SpaceVertical>
   )
 }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -26,12 +26,12 @@
 import React, { FC } from 'react'
 import { render } from 'react-dom'
 import { ComponentsProvider } from '@looker/components'
-import { AccordionDemo } from './Accordion/AccordionDemo'
+import { TooltipDemo } from './Tooltip/TooltipDemo'
 
 const App: FC = () => {
   return (
     <ComponentsProvider ie11Support>
-      <AccordionDemo />
+      <TooltipDemo />
     </ComponentsProvider>
   )
 }

--- a/packages/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/packages/www/src/MDX/Pre/CodeSandbox.tsx
@@ -196,16 +196,13 @@ export const ToggleCodeButton: FC<ToggleButtonProps> = ({
   const toggleLabel = editorIsVisible ? 'Hide code editor' : 'Show code editor'
   return (
     <Tooltip content={toggleLabel} placement="left">
-      {(tooltipProps) => (
-        <ActionButton
-          {...tooltipProps}
-          editorIsVisible={editorIsVisible}
-          onClick={onClick}
-          label={toggleLabel}
-          icon={toggleIcon}
-          size="xsmall"
-        />
-      )}
+      <ActionButton
+        editorIsVisible={editorIsVisible}
+        onClick={onClick}
+        label={toggleLabel}
+        icon={toggleIcon}
+        size="xsmall"
+      />
     </Tooltip>
   )
 }

--- a/packages/www/src/documentation/components/actions/icon-button.mdx
+++ b/packages/www/src/documentation/components/actions/icon-button.mdx
@@ -92,13 +92,6 @@ You can also use your own `Tooltip` around `IconButton` (this will effectively r
 
 ```jsx
 <Tooltip content="I'm a little teapot">
-  {(tooltipProps) => (
-    <IconButton
-      {...tooltipProps}
-      label="Add Something Neat"
-      icon="Plus"
-      size="xxsmall"
-    />
-  )}
+  <IconButton label="Add Something Neat" icon="Plus" size="xxsmall" />
 </Tooltip>
 ```

--- a/packages/www/src/documentation/components/overlays/popover.mdx
+++ b/packages/www/src/documentation/components/overlays/popover.mdx
@@ -73,7 +73,7 @@ If you want to hide the popover arrow you can set the prop `arrow` prop to false
 
   return (
     <SpaceVertical>
-      <Space between>
+      <Space between width="100%">
         <Popover content={popoverContent}>
           {(onClick, ref, className) =>
             button('Default', onClick, ref, className)
@@ -88,7 +88,7 @@ If you want to hide the popover arrow you can set the prop `arrow` prop to false
           {(onClick, ref, className) => button('Left', onClick, ref, className)}
         </Popover>
       </Space>
-      <Space>
+      <Space between width="100%">
         <Popover content={popoverContent} placement="bottom-start">
           {(onClick, ref, className) =>
             button('Bottom Start', onClick, ref, className)

--- a/packages/www/src/documentation/components/overlays/tooltip.mdx
+++ b/packages/www/src/documentation/components/overlays/tooltip.mdx
@@ -8,7 +8,7 @@ A simple Tooltip component with out of the box styles and behavior.
 
 ```jsx
 <Tooltip content="More things you should know...">
-  {(tooltipProps) => <Button {...tooltipProps}>Hover for Tooltip</Button>}
+  <Button>Hover for Tooltip</Button>
 </Tooltip>
 ```
 
@@ -25,13 +25,9 @@ A simple Tooltip component with out of the box styles and behavior.
     </>
   }
 >
-  {(tooltipProps) => (
-    <ButtonOutline {...tooltipProps}>Tooltip with lots of text</ButtonOutline>
-  )}
+  <ButtonOutline>Tooltip with lots of text</ButtonOutline>
 </Tooltip>
 ```
-
-## Tooltip Placement
 
 Tooltip allows you to specify where it should appear in relation to the target element. It accepts the following values:
 
@@ -51,35 +47,49 @@ Tooltip allows you to specify where it should appear in relation to the target e
 1. `left-start`
 
 ```jsx
-<Tooltip content="I'm on top" placement="top">
-  {(tooltipProps) => (
-    <Button {...tooltipProps}>
-      Top
-    </Button>
-  )}
-</Tooltip>
+<Space around>
+  <Tooltip content="I'm on top" placement="top">
+    <Button>Top</Button>
+  </Tooltip>
+  <Tooltip content="I'm on bottom" placement="bottom">
+    <Button>Bottom</Button>
+  </Tooltip>
+  <Tooltip content="I'm on the left" placement="left">
+    <Button>Left</Button>
+  </Tooltip>
+  <Tooltip content="I'm on the right" placement="right">
+    <Button>Right</Button>
+  </Tooltip>
+</Space>
+```
 
-<Tooltip content="I'm on bottom" placement="bottom">
-  {(tooltipProps) => (
-    <Button {...tooltipProps}>
-      Bottom
-    </Button>
-  )}
-</Tooltip>
+## "Render Prop" style
 
-<Tooltip content="I'm on the left" placement="left">
-  {(tooltipProps) => (
-    <Button {...tooltipProps}>
-      Left
-    </Button>
-  )}
-</Tooltip>
+Sometimes you may need to control how `Tooltip` applies handlers to the component within it. If so you can use the render prop form of the component:
 
-<Tooltip content="I'm on the right" placement="right">
-  {(tooltipProps) => (
-    <Button {...tooltipProps}>
-      Right
+```jsx
+<Tooltip content="Example using render props">
+  {(props) => <Button {...props}>Render Props Example</Button>}
+</Tooltip>
+```
+
+If you need to be very specific
+
+```jsx
+<Tooltip content="Example using render props exploded">
+  {(props) => (
+    <Button
+      aria-describedby={props['aria-describedby']}
+      onBlur={props.onBlur}
+      onFocus={props.onFocus}
+      onMouseOut={props.onMouseOut}
+      onMouseOver={props.onMouseOver}
+      ref={props.ref}
+    >
+      Render Props Example
     </Button>
   )}
 </Tooltip>
 ```
+
+## Tooltip Placement


### PR DESCRIPTION
### :sparkles: Changes

- Changelog for 0.7.32
- Render-props free version of Tooltip!

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
