### PR TITLE
Update TextArea documentation to reflect removal of `both` & `horizontal` support

### DIFF
--- a/packages/www/src/documentation/components/forms/text-area.mdx
+++ b/packages/www/src/documentation/components/forms/text-area.mdx
@@ -6,7 +6,7 @@ propsOf: TextArea
 
 ## TextArea
 
-`TextArea` component offeres a multi-line text editor. If you are bulding a form `FieldTextArea` may be a better fit.
+`TextArea` component offers a multi-line text editor. If you are building a form `FieldTextArea` may be a better fit.
 
 ```jsx
 <TextArea />
@@ -14,20 +14,15 @@ propsOf: TextArea
 
 ## Allowing TextArea to be resized
 
-`both` and `true` will allow for the `TextArea` to be resized on height and width. Alternatively, `none` and `false` will not allow any resizing.
-
-You can also specify only `horizontal` or `vertical` resizing.
+`true` and `vertical` will allow the `TextArea` height to be resized. Alternatively, `none` and `false` will not allow resizing.
 
 ```jsx
-<TextArea resize="both" placeholder="resize in both directions" />
-<TextArea resize placeholder="resize in both directions" />
+<TextArea resize placeholder="resize vertically" />
 <Divider my="medium" />
 <TextArea resize="none" placeholder="no resize" />
 <TextArea resize={false} placeholder="no resize" />
 <Divider my="medium" />
 <TextArea resize="vertical" placeholder="only resize vertically" />
-<TextArea resize="horizontal" placeholder="only resize horizontally" />
-
 ```
 
 ## Disabled


### PR DESCRIPTION
### :sparkles: Changes

- Update TextArea documentation to reflect removal of `both` & `horizontal` support

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [x] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
