### PR TITLE
InlineInputText simple prop updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InlineInputText` prop simple removes border-bottom
 - `Popover` positioning when placement is "top" and the height changes
   - `usePopper` reinstate the `adaptive` option of `computeStyles`
 - `CheckboxGroup` and `RadioGroup` now reflect changes to `value` prop

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -36,6 +36,7 @@ interface InlineInputTextProps
     Omit<InputProps, 'type'> {
   underlineOnlyOnHover?: boolean
   value?: string
+  simple?: boolean
 }
 
 export const InlineInputTextInternal = forwardRef(
@@ -46,6 +47,7 @@ export const InlineInputTextInternal = forwardRef(
       underlineOnlyOnHover,
       value: valueProp,
       placeholder,
+      simple = false,
       ...props
     }: InlineInputTextProps,
     ref: Ref<HTMLInputElement>
@@ -68,6 +70,7 @@ export const InlineInputTextInternal = forwardRef(
       <div className={className} data-testid="inlineInputText">
         <Input
           onChange={handleChange}
+          simple={simple}
           underlineOnlyOnHover={underlineOnlyOnHover}
           value={displayValue}
           ref={ref}
@@ -115,7 +118,7 @@ export const InlineInputText = styled(InlineInputTextInternal)`
   border: none;
   border-bottom: 1px dashed;
   border-bottom-color: ${(props) =>
-    props.underlineOnlyOnHover
+    props.underlineOnlyOnHover || props.simple
       ? 'transparent'
       : props.theme.colors.palette.charcoal300};
   display: inline-flex;

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 
 .c0:focus,
 .c0:hover {
-  background: blue;
   outline: none;
   border-bottom-color: #6C43E0;
   background-color: #F5F6F7;
@@ -113,7 +112,6 @@ exports[`InlineInputText renders an input with no value 1`] = `
 
 .c0:focus,
 .c0:hover {
-  background: blue;
   outline: none;
   border-bottom-color: #6C43E0;
   background-color: #F5F6F7;
@@ -183,7 +181,6 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 
 .c0:focus,
 .c0:hover {
-  background: blue;
   outline: none;
   border-bottom-color: #6C43E0;
   background-color: #F5F6F7;

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 
 .c0:focus,
 .c0:hover {
+  background: blue;
   outline: none;
   border-bottom-color: #6C43E0;
   background-color: #F5F6F7;
@@ -112,6 +113,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
 
 .c0:focus,
 .c0:hover {
+  background: blue;
   outline: none;
   border-bottom-color: #6C43E0;
   background-color: #F5F6F7;
@@ -181,6 +183,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 
 .c0:focus,
 .c0:hover {
+  background: blue;
   outline: none;
   border-bottom-color: #6C43E0;
   background-color: #F5F6F7;

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -25,13 +25,15 @@
  */
 import React, { FC } from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider } from '@looker/components'
-import { TestPopovers } from './Popovers/Testing'
+import { ComponentsProvider, Grid, InlineInputText } from '@looker/components'
 
 const App: FC = () => {
   return (
-    <ComponentsProvider ie11Support>
-      <TestPopovers />
+    <ComponentsProvider>
+      <Grid>
+        <InlineInputText simple value="Type here..." />
+        <InlineInputText value="Type here..." />
+      </Grid>
     </ComponentsProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- `InlineInputText` prop simple removes border-bottom


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="613" alt="Screen Shot 2020-05-26 at 1 01 32 PM" src="https://user-images.githubusercontent.com/23616264/82944838-c0db0280-9f50-11ea-972e-0b4e174d71cf.png">
