### PR TITLE
artwork is now available as prop for Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Icon` now supports "t-shirt" sizing. (i.e.: `size="small"`)
-
 - Jest no longer requires artifact build before being run
 
 ## [0.8.4]
 
 ### Added
 
+- Icon accepts artwork as props.
 - `Fieldset` supports an accordion mode via an `accordion` prop
 
 ### Changed

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -33,10 +33,11 @@ import {
   SizeMedium,
   SizeLarge,
 } from '@looker/design-tokens'
-import React, { forwardRef, Ref } from 'react'
+import React, { forwardRef, Ref, ReactNode } from 'react'
 import styled from 'styled-components'
 /* eslint import/namespace: ['error', { allowComputed: true }] */
 import { Glyphs, IconNames } from '@looker/icons'
+import omit from 'lodash/omit'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
 
 export type IconSize =
@@ -49,19 +50,31 @@ export type IconSize =
 export interface IconProps
   extends Omit<CompatibleHTMLProps<HTMLDivElement>, 'onClick'>,
     Omit<SimpleLayoutProps, 'height' | 'width'> {
+  artwork?: ReactNode
   color?: string
-  name: IconNames
+  name?: IconNames
 }
 
 export type { IconNames }
 
 const IconFactory = forwardRef(
-  ({ className, name }: IconProps, ref: Ref<HTMLDivElement>) => {
-    const Glyph = Glyphs[name]
-
+  (
+    { artwork = undefined, name, ...props }: IconProps,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    if ((artwork && name) || (!artwork && !name)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Please pass ether name or artwork as Icon prop. If both are passed the default will be artwork. If non is passed Icon won't be displayed"
+      )
+    }
+    const Glyph = name ? Glyphs[name] : 'div'
+    const value = artwork || (
+      <Glyph width="100%" height="100%" fill="currentColor" />
+    )
     return (
-      <div className={className} ref={ref}>
-        <Glyph width="100%" height="100%" fill="currentColor" />
+      <div ref={ref} {...omit(props, 'color', 'name', 'size')}>
+        {value}
       </div>
     )
   }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -30,15 +30,35 @@ import { ComponentsProvider, Flex, Icon } from '@looker/components'
 const App = () => {
   return (
     <ComponentsProvider>
-      <Flex alignItems="center" justifyContent="center">
+      <Flex alignItems="center" justifyContent="space-evenly">
+        <Icon
+          artwork={
+            <svg height="24" width="24">
+              <circle cx="12" cy="12" r="12" stroke="black" fill="red" />
+            </svg>
+          }
+          size="xsmall"
+        />
+        <Icon
+          artwork={
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+                fill="#1C2125"
+              />
+            </svg>
+          }
+          name="GearOutline"
+          size="large"
+        />
         <Icon name="GearOutline" size="xxsmall" />
-        <Icon name="GearOutline" size="xsmall" />
-        <Icon name="GearOutline" size="small" />
-        <Icon name="GearOutline" size="medium" />
-        <Icon name="GearOutline" />
-        <Icon name="GearOutline" size="large" />
-        <Icon name="GearOutline" size="78px" />
-        <Icon name="GearOutline" size="90px" />
+        <Icon size="xxsmall" />
       </Flex>
     </ComponentsProvider>
   )

--- a/packages/www/src/documentation/components/content/icon.mdx
+++ b/packages/www/src/documentation/components/content/icon.mdx
@@ -19,6 +19,30 @@ import { IconList } from './demos'
 
 ## Icon Attributes
 
+### artwork
+
+`artwork` alows for extarnal patterns that is not already available in our Icon list. Please pass ether `name` or `artwork` not both but yes at least one of them.
+
+```jsx
+<Icon
+  artwork={
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+        fill="#1C2125"
+      />
+    </svg>
+  }
+  size="large"
+/>
+```
+
 ### color
 
 `color` by default, icons inherit the text color of the component they are embedded within. But it can also have it specify as a prop.


### PR DESCRIPTION
### :sparkles: Changes

- Icon accepts artwork as props.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="753" alt="Screen Shot 2020-06-08 at 12 15 19 PM" src="https://user-images.githubusercontent.com/23616264/84070922-be7d9d00-a981-11ea-9da0-78ad9e84075d.png">
