### PR TITLE
ModalHeader now properly passes through DOM properties

### DIFF
--- a/packages/components/src/Modal/Layout/ModalHeader.test.tsx
+++ b/packages/components/src/Modal/Layout/ModalHeader.test.tsx
@@ -26,7 +26,11 @@
 
 import 'jest-styled-components'
 import React from 'react'
-import { assertSnapshot, mountWithTheme } from '@looker/components-test-utils'
+import {
+  assertSnapshot,
+  mountWithTheme,
+  renderWithTheme,
+} from '@looker/components-test-utils'
 import { IconButton } from '../../Button'
 import { ModalHeader } from './ModalHeader'
 
@@ -34,6 +38,16 @@ test('ModalHeader', () => {
   assertSnapshot(
     <ModalHeader id="test-modalHeader">The Heading for a Dialog</ModalHeader>
   )
+})
+
+test('ModalHeader passes through DOM props', () => {
+  const { findByLabelText } = renderWithTheme(
+    <ModalHeader aria-label="This is the ARIA label">
+      The Heading for a Dialog
+    </ModalHeader>
+  )
+
+  expect(findByLabelText('This is the ARIA label')).toBeTruthy()
 })
 
 test('ModalHeader with hideClose', () => {

--- a/packages/components/src/Modal/Layout/ModalHeader.tsx
+++ b/packages/components/src/Modal/Layout/ModalHeader.tsx
@@ -28,9 +28,10 @@ import React, { FC, useContext, ReactElement } from 'react'
 import { IconNames } from '@looker/icons'
 import styled from 'styled-components'
 import {
+  CompatibleHTMLProps,
+  omitStyledProps,
   SpaceProps,
   space,
-  CompatibleHTMLProps,
   reset,
 } from '@looker/design-tokens'
 
@@ -56,22 +57,20 @@ export interface ModalHeaderProps
    * Render an icon next to the title text
    */
   headerIcon?: ReactElement<IconProps>
-
-  className?: string
 }
 
 const ModalHeaderLayout: FC<ModalHeaderProps> = ({
-  className,
   children,
   closeIcon = 'Close',
   hideClose,
   headerIcon,
-  id,
+  ...props
 }) => {
   const { closeModal } = useContext(ModalContext)
+  const { id } = props
 
   return (
-    <header className={className}>
+    <header {...omitStyledProps(props)}>
       {headerIcon && <HeaderIconWrapper>{headerIcon}</HeaderIconWrapper>}
       <Heading
         as="h3"

--- a/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
+++ b/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`ModalHeader 1`] = `
 
 <header
   className="c0"
+  id="test-modalHeader"
 >
   <h3
     className="c1"


### PR DESCRIPTION
### :sparkles: Changes

- ModalHeader now properly passes through DOM properties (`id`, `aria-label`, etc...)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
