### PR TITLE
InputDate: Render correct month for value prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+##[0.8.1]
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+## Fixed
+
+- Fix issue where InputDate did not render the correct month when setting a value prop
+
 ## [0.8.0]
 
 ### NOTABLE

--- a/packages/components/src/Form/Inputs/InputDate/InputDate.tsx
+++ b/packages/components/src/Form/Inputs/InputDate/InputDate.tsx
@@ -95,7 +95,7 @@ export const InputDate: FC<InputDateProps> = forwardRef(
       selectedDate ? formatDateString(selectedDate, locale) : ''
     )
     const [viewMonth, setViewMonth] = useState<Date | undefined>(
-      defaultValue || new Date(Date.now())
+      value || defaultValue || new Date(Date.now())
     )
 
     const handleDateChange = (date?: Date) => {


### PR DESCRIPTION
### :sparkles: Changes

- Fixes a bug where `InputDate` would always render the current month regardless of what the value prop was set to. It worked correctly for `defaultValue`

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

### BEFORE (INCORRECT)
<img width="479" alt="Screen Shot 2020-06-02 at 5 33 45 PM" src="https://user-images.githubusercontent.com/238293/83582929-c3f96400-a4f7-11ea-99a6-76d629e5816c.png">

### AFTER (FIXED)
<img width="492" alt="Screen Shot 2020-06-02 at 5 33 48 PM" src="https://user-images.githubusercontent.com/238293/83582963-dbd0e800-a4f7-11ea-9bee-64d118755be6.png">

