### PR TITLE
Prevent InlineInputText collapse without special character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `CheckboxGroup` and `RadioGroup` now reflect changes to `value` prop
+- `InlineInputText` no longer adds a special character to prevent vertical-collapse when empty
 
 ## [0.7.37] - 2020-05-20
 

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -74,7 +74,7 @@ export const InlineInputTextInternal = forwardRef(
           {...pick(props, inputPropKeys)}
         />
         <VisibleText displayValue={displayValue}>
-          {displayValue || placeholder}&#8203;
+          {displayValue || placeholder || ' '}
         </VisibleText>
       </div>
     )
@@ -103,6 +103,7 @@ interface VisibleTextProps {
   displayValue?: string
 }
 const VisibleText = styled.div<VisibleTextProps>`
+  white-space: pre;
   color: ${({ displayValue, theme }) =>
     displayValue
       ? theme.colors.palette.charcoal900

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 }
 
 .c2 {
+  white-space: pre;
   color: #939BA5;
 }
 
@@ -65,7 +66,6 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
     className="c2"
   >
     this is the placeholder
-    ​
   </div>
 </div>
 `;
@@ -88,6 +88,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
 }
 
 .c2 {
+  white-space: pre;
   color: #939BA5;
 }
 
@@ -134,7 +135,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
   <div
     className="c2"
   >
-    ​
+     
   </div>
 </div>
 `;
@@ -157,6 +158,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 }
 
 .c2 {
+  white-space: pre;
   color: #262D33;
 }
 
@@ -204,7 +206,6 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
     className="c2"
   >
     type here...
-    ​
   </div>
 </div>
 `;


### PR DESCRIPTION
### :sparkles: Changes

- Prevent InlineInputText collapse without special character

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
