### PR TITLE
Fix ButtonGroup row spacing when wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- `ButtonGroup` space between rows when wrapping
+
 ## [0.8.6]
 
 ### Fixed

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -108,7 +108,7 @@ export const ButtonSetLayout = forwardRef(
         const rowHeight = firstItem
           ? firstItem.getBoundingClientRect().height
           : buttonItemHeight
-        if (height > rowHeight * 2) {
+        if (height >= rowHeight * 2) {
           setIsWrapping(true)
         } else {
           setIsWrapping(false)

--- a/packages/components/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`ButtonGroup controlled 1`] = `
 }
 
 <div
-  class="c0 c1"
+  class="wrapping c0 c1"
   role="group"
 >
   <button

--- a/packages/components/src/Button/__snapshots__/ButtonToggle.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonToggle.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`ButtonToggle controlled 1`] = `
 }
 
 <div
-  class="c0 c1"
+  class="wrapping c0 c1"
   role="group"
 >
   <button


### PR DESCRIPTION
### :sparkles: Changes

- A last-minute change on my previous `ButtonGroup` PR broke the row spacing

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue:
![image](https://user-images.githubusercontent.com/53451193/84183216-622d8280-aa40-11ea-8807-1a1192545a51.png)

#### Fixed:
![image](https://user-images.githubusercontent.com/53451193/84183160-4cb85880-aa40-11ea-8bd0-8ea62e9af983.png)

