### PR TITLE
TextArea has min-height as defaultProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- update `TextArea` to have min-height as `defaultProps`
 - `InlineInputText` prop simple removes border-bottom
 - `Popover` positioning when placement is "top" and the height changes
   - `usePopper` reinstate the `adaptive` option of `computeStyles`

--- a/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`A FieldTextArea with default label 1`] = `
 }
 
 .c4 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -24,7 +24,6 @@ exports[`A FieldTextArea with default label 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }
@@ -137,7 +136,7 @@ exports[`A FieldTextArea with label inline 1`] = `
 }
 
 .c4 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -145,7 +144,6 @@ exports[`A FieldTextArea with label inline 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }

--- a/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
+++ b/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
@@ -108,7 +108,6 @@ export const TextArea = styled(TextAreaLayout)`
     border-color: ${(props) => props.theme.colors.palette.charcoal200};
     border-radius: ${(props) => props.theme.radii.medium};
     font-size: ${(props) => props.theme.fontSizes.small};
-    min-height: 6.25rem;
     padding: ${({ theme }) => `${theme.space.xsmall} ${theme.space.small}`};
     padding-right: ${(props) => props.theme.space.xlarge};
 
@@ -127,7 +126,7 @@ export const TextArea = styled(TextAreaLayout)`
 `
 
 TextArea.defaultProps = {
-  height: '6.25rem',
+  minHeight: '6.25rem',
   resize: 'vertical',
   width: '100%',
 }

--- a/packages/components/src/Form/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`TextArea default 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -24,7 +24,6 @@ exports[`TextArea default 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }
@@ -65,7 +64,7 @@ exports[`TextArea resizes with prop resize = false 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: none;
   border: solid 1px;
@@ -73,7 +72,6 @@ exports[`TextArea resizes with prop resize = false 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }
@@ -114,7 +112,7 @@ exports[`TextArea resizes with prop resize = none 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: none;
   border: solid 1px;
@@ -122,7 +120,6 @@ exports[`TextArea resizes with prop resize = none 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }
@@ -163,7 +160,7 @@ exports[`TextArea resizes with prop resize = true 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -171,7 +168,6 @@ exports[`TextArea resizes with prop resize = true 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }
@@ -212,7 +208,7 @@ exports[`TextArea resizes with prop resize = vertical 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -220,7 +216,6 @@ exports[`TextArea resizes with prop resize = vertical 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }
@@ -261,7 +256,7 @@ exports[`TextArea should accept disabled 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -269,7 +264,6 @@ exports[`TextArea should accept disabled 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
   background: #F5F6F7;
@@ -343,7 +337,7 @@ exports[`TextArea with an error validation 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -351,7 +345,6 @@ exports[`TextArea with an error validation 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
   border-color: #ED3B53;
@@ -424,7 +417,7 @@ exports[`TextArea with placeholder 1`] = `
 }
 
 .c0 textarea {
-  height: 6.25rem;
+  min-height: 6.25rem;
   width: 100%;
   resize: vertical;
   border: solid 1px;
@@ -432,7 +425,6 @@ exports[`TextArea with placeholder 1`] = `
   border-color: #DEE1E5;
   border-radius: 0.25rem;
   font-size: 0.875rem;
-  min-height: 6.25rem;
   padding: 0.5rem 0.75rem;
   padding-right: 2rem;
 }


### PR DESCRIPTION
### :sparkles: Changes

- TextArea has min-height as defaultProps

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
