### PR TITLE
 artwork props added to Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Icon accepts artwork as props.
 - `Fieldset` supports an accordion mode via an `accordion` prop
 
 ### Changed

--- a/packages/components/src/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/components/src/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -15,6 +15,11 @@ exports[`AvatarCombo renders Avatar and its secondary avatar 1`] = `
   display: inline-flex;
 }
 
+.c7 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c3 {
   width: 100%;
   height: 100%;
@@ -144,6 +149,11 @@ exports[`AvatarCombo renders Avatar initials and secondary with Code icon 1`] = 
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c7 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c3 {
@@ -277,6 +287,11 @@ exports[`AvatarCombo renders AvatarIcon and secondary avatar if user is not avai
   display: inline-flex;
 }
 
+.c3 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c1 {
   color: #9785F2;
   background-color: #FFFFFF;
@@ -407,6 +422,11 @@ exports[`AvatarIcon renders  1`] = `
   display: inline-flex;
 }
 
+.c2 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c3 .c1 {
   height: 20px;
   width: 20px;
@@ -481,6 +501,11 @@ exports[`AvatarIcon renders different icon if specified 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c2 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c3 .c1 {

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -544,6 +544,11 @@ exports[`Button with icon validates all sizes 1`] = `
   display: inline-flex;
 }
 
+.c3 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -695,6 +700,11 @@ exports[`Button with icon validates all sizes 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c3 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c0 {
@@ -850,6 +860,11 @@ exports[`Button with icon validates all sizes 3`] = `
   display: inline-flex;
 }
 
+.c3 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1001,6 +1016,11 @@ exports[`Button with icon validates all sizes 4`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c3 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c0 {

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -14,6 +14,11 @@ exports[`IconButton accepts color 1`] = `
   display: inline-flex;
 }
 
+.c4 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   width: 24px;
   -webkit-align-items: center;
@@ -155,6 +160,11 @@ exports[`IconButton accepts events 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c0 {
@@ -301,6 +311,11 @@ exports[`IconButton accepts events 2`] = `
   display: inline-flex;
 }
 
+.c4 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   width: 24px;
   -webkit-align-items: center;
@@ -443,6 +458,11 @@ exports[`IconButton allows for ARIA attributes 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c0 {
@@ -589,6 +609,11 @@ exports[`IconButton default 1`] = `
   display: inline-flex;
 }
 
+.c4 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   width: 24px;
   -webkit-align-items: center;
@@ -730,6 +755,11 @@ exports[`IconButton outline 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c0 {
@@ -893,6 +923,11 @@ exports[`IconButton renders focus ring on tab input but not on click 1`] = `
   display: inline-flex;
 }
 
+.c4 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   width: 24px;
   -webkit-align-items: center;
@@ -1036,6 +1071,11 @@ exports[`IconButton renders focus ring on tab input but not on click 2`] = `
   display: inline-flex;
 }
 
+.c4 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c0 {
   width: 24px;
   -webkit-align-items: center;
@@ -1177,6 +1217,11 @@ exports[`IconButton resized 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c0 {

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -40,6 +40,11 @@ exports[`A FieldSelect 1`] = `
   display: inline-flex;
 }
 
+.c12 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -348,6 +353,11 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
   display: inline-flex;
 }
 
+.c14 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c12 {
   width: 20px;
   height: 20px;
@@ -361,6 +371,11 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c12 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c8 {
@@ -743,6 +758,11 @@ exports[`A required FieldSelect 1`] = `
   display: inline-flex;
 }
 
+.c14 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1074,6 +1094,11 @@ exports[`FieldSelect supports labelWeight 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c12 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c8 {

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -281,6 +281,7 @@ exports[`A FieldSelect 1`] = `
         >
           <div
             className="c12"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -649,6 +650,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
         >
           <div
             className="c12"
+            mr="xxsmall"
           >
             <svg
               fill="currentColor"
@@ -670,6 +672,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
           />
           <div
             className="c14"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -1009,6 +1012,7 @@ exports[`A required FieldSelect 1`] = `
         >
           <div
             className="c14"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -1317,6 +1321,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
         >
           <div
             className="c12"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -281,7 +281,6 @@ exports[`A FieldSelect 1`] = `
         >
           <div
             className="c12"
-            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -650,7 +649,6 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
         >
           <div
             className="c12"
-            mr="xxsmall"
           >
             <svg
               fill="currentColor"
@@ -672,7 +670,6 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
           />
           <div
             className="c14"
-            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -1012,7 +1009,6 @@ exports[`A required FieldSelect 1`] = `
         >
           <div
             className="c14"
-            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -1321,7 +1317,6 @@ exports[`FieldSelect supports labelWeight 1`] = `
         >
           <div
             className="c12"
-            mr="xsmall"
           >
             <svg
               fill="currentColor"

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -286,6 +286,7 @@ exports[`A FieldSelect 1`] = `
         >
           <div
             className="c12"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -664,6 +665,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
         >
           <div
             className="c12"
+            mr="xxsmall"
           >
             <svg
               fill="currentColor"
@@ -685,6 +687,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
           />
           <div
             className="c14"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -1029,6 +1032,7 @@ exports[`A required FieldSelect 1`] = `
         >
           <div
             className="c14"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"
@@ -1342,6 +1346,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
         >
           <div
             className="c12"
+            mr="xsmall"
           >
             <svg
               fill="currentColor"

--- a/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
@@ -148,6 +148,11 @@ exports[`InputSearch default 1`] = `
   padding-left: 0.75rem;
 }
 
+.c2 svg {
+  height: 100%;
+  width: 100%;
+}
+
 <div
   className="c0 c1"
   fontSize="small"

--- a/packages/components/src/Form/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -310,6 +310,11 @@ exports[`TextArea with an error validation 1`] = `
   display: inline-flex;
 }
 
+.c2 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c3 .c1 {
   position: absolute;
   top: 0.5rem;

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -50,7 +50,10 @@ export type IconSize =
 
 export interface IconProps
   extends Omit<CompatibleHTMLProps<HTMLDivElement>, 'onClick'>,
-    Omit<SimpleLayoutProps, 'height' | 'width'> {
+    SimpleLayoutProps {
+  /**
+   * Display an icon/logo that is not available on our components list. Use artwork prop with an svg instead of Icon name.
+   */
   artwork?: ReactNode
   color?: string
   name?: IconNames
@@ -65,9 +68,7 @@ const IconFactory = forwardRef(
   ) => {
     if ((artwork && name) || (!artwork && !name)) {
       // eslint-disable-next-line no-console
-      console.warn(
-        "Please pass ether name or artwork as Icon prop. If both are passed the default will be artwork. If non is passed Icon won't be displayed"
-      )
+      console.warn('You may only specify name OR artwork, not both.')
     }
     const Glyph = name ? Glyphs[name] : 'div'
     const value = artwork || (
@@ -93,6 +94,11 @@ export const Icon = styled(IconFactory).attrs(({ size, height, width }) => ({
   display: inline-flex;
   height: ${({ height }) => height};
   width: ${({ width }) => width};
+
+  svg {
+    height: 100%;
+    width: 100%;
+  }
 `
 
 // Icon.defaultProps = { size: 'medium' }

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -27,7 +27,6 @@
 import {
   color,
   CompatibleHTMLProps,
-  omitStyledProps,
   SizeXXSmall,
   SizeXSmall,
   SizeSmall,

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -99,5 +99,3 @@ export const Icon = styled(IconFactory).attrs(({ size, height, width }) => ({
     width: 100%;
   }
 `
-
-// Icon.defaultProps = { size: 'medium' }

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -34,10 +34,11 @@ import {
   SizeMedium,
   SizeLarge,
 } from '@looker/design-tokens'
-import React, { forwardRef, Ref } from 'react'
+import React, { forwardRef, Ref, ReactNode } from 'react'
 import styled from 'styled-components'
 /* eslint import/namespace: ['error', { allowComputed: true }] */
 import { Glyphs, IconNames } from '@looker/icons'
+import omit from 'lodash/omit'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
 
 export type IconSize =
@@ -49,20 +50,32 @@ export type IconSize =
 
 export interface IconProps
   extends Omit<CompatibleHTMLProps<HTMLDivElement>, 'onClick'>,
-    SimpleLayoutProps {
+    Omit<SimpleLayoutProps, 'height' | 'width'> {
+  artwork?: ReactNode
   color?: string
-  name: IconNames
+  name?: IconNames
 }
 
 export type { IconNames }
 
 const IconFactory = forwardRef(
-  ({ className, name, ...props }: IconProps, ref: Ref<HTMLDivElement>) => {
-    const Glyph = Glyphs[name]
-
+  (
+    { artwork = undefined, name, ...props }: IconProps,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    if ((artwork && name) || (!artwork && !name)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Please pass ether name or artwork as Icon prop. If both are passed the default will be artwork. If non is passed Icon won't be displayed"
+      )
+    }
+    const Glyph = name ? Glyphs[name] : 'div'
+    const value = artwork || (
+      <Glyph width="100%" height="100%" fill="currentColor" />
+    )
     return (
-      <div className={className} ref={ref} {...omitStyledProps(props)}>
-        <Glyph width="100%" height="100%" fill="currentColor" />
+      <div ref={ref} {...omit(props, 'color', 'name', 'size')}>
+        {value}
       </div>
     )
   }

--- a/packages/components/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -14,6 +14,11 @@ exports[`Icon default 1`] = `
   display: inline-flex;
 }
 
+.c0 svg {
+  height: 100%;
+  width: 100%;
+}
+
 <div
   className="c0"
 >
@@ -46,6 +51,11 @@ exports[`Icon with styled system size 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c0 svg {
+  height: 100%;
+  width: 100%;
 }
 
 <div
@@ -82,6 +92,11 @@ exports[`Icon with styled system size 2`] = `
   display: inline-flex;
 }
 
+.c0 svg {
+  height: 100%;
+  width: 100%;
+}
+
 <div
   className="c0"
 >
@@ -114,6 +129,11 @@ exports[`Icon with styled system size 3`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c0 svg {
+  height: 100%;
+  width: 100%;
 }
 
 <div

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`MenuItem - current + marker 1`] = `
     >
       <div
         className="c3 c4"
+        mr="xsmall"
       >
         <svg
           fill="currentColor"
@@ -288,6 +289,7 @@ exports[`MenuItem - current 1`] = `
     >
       <div
         className="c3 c4"
+        mr="xsmall"
       >
         <svg
           fill="currentColor"
@@ -575,6 +577,7 @@ exports[`MenuItem - icon 1`] = `
     >
       <div
         className="c3 c4"
+        mr="xsmall"
       >
         <svg
           fill="currentColor"

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -16,6 +16,11 @@ exports[`MenuItem - current + marker 1`] = `
   display: inline-flex;
 }
 
+.c4 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c1 {
   padding-bottom: 0.75rem;
   padding-left: 1rem;
@@ -164,6 +169,11 @@ exports[`MenuItem - current 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c1 {
@@ -446,6 +456,11 @@ exports[`MenuItem - icon 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c4 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c1 {

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`MenuItem - current + marker 1`] = `
     >
       <div
         className="c3 c4"
-        mr="xsmall"
       >
         <svg
           fill="currentColor"
@@ -279,7 +278,6 @@ exports[`MenuItem - current 1`] = `
     >
       <div
         className="c3 c4"
-        mr="xsmall"
       >
         <svg
           fill="currentColor"
@@ -562,7 +560,6 @@ exports[`MenuItem - icon 1`] = `
     >
       <div
         className="c3 c4"
-        mr="xsmall"
       >
         <svg
           fill="currentColor"

--- a/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`MenuItem - current + marker 1`] = `
     >
       <div
         className="c3 c4"
+        mr="xsmall"
       >
         <svg
           fill="currentColor"
@@ -278,6 +279,7 @@ exports[`MenuItem - current 1`] = `
     >
       <div
         className="c3 c4"
+        mr="xsmall"
       >
         <svg
           fill="currentColor"
@@ -560,6 +562,7 @@ exports[`MenuItem - icon 1`] = `
     >
       <div
         className="c3 c4"
+        mr="xsmall"
       >
         <svg
           fill="currentColor"

--- a/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -15,6 +15,11 @@ exports[`Confirmation MessageBar 1`] = `
   display: inline-flex;
 }
 
+.c1 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c2 {
   position: absolute;
   height: 1px;
@@ -108,6 +113,11 @@ exports[`Error MessageBar 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c1 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c2 {
@@ -205,6 +215,11 @@ exports[`Info MessageBar 1`] = `
   display: inline-flex;
 }
 
+.c1 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c2 {
   position: absolute;
   height: 1px;
@@ -300,6 +315,11 @@ exports[`MessageBar can be dismissed 1`] = `
   display: inline-flex;
 }
 
+.c1 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c7 {
   width: 22px;
   height: 22px;
@@ -311,6 +331,11 @@ exports[`MessageBar can be dismissed 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c7 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c4 {
@@ -540,6 +565,11 @@ exports[`Warn MessageBar 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c1 svg {
+  height: 100%;
+  width: 100%;
 }
 
 .c2 {

--- a/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
+++ b/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
@@ -14,6 +14,11 @@ exports[`ModalHeader 1`] = `
   display: inline-flex;
 }
 
+.c6 svg {
+  height: 100%;
+  width: 100%;
+}
+
 .c2 {
   width: 28px;
   -webkit-align-items: center;

--- a/packages/components/src/Status/__snapshots__/Status.test.tsx.snap
+++ b/packages/components/src/Status/__snapshots__/Status.test.tsx.snap
@@ -16,6 +16,11 @@ Array [
   display: inline-flex;
 }
 
+.c0 svg {
+  height: 100%;
+  width: 100%;
+}
+
 <div
     className="c0"
   >
@@ -65,6 +70,11 @@ Array [
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c0 svg {
+  height: 100%;
+  width: 100%;
 }
 
 <div
@@ -118,6 +128,11 @@ Array [
   display: inline-flex;
 }
 
+.c0 svg {
+  height: 100%;
+  width: 100%;
+}
+
 <div
     className="c0"
   >
@@ -165,6 +180,11 @@ Array [
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c0 svg {
+  height: 100%;
+  width: 100%;
 }
 
 <div
@@ -216,6 +236,11 @@ Array [
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.c0 svg {
+  height: 100%;
+  width: 100%;
 }
 
 <div

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -26,18 +26,13 @@
 
 import React from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider, FieldTime, InputTime } from '@looker/components'
+import { ComponentsProvider } from '@looker/components'
+import { GetMe } from './data/GetMe'
+
 const App = () => {
   return (
     <ComponentsProvider>
-      <InputTime validationType="error" />
-      <FieldTime
-        defaultValue="14:34"
-        description="this is the description"
-        detail="detail"
-        label="Label"
-        validationMessage={{ message: 'validation Message', type: 'error' }}
-      />
+      <GetMe />
     </ComponentsProvider>
   )
 }

--- a/storybook/src/Icon.stories.tsx
+++ b/storybook/src/Icon.stories.tsx
@@ -1,0 +1,116 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { Icon, Space } from '@looker/components'
+import React from 'react'
+
+export const Artwork = () => (
+  <>
+    <Space around>
+      <Icon name="GearOutline" size="xxsmall" />
+      <Icon name="GearOutline" size="xsmall" />
+      <Icon name="GearOutline" size="small" />
+      <Icon name="GearOutline" size="medium" />
+      <Icon name="GearOutline" size="large" />
+    </Space>
+    <Space around>
+      <Icon
+        artwork={
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+              fill="#1C2125"
+            />
+          </svg>
+        }
+        name="GearOutline"
+        size="xxsmall"
+      />
+      <Icon name="GearOutline" size="xxsmall" />
+      <Icon
+        artwork={
+          <svg>
+            <rect
+              width="100"
+              height="100"
+              fill="rgb(0,0,255)"
+              strokeWidth="3"
+              stroke="rgb(0,0,0)"
+            />
+          </svg>
+        }
+      />
+      <Icon
+        size="large"
+        artwork={
+          <svg viewBox="0 0 104 97" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M14,85l3,9h72c0,0,5-9,4-10c-2-2-79,0-79,1"
+              fill="#7C4E32"
+            />
+            <path
+              d="M19,47c0,0-9,7-13,14c-5,6,3,7,3,7l1,14c0,0,10,8,23,8c14,0,26,1,28,0c2-1,9-2,9-4c1-1,27,1,27-9c0-10,7-20-11-29c-17-9-67-1-67-1"
+              fill="#E30000"
+            />
+            <path d="M17,32c-3,48,80,43,71-3 l-35-15" fill="#FFE1C4" />
+            <path d="M17,32c9-36,61-32,71-3c-20-9-40-9-71,3" fill="#8ED8F8" />
+            <path
+              d="M54,35a10 8 60 1 1 0,0.1zM37,38a10 8 -60 1 1 0,0.1z"
+              fill="#FFF"
+            />
+            <path
+              d="M41,6c1-1,4-3,8-3c3-0,9-1,14,3l-1,2h-2h-2c0,0-3,1-5,0c-2-1-1-1-1-1l-3,1l-2-1h-1c0,0-1,2-3,2c0,0-2-1-2-3M17,34l0-2c0,0,35-20,71-3v2c0,0-35-17-71,3M5,62c3-2,5-2,8,0c3,2,13,6,8,11c-2,2-6,0-8,0c-1,1-4,2-6,1c-4-3-6-8-2-12M99,59c0,0-9-2-11,4l-3,5c0,1-2,3,3,3c5,0,5,2,7,2c3,0,7-1,7-4c0-4-1-11-3-10"
+              fill="#FFF200"
+            />
+            <path
+              d="M56,78v1M55,69v1M55,87v1"
+              stroke="#000"
+              strokeLinecap="round"
+            />
+            <path d="M60,36a1 1 0 1 1 0-0.1M49,36a1 1 0 1 1 0-0.1M57,55a2 3 0 1 1 0-0.1M12,94c0,0,20-4,42,0c0,0,27-4,39,0z" />
+            <path
+              d="M50,59c0,0,4,3,10,0M56,66l2,12l-2,12M25,50c0,0,10,12,23,12c13,0,24,0,35-15"
+              fill="none"
+              stroke="#000"
+              strokeWidth="0.5"
+            />
+          </svg>
+        }
+      />
+    </Space>
+  </>
+)
+
+export default {
+  component: Artwork,
+  title: 'Icons',
+}

--- a/www/src/documentation/components/content/icon.mdx
+++ b/www/src/documentation/components/content/icon.mdx
@@ -21,26 +21,38 @@ import { IconList } from './demos'
 
 ### artwork
 
-`artwork` alows for extarnal patterns that is not already available in our Icon list. Please pass ether `name` or `artwork` not both but yes at least one of them.
+`artwork` allows for external patterns that is not already available in our Icon list. You may only specify name OR artwork, not both.
 
 ```jsx
-<Icon
-  artwork={
-    <svg
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
-        fill="#1C2125"
-      />
-    </svg>
-  }
-  size="large"
-/>
+<Space around>
+  <Icon
+    artwork={
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+          fill="#7FFFD4"
+        />
+      </svg>
+    }
+    size="large"
+  />
+  <Icon
+    artwork={
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7 11H9V13H7V11ZM21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4H19C20.1 4 21 4.9 21 6ZM5 8H19V6H5V8ZM19 20V10H5V20H19ZM15 13H17V11H15V13ZM11 13H13V11H11V13Z"
+          fill="#FF7F50"
+        />
+      </svg>
+    }
+  />
+</Space>
 ```
 
 ### color

--- a/www/src/documentation/components/content/icon.mdx
+++ b/www/src/documentation/components/content/icon.mdx
@@ -19,6 +19,30 @@ import { IconList } from './demos'
 
 ## Icon Attributes
 
+### artwork
+
+`artwork` alows for extarnal patterns that is not already available in our Icon list. Please pass ether `name` or `artwork` not both but yes at least one of them.
+
+```jsx
+<Icon
+  artwork={
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V15H13V17ZM13 13H11V7H13V13Z"
+        fill="#1C2125"
+      />
+    </svg>
+  }
+  size="large"
+/>
+```
+
 ### color
 
 `color` by default, icons inherit the text color of the component they are embedded within. But it can also have it specify as a prop.


### PR DESCRIPTION
### :sparkles: Changes

-  artwork props added to Icon

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="581" alt="Screen Shot 2020-06-10 at 11 35 07 AM" src="https://user-images.githubusercontent.com/23616264/84316404-f02c6a80-ab1f-11ea-9a88-8f42954ecb71.png">
