### PR TITLE
update InputTime to have warning Icon when validationType=error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Icon` now supports "t-shirt" sizing. (i.e.: `size="small"`)
-
 - Jest no longer requires artifact build before being run
+
+### Fixed
+
+- `InputTime` now renders warning icon when validationType="error"
 
 ## [0.8.4]
 

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -547,8 +547,7 @@ const InputTimeInternal = forwardRef(
 const InputTimeLayout = styled.div`
   display: grid;
   grid-gap: 0.15rem;
-  grid-template-columns: repeat(6, min-content);
-  grid-template-areas: 'hour colon minute 12 . warning';
+  grid-template-columns: auto auto auto auto 1fr;
   align-items: center;
 `
 const IconWarning = styled(Icon)`

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -480,6 +480,7 @@ const InputTimeInternal = forwardRef(
           <InputTimeLayout>
             <InputText
               id={id}
+              grid-area="hour"
               maxLength={2}
               placeholder="--"
               value={hour}
@@ -493,8 +494,9 @@ const InputTimeInternal = forwardRef(
               readOnly={readOnly}
               required={required}
             />
-            <div>:</div>
+            <div grid-area="colon">:</div>
             <InputText
+              grid-area="minute"
               maxLength={2}
               placeholder="--"
               value={minute}
@@ -510,6 +512,7 @@ const InputTimeInternal = forwardRef(
             />
             {format === '12h' ? (
               <InputText
+                grid-area="second"
                 maxLength={2}
                 placeholder="--"
                 value={period}
@@ -527,7 +530,12 @@ const InputTimeInternal = forwardRef(
               <span />
             )}
             {validationType && (
-              <Icon name="CircleInfo" color="critical" size={20} />
+              <IconWarning
+                name="CircleInfo"
+                color="critical"
+                grid-area="warning"
+                size={20}
+              />
             )}
           </InputTimeLayout>
         </InputTimeWrapper>
@@ -539,8 +547,12 @@ const InputTimeInternal = forwardRef(
 const InputTimeLayout = styled.div`
   display: grid;
   grid-gap: 0.15rem;
-  grid-template-columns: repeat(5, min-content);
+  grid-template-columns: repeat(6, min-content);
+  grid-template-areas: 'hour colon minute 12 . warning';
   align-items: center;
+`
+const IconWarning = styled(Icon)`
+  justify-self: end;
 `
 
 export const InputTime = styled(InputTimeInternal)`

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -56,6 +56,7 @@ import {
   inputTextDisabled,
   inputTextValidation,
 } from '../InputText'
+import { Icon } from '../../../Icon'
 import {
   formatTimeString,
   TimeFormats,
@@ -279,6 +280,7 @@ const InputTimeInternal = forwardRef(
       onBlur,
       required,
       onValidationFail,
+      validationType,
     }: InputTimeProps,
     ref: Ref<HTMLDivElement>
   ) => {
@@ -472,6 +474,7 @@ const InputTimeInternal = forwardRef(
         ref={ref}
         onFocus={onFocus}
         onBlur={onBlur}
+        aria-invalid={validationType === 'error' ? 'true' : undefined}
       >
         <InputTimeWrapper hasInputValues={hasInputValues}>
           <InputTimeLayout>
@@ -523,6 +526,9 @@ const InputTimeInternal = forwardRef(
             ) : (
               <span />
             )}
+            {validationType && (
+              <Icon name="CircleInfo" color="critical" size={20} />
+            )}
           </InputTimeLayout>
         </InputTimeWrapper>
       </div>
@@ -533,7 +539,7 @@ const InputTimeInternal = forwardRef(
 const InputTimeLayout = styled.div`
   display: grid;
   grid-gap: 0.15rem;
-  grid-template-columns: repeat(4, min-content);
+  grid-template-columns: repeat(5, min-content);
   align-items: center;
 `
 

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -25,14 +25,26 @@
  */
 import React from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider, Flex, InputTime } from '@looker/components'
+import {
+  ComponentsProvider,
+  FieldTime,
+  Grid,
+  InputTime,
+} from '@looker/components'
 
 const App = () => {
   return (
     <ComponentsProvider>
-      <Flex alignItems="center" justifyContent="space-around" mt="10px">
+      <Grid columns={1} m="10px">
         <InputTime validationType="error" />
-      </Flex>
+        <FieldTime
+          defaultValue="14:34"
+          description="this is the description"
+          detail="detail"
+          label="Label"
+          validationMessage={{ message: 'validation Message', type: 'error' }}
+        />
+      </Grid>
     </ComponentsProvider>
   )
 }

--- a/packages/playground/src/index.tsx
+++ b/packages/playground/src/index.tsx
@@ -25,20 +25,13 @@
  */
 import React from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider, Flex, Icon } from '@looker/components'
+import { ComponentsProvider, Flex, InputTime } from '@looker/components'
 
 const App = () => {
   return (
     <ComponentsProvider>
-      <Flex alignItems="center" justifyContent="center">
-        <Icon name="GearOutline" size="xxsmall" />
-        <Icon name="GearOutline" size="xsmall" />
-        <Icon name="GearOutline" size="small" />
-        <Icon name="GearOutline" size="medium" />
-        <Icon name="GearOutline" />
-        <Icon name="GearOutline" size="large" />
-        <Icon name="GearOutline" size="78px" />
-        <Icon name="GearOutline" size="90px" />
+      <Flex alignItems="center" justifyContent="space-around" mt="10px">
+        <InputTime validationType="error" />
       </Flex>
     </ComponentsProvider>
   )


### PR DESCRIPTION
### :sparkles: Changes

- update InputTime to have warning Icon when validationType=error

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
<img width="732" alt="Screen Shot 2020-06-08 at 2 37 05 PM" src="https://user-images.githubusercontent.com/23616264/84082937-9009bd00-a995-11ea-894e-b085d2472efd.png">
