### PR TITLE
updating InputTime to have Warning Icon when ValidationType=error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InputTime` now renders warning icon when validationType="error" is passed
 - `Icon` properly passes through DOM elements
 
 ## [0.8.5]

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -56,6 +56,7 @@ import {
   inputTextDisabled,
   inputTextValidation,
 } from '../InputText'
+import { Icon } from '../../../Icon'
 import {
   formatTimeString,
   TimeFormats,
@@ -267,18 +268,19 @@ export const convert12To24HrString = (value: string) => {
 const InputTimeInternal = forwardRef(
   (
     {
-      format = '12h',
-      onChange,
-      defaultValue,
-      value,
       className,
+      defaultValue,
       disabled,
-      readOnly,
+      format = '12h',
       id,
-      onFocus,
+      onChange,
+      readOnly,
       onBlur,
-      required,
+      onFocus,
       onValidationFail,
+      required,
+      validationType,
+      value,
     }: InputTimeProps,
     ref: Ref<HTMLDivElement>
   ) => {
@@ -472,6 +474,7 @@ const InputTimeInternal = forwardRef(
         ref={ref}
         onFocus={onFocus}
         onBlur={onBlur}
+        aria-invalid={validationType === 'error' ? 'true' : undefined}
       >
         <InputTimeWrapper hasInputValues={hasInputValues}>
           <InputTimeLayout>
@@ -523,6 +526,14 @@ const InputTimeInternal = forwardRef(
             ) : (
               <span />
             )}
+            {validationType && (
+              <WarningIcon
+                name="CircleInfo"
+                color="critical"
+                grid-area="warning"
+                size={20}
+              />
+            )}
           </InputTimeLayout>
         </InputTimeWrapper>
       </div>
@@ -530,11 +541,17 @@ const InputTimeInternal = forwardRef(
   }
 )
 
+const WarningIcon = styled(Icon)``
+
 const InputTimeLayout = styled.div`
   display: grid;
   grid-gap: 0.15rem;
-  grid-template-columns: repeat(4, min-content);
+  grid-template-columns: auto auto auto auto 1fr;
   align-items: center;
+
+  ${WarningIcon} {
+    justify-self: end;
+  }
 `
 
 export const InputTime = styled(InputTimeInternal)`

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -26,13 +26,18 @@
 
 import React from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider } from '@looker/components'
-import { GetMe } from './data/GetMe'
-
+import { ComponentsProvider, FieldTime, InputTime } from '@looker/components'
 const App = () => {
   return (
     <ComponentsProvider>
-      <GetMe />
+      <InputTime validationType="error" />
+      <FieldTime
+        defaultValue="14:34"
+        description="this is the description"
+        detail="detail"
+        label="Label"
+        validationMessage={{ message: 'validation Message', type: 'error' }}
+      />
     </ComponentsProvider>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- `InputTime` now renders warning icon when validationType="error" is passed

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="212" alt="Screen Shot 2020-06-09 at 11 31 10 AM" src="https://user-images.githubusercontent.com/23616264/84186034-bcc8dd80-aa44-11ea-97c6-35b1eeb574b9.png">