### PR TITLE
InputText fix for Firefox

### DIFF
--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`A FieldSelect 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -390,6 +391,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -773,6 +775,7 @@ exports[`A required FieldSelect 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -1107,6 +1110,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`A FieldText with default label 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -183,6 +184,7 @@ exports[`A FieldText with label inline 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`Fieldset 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }

--- a/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`InputSearch default 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -230,6 +231,7 @@ exports[`InputSearch hideSearchIcon removes the icon 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -187,6 +187,7 @@ export const InputLayout = styled.div`
     font-size: ${(props) => props.theme.fontSizes.small};
     height: 100%;
     width: 100%;
+    max-width: 100%;
     outline: none;
     padding: 0;
   }

--- a/packages/components/src/Form/Inputs/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputText/__snapshots__/InputText.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`InputText default 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -109,6 +110,7 @@ exports[`InputText should accept disabled 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -198,6 +200,7 @@ exports[`InputText should accept readOnly 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -281,6 +284,7 @@ exports[`InputText should accept required 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -364,6 +368,7 @@ exports[`InputText with a placeholder 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -447,6 +452,7 @@ exports[`InputText with a value 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -530,6 +536,7 @@ exports[`InputText with aria-describedby 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }
@@ -613,6 +620,7 @@ exports[`InputText with name and id 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`Form with one child 1`] = `
   font-size: 0.875rem;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
   padding: 0;
 }


### PR DESCRIPTION
### :sparkles: Changes

- InputText fix for Firefox
- This still leaves minor breakage in place for narrow InputText fields (and it's derivatives) that have an associated Icon (see screenshot) but addresses the core breakage.

### Before

![image](https://user-images.githubusercontent.com/34253496/83201435-4f3eb800-a0fa-11ea-98f8-ac8c46e8feae.png)

![image](https://user-images.githubusercontent.com/34253496/83201344-24546400-a0fa-11ea-8eab-63a3d5de0c09.png)


### After (still a minor problem child)

![image](https://user-images.githubusercontent.com/34253496/83201254-f0793e80-a0f9-11ea-8ab1-d837178dcc20.png)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
