### PR TITLE
Publishing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ We follow a [semantic versioning scheme](https://semver.org/). That means:
 
 ### Update Changelog & Version
 
-1.  Increment the version number according to sematic versioning philosophy in [package.json](package.json)
 1.  Update CHANGELOG
-1.  PR for package.json & CHANGELOG changes
+1.  Open PR for change review
 1.  Merge PR
+1.  Pull latest master
+1.  `yarn release`
 
 ### 4. Tooling
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -48,13 +48,22 @@ module.exports = (api) => {
     plugins: [
       '@babel/plugin-proposal-class-properties',
       '@babel/plugin-proposal-object-rest-spread',
-      ['@babel/plugin-transform-runtime', { corejs: 3 }],
+      // ['@babel/plugin-transform-runtime', { corejs: 3 }],
       'babel-plugin-styled-components',
       '@babel/plugin-proposal-optional-chaining',
       '@babel/plugin-proposal-nullish-coalescing-operator',
     ],
 
     presets: [
+      [
+        '@babel/preset-env',
+        {
+          targets: {
+            esmodules: true,
+          },
+          useBuiltIns: false,
+        },
+      ],
       [
         '@babel/preset-react',
         {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "build": "run-p -c build:*",
     "build:es": "yarn lerna exec --scope '@looker/*' --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments'",
     "build:ts": "yarn lerna exec --stream --scope '@looker/*' --sort 'tsc -b tsconfig.build.json'",
+    "prerelease": "yarn build",
+    "release": "yarn lerna publish",
     "clean": "rm -Rf packages/*/lib",
-    "prepublishOnly": "yarn build",
     "deploy": "yarn workspace www deploy",
     "playground": "yarn workspace playground start",
     "server": "yarn workspace server start",
@@ -85,16 +86,13 @@
   "lint-staged": {
     "**/*.ts?(x)": [
       "stylelint",
-      "eslint --cache",
-      "git add"
+      "eslint --cache"
     ],
     "**/*.js?(x)": [
-      "eslint --cache",
-      "git add"
+      "eslint --cache"
     ],
     "**/*.mdx": [
-      "eslint",
-      "git add"
+      "eslint"
     ]
   },
   "pre-commit": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@looker/components",
   "license": "MIT",
-  "version": "0.7.34",
+  "version": "0.7.35-beta.1+a66911d11",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -16,9 +16,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@looker/components-providers": "^0.7.34",
-    "@looker/design-tokens": "^0.7.34",
-    "@looker/icons": "^0.7.34",
+    "@looker/components-providers": "^0.7.35-beta.1+a66911d11",
+    "@looker/design-tokens": "^0.7.35-beta.1+a66911d11",
+    "@looker/icons": "^0.7.35-beta.1+a66911d11",
     "@popperjs/core": "^2.4.0",
     "d3-color": "^1.4.1",
     "d3-hsv": "^0.1.0",
@@ -36,7 +36,7 @@
     "uuid": "^8.0.0"
   },
   "devDependencies": {
-    "@looker/components-test-utils": "^0.7.34",
+    "@looker/components-test-utils": "^0.7.35-beta.1+a66911d11",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^10.0.4",
     "@types/d3-color": "^1.2.2",
@@ -58,5 +58,5 @@
     "react-dom": "^16.9.0",
     "styled-components": "^4"
   },
-  "gitHead": "6824d04c5c7c42fbf87e5ceb1172f5de59b6dfdd"
+  "gitHead": "a66911d11418049c25319d4b283635e29d0d94a9"
 }

--- a/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.test.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.test.tsx
@@ -27,7 +27,7 @@ import 'jest-styled-components'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'
-import { map } from 'lodash'
+import map from 'lodash/map'
 import { CheckboxGroup } from './CheckboxGroup'
 
 const checkboxOptions = [

--- a/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.test.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.test.tsx
@@ -27,7 +27,7 @@ import 'jest-styled-components'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'
-import { map } from 'lodash'
+import map from 'lodash/map'
 import { RadioGroup } from './RadioGroup'
 
 const radioOptions = [

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -36,7 +36,7 @@ import React, {
   ReactNode,
   Ref,
 } from 'react'
-import { omit } from 'lodash'
+import omit from 'lodash/omit'
 import { ModalContext } from '../Modal'
 import {
   useCallbackRef,

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@looker/design-tokens",
   "license": "MIT",
-  "version": "0.7.34",
+  "version": "0.7.35-beta.1+a66911d11",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -35,5 +35,5 @@
     "react-dom": "^16.9.0",
     "styled-components": "^4"
   },
-  "gitHead": "05b63c793e74648ca4ada0d1bb9d4cc278256778"
+  "gitHead": "a66911d11418049c25319d4b283635e29d0d94a9"
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@looker/icons",
   "license": "MIT",
-  "version": "0.7.34",
+  "version": "0.7.35-beta.1+a66911d11",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -28,5 +28,5 @@
     "ora": "^4.0.4",
     "rimraf": "^3.0.2"
   },
-  "gitHead": "6824d04c5c7c42fbf87e5ceb1172f5de59b6dfdd"
+  "gitHead": "a66911d11418049c25319d4b283635e29d0d94a9"
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,7 +1,6 @@
 {
   "name": "playground",
   "version": "0.7.34",
-  "main": "index.js",
   "license": "MIT",
   "author": "Looker",
   "repository": {
@@ -14,7 +13,7 @@
     "start": "webpack-dev-server --port 3000"
   },
   "dependencies": {
-    "@looker/components": "^0.7.34",
+    "@looker/components": "*",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/playground/src/Form/OptionsGroupDemo.tsx
+++ b/packages/playground/src/Form/OptionsGroupDemo.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import { noop } from 'lodash'
+import noop from 'lodash/noop'
 import React from 'react'
 import {
   CheckboxGroup,

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@looker/components-providers",
   "license": "MIT",
-  "version": "0.7.34",
+  "version": "0.7.35-beta.1+a66911d11",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@looker/design-tokens": "^0.7.34"
+    "@looker/design-tokens": "^0.7.35-beta.1+a66911d11"
   },
   "devDependencies": {
     "@types/react": "^16.9.35",
@@ -27,5 +27,6 @@
   "peerDependencies": {
     "react": "^16.9.0",
     "styled-components": "^4"
-  }
+  },
+  "gitHead": "a66911d11418049c25319d4b283635e29d0d94a9"
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@looker/components-test-utils",
   "license": "MIT",
-  "version": "0.7.34",
+  "version": "0.7.35-beta.1+a66911d11",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@looker/components-providers": "^0.7.34",
+    "@looker/components-providers": "^0.7.35-beta.1+a66911d11",
     "@testing-library/react": "^10.0.4",
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^25.2.3",
@@ -31,5 +31,5 @@
   "peerDependencies": {
     "react": "^16.11"
   },
-  "gitHead": "05b63c793e74648ca4ada0d1bb9d4cc278256778"
+  "gitHead": "a66911d11418049c25319d4b283635e29d0d94a9"
 }

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "version": "0.7.34",
   "devDependencies": {
-    "@looker/components": "^0.7.34",
-    "@looker/design-tokens": "^0.7.34",
-    "@looker/icons": "^0.7.34",
+    "@looker/components": "*",
+    "@looker/design-tokens": "*",
+    "@looker/icons": "*",
     "@mdx-js/mdx": "^1.6.0",
     "@mdx-js/react": "^1.6.1",
     "@reach/router": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,6 +2053,47 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@looker/components-providers@^0.7.34":
+  version "0.7.34"
+  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-0.7.34.tgz#e722fc19faa9e67d63c37abef2b4ab9a794789bb"
+  integrity sha512-qLE7L4PSYm7g6RWF7JkQvDG/M1dLXjpZ9MFruUEkZWd8A1onzbbniGajEMQrUEWkf5VJoX9uXrn2guec4LytdQ==
+  dependencies:
+    "@looker/design-tokens" "^0.7.34"
+
+"@looker/components@*":
+  version "0.7.34"
+  resolved "https://registry.yarnpkg.com/@looker/components/-/components-0.7.34.tgz#79b87aa69f66d073a2030b7fe0abec02544f5a57"
+  integrity sha512-+WfAxVv03gtrY9RIoY1/v9A4TnT3lroKtt9f/A7zW4TvBKwEsGFP4aZC/OPUUPzpcCpnjjcvMoWsLGYFKSI9Zg==
+  dependencies:
+    "@looker/components-providers" "^0.7.34"
+    "@looker/design-tokens" "^0.7.34"
+    "@looker/icons" "^0.7.34"
+    "@popperjs/core" "^2.4.0"
+    d3-color "^1.4.1"
+    d3-hsv "^0.1.0"
+    date-fns "^2.14.0"
+    date-fns-tz "^1.0.10"
+    focus-trap "^5.1.0"
+    lodash "^4.17.15"
+    polished "^3.6.3"
+    react-day-picker "^7.4.8"
+    react-hotkeys "^2.0.0"
+    react-resize-detector "^4.2.3"
+    react-transition-group "^4.3.0"
+    resize-observer-polyfill "^1.5.1"
+    styled-system "^5.1.5"
+    uuid "^8.0.0"
+
+"@looker/design-tokens@*", "@looker/design-tokens@^0.7.34":
+  version "0.7.34"
+  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-0.7.34.tgz#94b8b7b744602c12ba21778efca1638205cad197"
+  integrity sha512-uPuHSYZeY53Zv9BnhLtFnKUZbZSkW48LYaN+Es+Y8Lz8lq5eIC3AvT9kcoprOMmlDhScF1WFBrGnqoGflaC1lg==
+  dependencies:
+    "@types/styled-system" "^5.1.9"
+    lodash "^4.17.15"
+    polished "^3.6.3"
+    styled-system "^5.1.5"
+
 "@looker/eslint-config@^1.0.14":
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/@looker/eslint-config/-/eslint-config-1.0.16.tgz#6221efeb686b7c82f82817975892895599a231a7"
@@ -2077,6 +2118,11 @@
     stylelint-config-styled-components "^0.1.1"
     stylelint-processor-styled-components "^1.10.0"
     typescript "^3.8.3"
+
+"@looker/icons@*", "@looker/icons@^0.7.34":
+  version "0.7.34"
+  resolved "https://registry.yarnpkg.com/@looker/icons/-/icons-0.7.34.tgz#119fc8257278dd72fb8990eb459737ebf592b3d4"
+  integrity sha512-nwNPV+azo4DqHTh+9jf1XkyiKliLy2EhJUjBaoBCOyIR4jyk8TXL8w00x96G9GgdvfXcNS4UdLqjsCWdcYzJyQ==
 
 "@looker/prettier-config@^1.0.15":
   version "1.0.15"


### PR DESCRIPTION
### :sparkles: Changes

- Added `yarn release` to pre-build packages
- Reconfigured babel build a bit to properly build packages for external consumption
- Correct `lodash` imports to not cause a global lodash/underscore collision in consumers

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
