### PR TITLE
InlineInputText has color inherit from parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - update `TextArea` to have min-height as `defaultProps`
-- `InlineInputText` has color inherit from parent
+- `InlineInputText` inherits color and text-alignment from parent
 - `InlineInputText` prop simple removes border-bottom
 - `Popover` positioning when placement is "top" and the height changes
   - `usePopper` reinstate the `adaptive` option of `computeStyles`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InlineInputText` has color inherit from parent
 - `InlineInputText` prop simple removes border-bottom
 - `Popover` positioning when placement is "top" and the height changes
   - `usePopper` reinstate the `adaptive` option of `computeStyles`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - update `TextArea` to have min-height as `defaultProps`
-- `InlineInputText` inherits color and text-alignment from parent
+- `InlineInputText` & `InlineInputTextArea` inherit color and text-alignment from parent
 - `InlineInputText` prop simple removes border-bottom
 - `Popover` positioning when placement is "top" and the height changes
   - `usePopper` reinstate the `adaptive` option of `computeStyles`

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -89,7 +89,7 @@ InlineInputTextInternal.displayName = 'InlineInputTextInternal'
 const Input = styled.input.attrs({ type: 'text' })<InlineInputTextProps>`
   background: transparent;
   border: none;
-  color: transparent;
+  color: inherit;
   font: inherit;
   caret-color: ${(props) => props.theme.colors.palette.charcoal900};
   height: 100%;
@@ -114,7 +114,7 @@ const VisibleText = styled.div<VisibleTextProps>`
 
 export const InlineInputText = styled(InlineInputTextInternal)`
   ${typography}
-
+  color: inherit;
   border: none;
   border-bottom: 1px dashed;
   border-bottom-color: ${(props) =>

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -126,6 +126,7 @@ export const InlineInputText = styled(InlineInputTextInternal)`
   justify-content: center;
   position: relative;
   min-width: 2rem;
+  text-align: inherit;
 
   :focus,
   :hover {

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
   justify-content: center;
   position: relative;
   min-width: 2rem;
+  text-align: inherit;
 }
 
 .c0:focus,
@@ -110,6 +111,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
   justify-content: center;
   position: relative;
   min-width: 2rem;
+  text-align: inherit;
 }
 
 .c0:focus,
@@ -180,6 +182,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
   justify-content: center;
   position: relative;
   min-width: 2rem;
+  text-align: inherit;
 }
 
 .c0:focus,

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 .c1 {
   background: transparent;
   border: none;
-  color: transparent;
+  color: inherit;
   font: inherit;
   caret-color: #262D33;
   height: 100%;
@@ -22,6 +22,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 }
 
 .c0 {
+  color: inherit;
   border: none;
   border-bottom: 1px dashed;
   border-bottom-color: #C1C6CC;
@@ -74,7 +75,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
 .c1 {
   background: transparent;
   border: none;
-  color: transparent;
+  color: inherit;
   font: inherit;
   caret-color: #262D33;
   height: 100%;
@@ -92,6 +93,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
 }
 
 .c0 {
+  color: inherit;
   border: none;
   border-bottom: 1px dashed;
   border-bottom-color: #C1C6CC;
@@ -143,7 +145,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 .c1 {
   background: transparent;
   border: none;
-  color: transparent;
+  color: inherit;
   font: inherit;
   caret-color: #262D33;
   height: 100%;
@@ -161,6 +163,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 }
 
 .c0 {
+  color: inherit;
   border: none;
   border-bottom: 1px dashed;
   border-bottom-color: #C1C6CC;

--- a/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
+++ b/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
@@ -99,6 +99,7 @@ const Input = styled.textarea<InlineTextAreaProps>`
   padding: 0;
   position: absolute;
   resize: none;
+  text-align: inherit;
   text-transform: inherit;
   top: 0;
   width: 100%;
@@ -129,6 +130,7 @@ export const InlineTextArea = styled(InlineTextAreaLayout)`
   position: relative;
   min-width: 2rem;
   min-height: ${(props) => props.theme.lineHeights.medium};
+  text-align: inherit;
   white-space: pre-wrap;
 
   :focus,

--- a/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
+++ b/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
@@ -108,11 +108,10 @@ const Input = styled.textarea<InlineTextAreaProps>`
 interface VisibleTextProps {
   displayValue?: string
 }
+
 const VisibleText = styled.div<VisibleTextProps>`
   color: ${({ displayValue, theme }) =>
-    displayValue
-      ? theme.colors.palette.charcoal900
-      : theme.colors.palette.charcoal400};
+    displayValue ? 'inherit' : theme.colors.palette.charcoal400};
 `
 
 export const InlineTextArea = styled(InlineTextAreaLayout)`
@@ -124,6 +123,7 @@ export const InlineTextArea = styled(InlineTextAreaLayout)`
     props.underlineOnlyOnHover
       ? 'transparent'
       : props.theme.colors.palette.charcoal300};
+  color: inherit;
   display: inline-flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -25,15 +25,22 @@
  */
 import React, { FC } from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider, Grid, InlineInputText } from '@looker/components'
+import {
+  ComponentsProvider,
+  InlineInputText,
+  Paragraph,
+} from '@looker/components'
 
 const App: FC = () => {
   return (
     <ComponentsProvider>
-      <Grid>
-        <InlineInputText simple value="Type here..." />
+      <Paragraph variant="critical">some text...</Paragraph>
+      <Paragraph variant="critical">
         <InlineInputText value="Type here..." />
-      </Grid>
+      </Paragraph>
+      <Paragraph variant="critical">
+        <InlineInputText placeholder="Type here..." />
+      </Paragraph>
     </ComponentsProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- `InlineInputText` has color inherit from parent

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="589" alt="Screen Shot 2020-05-26 at 4 05 42 PM" src="https://user-images.githubusercontent.com/23616264/82958715-dc530700-9f6a-11ea-83d7-c39ba7adc33c.png">