### PR TITLE
`InlineInputText` now correctly renders underlying text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2]
+
+### Fixed
+
+- `InlineInputText` was mis-rendering underlying text and not absorbing `text-align` from parent element
+
 ## [0.8.1]
 
 ### Fixed

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -97,6 +97,7 @@ const Input = styled.input.attrs({ type: 'text' })<InlineInputTextProps>`
   outline: none;
   padding: 0;
   position: absolute;
+  text-align: inherit;
   text-transform: inherit;
   top: 0;
   width: 100%;
@@ -105,10 +106,12 @@ const Input = styled.input.attrs({ type: 'text' })<InlineInputTextProps>`
 interface VisibleTextProps {
   displayValue?: string
 }
+
 const VisibleText = styled.div<VisibleTextProps>`
   white-space: pre;
   color: ${({ displayValue, theme }) =>
-    displayValue ? theme.colors.text0 : theme.colors.text5};
+    displayValue ? 'transparent' : theme.colors.text5};
+  text-align: inherit;
 `
 
 export const InlineInputText = styled(InlineInputTextInternal)`

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
   outline: none;
   padding: 0;
   position: absolute;
+  text-align: inherit;
   text-transform: inherit;
   top: 0;
   width: 100%;
@@ -20,6 +21,7 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 .c2 {
   white-space: pre;
   color: #939BA5;
+  text-align: inherit;
 }
 
 .c0 {
@@ -84,6 +86,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
   outline: none;
   padding: 0;
   position: absolute;
+  text-align: inherit;
   text-transform: inherit;
   top: 0;
   width: 100%;
@@ -92,6 +95,7 @@ exports[`InlineInputText renders an input with no value 1`] = `
 .c2 {
   white-space: pre;
   color: #939BA5;
+  text-align: inherit;
 }
 
 .c0 {
@@ -156,6 +160,7 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
   outline: none;
   padding: 0;
   position: absolute;
+  text-align: inherit;
   text-transform: inherit;
   top: 0;
   width: 100%;
@@ -163,7 +168,8 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 
 .c2 {
   white-space: pre;
-  color: #262D33;
+  color: transparent;
+  text-align: inherit;
 }
 
 .c0 {


### PR DESCRIPTION

### :sparkles: Changes

- `InlineInputText` now correctly renders underlying text and not absorbing `text-align` from parent element


### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
