### PR TITLE
MessageBar should passthrough DOM properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1]
+
+### Fixed
+
+- `MessageBar` needs to allow DOM properties to be passed through (aria support and the like)
+
 ## [0.8.0]
 
 ### NOTABLE

--- a/packages/components/src/MessageBar/MessageBar.tsx
+++ b/packages/components/src/MessageBar/MessageBar.tsx
@@ -27,6 +27,7 @@
 import { CompatibleHTMLProps, TypographyProps } from '@looker/design-tokens'
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
+import { omitStyledProps } from '@looker/design-tokens'
 import { IconButton } from '../Button'
 import { SimpleLayoutProps, simpleLayoutCSS } from '../Layout/utils/simple'
 import { getIntentLabel, Status } from '../Status'
@@ -54,13 +55,13 @@ const MessageBarLayout = forwardRef(
       id,
       children,
       canDismiss,
-      className,
       intent = 'inform',
       onDismiss,
+      ...props
     }: MessageBarProps,
     ref: Ref<HTMLDivElement>
   ) => (
-    <div className={className} aria-live="polite" ref={ref} role="status">
+    <div aria-live="polite" ref={ref} role="status" {...omitStyledProps(props)}>
       <Status intent={intent} />
       <MessageBarContent>{children}</MessageBarContent>
       {canDismiss && (

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -36,4 +36,5 @@ export { prismTheme } from './prismTheme'
 // Useful external utilities
 export * from './customizeable_attributes'
 export * from './utils/animations'
+export * from './utils/omit'
 export { generateThemeFromCoreColors } from './utils/theme'


### PR DESCRIPTION
### :sparkles: Changes

- MessageBar should passthrough DOM properties

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
