### PR TITLE
Form Improvements

### DIFF
--- a/packages/components/src/Badge/Badge.tsx
+++ b/packages/components/src/Badge/Badge.tsx
@@ -35,7 +35,7 @@ import {
   typography,
   CompatibleHTMLProps,
 } from '@looker/design-tokens'
-import React, { ReactNode, FC } from 'react'
+import React, { forwardRef, ReactNode, Ref } from 'react'
 import styled from 'styled-components'
 import { variant } from 'styled-system'
 
@@ -98,9 +98,17 @@ const intent = variant({
   },
 })
 
-const BadgeLayout: FC<BadgeProps> = ({ children, ...props }) => {
-  return <span {...props}>{children}</span>
-}
+const BadgeLayout = forwardRef(
+  ({ children, ...props }: BadgeProps, ref: Ref<HTMLElement>) => {
+    return (
+      <span ref={ref} {...props}>
+        {children}
+      </span>
+    )
+  }
+)
+
+BadgeLayout.displayName = 'BadgeLayout'
 
 export const Badge = styled(BadgeLayout).attrs({ fontWeight: 'semiBold' })`
   ${reset}

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -42,6 +42,7 @@ import {
   StatefulColor,
 } from '@looker/design-tokens'
 import { IconNames } from '@looker/icons'
+import { TextAlignProperty } from 'csstype'
 import React, { forwardRef, Ref } from 'react'
 import { Placement } from '@popperjs/core'
 import { Icon } from '../Icon'
@@ -116,6 +117,10 @@ export interface IconButtonProps
    * Assign the placement of the built-in Tooltip.
    */
   tooltipPlacement?: Placement
+  /**
+   * Assign the placement of the built-in Tooltip.
+   */
+  tooltipTextAlign?: TextAlignProperty
 }
 
 export const IconButtonStyle = styled.button<IconButtonProps>`
@@ -133,6 +138,7 @@ const IconButtonComponent = forwardRef(
       color,
       tooltipDisabled,
       tooltipPlacement,
+      tooltipTextAlign,
       onFocus: propsOnFocus,
       onBlur: propsOnBlur,
       onMouseOver: propsOnMouseOver,
@@ -159,6 +165,7 @@ const IconButtonComponent = forwardRef(
       disabled: tooltipDisabled || hasOuterTooltip,
       id: id ? `${id}-tooltip` : undefined,
       placement: tooltipPlacement,
+      textAlign: tooltipTextAlign,
     })
 
     const eventHandlers = {

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -67,8 +67,6 @@ export const fieldPropKeys = [
   'id',
   'inline',
   'label',
-  'labelFontSize',
-  'labelFontWeight',
   'labelWidth',
   'validationMessage',
   'width',

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -29,10 +29,9 @@ import styled, { css } from 'styled-components'
 import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
+import { Paragraph, Text } from '../../Text'
 import { inputHeight } from '../Inputs/InputText/InputText'
-import { Label } from '../Label/Label'
-import { Paragraph } from '../../Text/Paragraph'
-import { Text } from '../../Text/Text'
+import { Label } from '../Label'
 import { ValidationMessage } from '../ValidationMessage'
 import { FieldBaseProps } from './FieldBase'
 import { RequiredStar } from './RequiredStar'
@@ -44,10 +43,7 @@ export interface FieldProps extends FieldBaseProps {
    * optional extra description
    */
   description?: ReactNode
-  /**
-   * notes and details added to the top right corner of the field
-   */
-  detail?: ReactNode
+
   /**
    * Id of the input element to match a label to.
    */
@@ -57,13 +53,6 @@ export interface FieldProps extends FieldBaseProps {
    * @default false
    */
   inline?: boolean
-
-  /**
-   * Specifies for horizontally aligned labels how much space to take up.
-   * @default '150px'
-   */
-  labelWidth?: ResponsiveSpaceValue
-
   /**
    *
    * Specify the width of the FieldText if different then 100%
@@ -107,8 +96,6 @@ const FieldLayout: FunctionComponent<FieldPropsInternal> = ({
   detail,
   id,
   label,
-  labelFontSize,
-  labelFontWeight,
   required,
   validationMessage,
 }) => {
@@ -124,12 +111,7 @@ const FieldLayout: FunctionComponent<FieldPropsInternal> = ({
 
   return (
     <div className={className}>
-      <Label
-        fontSize={labelFontSize}
-        fontWeight={labelFontWeight}
-        htmlFor={id}
-        id={`${id}-labelledby`}
-      >
+      <Label htmlFor={id} id={`${id}-labelledby`}>
         {label}
         {required && <RequiredStar />}
       </Label>
@@ -177,8 +159,7 @@ export const Field = styled(FieldLayout)<FieldPropsInternal>`
     inline
       ? '"label input detail" ". messages messages"'
       : '"label detail" "input input" "messages messages"'};
-  grid-template-columns: ${({ inline, labelWidth }) =>
-    inline ? `${labelWidth} 1fr` : undefined};
+  grid-template-columns: ${({ inline }) => (inline ? `150px 1fr` : undefined)};
 
   ${InputArea} {
     grid-area: input;
@@ -209,4 +190,4 @@ export const Field = styled(FieldLayout)<FieldPropsInternal>`
   }
 `
 
-Field.defaultProps = { labelWidth: '150px', width: '100%' }
+Field.defaultProps = { width: '100%' }

--- a/packages/components/src/Form/Fields/FieldBase.tsx
+++ b/packages/components/src/Form/Fields/FieldBase.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import { FontSizes, FontWeights } from '@looker/design-tokens'
+import { ReactNode } from 'react'
 import { ValidationMessageProps } from '../ValidationMessage/ValidationMessage'
 
 export interface FieldBaseProps {
@@ -35,18 +35,13 @@ export interface FieldBaseProps {
    */
   label?: string
   /**
-   * Specifies the fontWeight of the internal Label.
-   * TODO - Deprecate usage in HT, then here.
-   */
-  labelFontSize?: FontSizes
-  /**
-   * Specifies the fontWeight of the internal Label.
-   */
-  labelFontWeight?: FontWeights
-  /**
    * Whether or not the field should display a `*` denoting it is required.
    */
   required?: boolean
+  /**
+   * notes and details added to the top right corner of the field
+   */
+  detail?: ReactNode
   /**
    *
    * Holds the type of validation (error, warning, etc.) and corresponding message.

--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`A FieldCheckbox 1`] = `
 }
 
 .c4 input:disabled + .c5 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -74,8 +74,8 @@ exports[`A FieldCheckbox 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3,max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2,max-content) 1fr;
   line-height: 1.25rem;
 }
 
@@ -88,6 +88,30 @@ exports[`A FieldCheckbox 1`] = `
   font-weight: normal;
   grid-area: label;
   padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .c8 {
+  grid-area: detail;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  margin-left: 0.25rem;
 }
 
 .c0 .c7 {
@@ -203,7 +227,7 @@ exports[`A FieldCheckbox with checked value 1`] = `
 }
 
 .c4 input:disabled + .c5 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -224,8 +248,8 @@ exports[`A FieldCheckbox with checked value 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3,max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2,max-content) 1fr;
   line-height: 1.25rem;
 }
 
@@ -238,6 +262,30 @@ exports[`A FieldCheckbox with checked value 1`] = `
   font-weight: normal;
   grid-area: label;
   padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .c8 {
+  grid-area: detail;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  margin-left: 0.25rem;
 }
 
 .c0 .c7 {

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -41,42 +41,38 @@ interface FieldInlinePropsInternal extends FieldBaseProps {
   id: string
 }
 
-const FieldInlineLayout: FC<Omit<
-  FieldInlinePropsInternal,
-  'labelFontWeight'
->> = ({
+const FieldInlineLayout: FC<FieldInlinePropsInternal> = ({
   className,
   children,
+  detail,
   label,
-  labelFontSize,
   id,
   required,
   validationMessage,
-}) => {
-  return (
-    <label className={className} htmlFor={id}>
-      <Label as="span" fontSize={labelFontSize}>
-        {label}
-        {required && <RequiredStar />}
-      </Label>
-      <InputArea>{children}</InputArea>
-      <MessageArea id={`${id}-describedby`}>
-        {validationMessage ? (
-          <ValidationMessage {...validationMessage} />
-        ) : null}
-      </MessageArea>
-    </label>
-  )
-}
+}) => (
+  <label className={className} htmlFor={id}>
+    <Label as="span">
+      {label}
+      {required && <RequiredStar />}
+    </Label>
+    {detail && <FieldDetail>{detail}</FieldDetail>}
+    <InputArea>{children}</InputArea>
+    <MessageArea id={`${id}-describedby`}>
+      {validationMessage ? <ValidationMessage {...validationMessage} /> : null}
+    </MessageArea>
+  </label>
+)
 
 const InputArea = styled.div``
+const FieldDetail = styled.div``
+
 const MessageArea = styled.div``
 
 export const FieldInline = styled(FieldInlineLayout)`
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3, max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2, max-content) 1fr;
   line-height: ${({ theme }) => theme.lineHeights.small};
 
   ${InputArea} {
@@ -84,11 +80,21 @@ export const FieldInline = styled(FieldInlineLayout)`
   }
 
   ${Label} {
-    color: ${({ theme, disabled }) => disabled && theme.colors.text4};
+    color: ${({ theme, disabled }) => disabled && theme.colors.text5};
     font-size: ${({ theme }) => theme.fontSizes.small};
     font-weight: normal;
     grid-area: label;
     padding-left: ${({ theme }) => theme.space.xsmall};
+    display: flex;
+    align-items: center;
+  }
+
+  ${FieldDetail} {
+    grid-area: detail;
+    display: flex;
+    justify-content: flex-end;
+    align-content: center;
+    margin-left: ${({ theme: { space } }) => space.xxsmall};
   }
 
   ${MessageArea} {

--- a/packages/components/src/Form/Fields/FieldRadio/FieldRadio.tsx
+++ b/packages/components/src/Form/Fields/FieldRadio/FieldRadio.tsx
@@ -29,8 +29,8 @@ import styled from 'styled-components'
 import { useID } from '../../../utils'
 import { Radio, RadioProps } from '../../Inputs/Radio/Radio'
 import { omitFieldProps, pickFieldProps } from '../Field'
-import { FieldInline } from '../FieldInline'
 import { FieldBaseProps } from '../FieldBase'
+import { FieldInline } from '../FieldInline'
 
 export interface FieldRadioProps
   extends RadioProps,

--- a/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
@@ -60,11 +60,11 @@ exports[`A FieldRadio 1`] = `
 }
 
 .c4 input:disabled:not(:checked) + .c5 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c4 input:disabled:not(:checked) + .c5::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c2 {
@@ -79,8 +79,8 @@ exports[`A FieldRadio 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3,max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2,max-content) 1fr;
   line-height: 1.25rem;
 }
 
@@ -93,6 +93,30 @@ exports[`A FieldRadio 1`] = `
   font-weight: normal;
   grid-area: label;
   padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .c8 {
+  grid-area: detail;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  margin-left: 0.25rem;
 }
 
 .c0 .c7 {
@@ -196,11 +220,11 @@ exports[`A FieldRadio checked 1`] = `
 }
 
 .c4 input:disabled:not(:checked) + .c5 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c4 input:disabled:not(:checked) + .c5::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c2 {
@@ -215,8 +239,8 @@ exports[`A FieldRadio checked 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3,max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2,max-content) 1fr;
   line-height: 1.25rem;
 }
 
@@ -229,6 +253,30 @@ exports[`A FieldRadio checked 1`] = `
   font-weight: normal;
   grid-area: label;
   padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .c8 {
+  grid-area: detail;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  margin-left: 0.25rem;
 }
 
 .c0 .c7 {

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.test.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.test.tsx
@@ -38,14 +38,7 @@ test('A FieldSelect', () => {
 })
 
 test('FieldSelect supports labelWeight', () => {
-  assertSnapshot(
-    <FieldSelect
-      label="👍"
-      name="thumbsUp"
-      id="thumbs-up"
-      labelFontWeight="normal"
-    />
-  )
+  assertSnapshot(<FieldSelect label="👍" name="thumbsUp" id="thumbs-up" />)
 })
 
 test('Should accept a value', () => {

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -1155,7 +1155,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
 .c2 {
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 400;
+  font-weight: 600;
 }
 
 .c0 {
@@ -1266,7 +1266,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
     className="c1 c2"
     color="text2"
     fontSize="xsmall"
-    fontWeight="normal"
+    fontWeight="semiBold"
     htmlFor="thumbs-up"
     id="thumbs-up-labelledby"
   >

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -61,8 +61,8 @@ exports[`A FieldToggleSwitch 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3,max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2,max-content) 1fr;
   line-height: 1.25rem;
 }
 
@@ -75,6 +75,30 @@ exports[`A FieldToggleSwitch 1`] = `
   font-weight: normal;
   grid-area: label;
   padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .c8 {
+  grid-area: detail;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  margin-left: 0.25rem;
 }
 
 .c0 .c7 {
@@ -186,8 +210,8 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   -ms-flex-align: center;
   align-items: center;
   display: grid;
-  grid-template-areas: 'input label' '. messages';
-  grid-template-columns: repeat(3,max-content);
+  grid-template-areas: 'input label detail' '. messages messages';
+  grid-template-columns: repeat(2,max-content) 1fr;
   line-height: 1.25rem;
 }
 
@@ -200,6 +224,30 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   font-weight: normal;
   grid-area: label;
   padding-left: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 .c8 {
+  grid-area: detail;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  margin-left: 0.25rem;
 }
 
 .c0 .c7 {

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -26,7 +26,7 @@
 
 import React, { forwardRef, ReactNode, Ref } from 'react'
 import styled from 'styled-components'
-import { CompatibleHTMLProps } from '@looker/design-tokens'
+import { CompatibleHTMLProps, SpacingSizes } from '@looker/design-tokens'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
 import { Space, SpaceHelperProps, SpaceVertical } from '../../Layout'
@@ -56,6 +56,11 @@ export interface FieldsetProps
   /** Displayed above the children of Fieldset
    */
   legend?: ReactNode
+  /**
+   * Amount of space between fields
+   * @default 'inline ? 'medium' : 'small'
+   */
+  gap?: SpacingSizes
 }
 
 const accordionIndicatorDefaults: AccordionIndicatorProps = {
@@ -73,15 +78,17 @@ const FieldsetLayout = forwardRef(
     const {
       accordion,
       inline,
-      className,
+      gap,
       legend,
       children,
       ...restProps
     } = omit(props, [...AccordionControlPropKeys])
+
     const accordionProps = {
       ...pick(props, [...AccordionControlPropKeys]),
       ...accordionIndicatorDefaults,
     }
+
     const LayoutComponent = inline ? Space : SpaceVertical
 
     /**
@@ -95,8 +102,7 @@ const FieldsetLayout = forwardRef(
 
     const content = (
       <LayoutComponent
-        {...restProps}
-        gap={inline ? 'medium' : 'small'}
+        gap={gap || (inline ? 'medium' : 'small')}
         ref={ref}
         role="group"
         align="start"
@@ -128,7 +134,7 @@ const FieldsetLayout = forwardRef(
       content
     )
 
-    return <div className={className}>{renderedFieldset}</div>
+    return <div {...restProps}>{renderedFieldset}</div>
   }
 )
 
@@ -149,4 +155,5 @@ export const Fieldset = styled(FieldsetLayout)`
 
 Fieldset.defaultProps = {
   padding: 'none',
+  width: '100%',
 }

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`Fieldset 1`] = `
 
 .c3 {
   width: 100%;
-  padding: 0rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -190,6 +189,8 @@ exports[`Fieldset 1`] = `
 
 <div
   className="c0"
+  padding="none"
+  width="100%"
 >
   <div
     className="c1"

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -138,7 +138,7 @@ export const Checkbox = styled(CheckboxLayout)`
   }
 
   input:disabled + ${FauxCheckbox} {
-    background: transparent;
+    background: ${({ theme }) => theme.colors.ui1};
     border-color: ${({ theme }) => theme.colors.ui2};
     color: ${({ theme }) => theme.colors.text5};
   }

--- a/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Checkbox checked set to mixed 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -143,7 +143,7 @@ exports[`Checkbox should accept disabled & checked 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -183,7 +183,7 @@ exports[`Checkbox should accept disabled & checked 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -265,7 +265,7 @@ exports[`Checkbox should accept disabled & checked="mixed" 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -305,7 +305,7 @@ exports[`Checkbox should accept disabled & checked="mixed" 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -396,7 +396,7 @@ exports[`Checkbox should accept disabled 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -436,7 +436,7 @@ exports[`Checkbox should accept disabled 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -517,7 +517,7 @@ exports[`Checkbox should accept readOnly & checked 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -557,7 +557,7 @@ exports[`Checkbox should accept readOnly & checked 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -637,7 +637,7 @@ exports[`Checkbox should accept readOnly & checked="mixed" 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -677,7 +677,7 @@ exports[`Checkbox should accept readOnly & checked="mixed" 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -766,7 +766,7 @@ exports[`Checkbox should accept readOnly 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -806,7 +806,7 @@ exports[`Checkbox should accept readOnly 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -899,7 +899,7 @@ exports[`Checkbox with aria-describedby 1`] = `
 }
 
 .c0 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }
@@ -924,7 +924,7 @@ exports[`Checkbox with aria-describedby 1`] = `
 }
 
 .c3 input:disabled + .c1 {
-  background: transparent;
+  background: #F5F6F7;
   border-color: #DEE1E5;
   color: #939BA5;
 }

--- a/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
@@ -90,6 +90,7 @@ const CheckboxGroupLayout = forwardRef(
           disabled={option.disabled || disabled}
           key={option.value}
           label={option.label}
+          detail={option.detail}
           name={name}
           value={option.value}
           {...checkedProps}
@@ -102,6 +103,7 @@ const CheckboxGroupLayout = forwardRef(
         data-testid="checkbox-list"
         inline={inline}
         flexWrap={inline ? 'wrap' : undefined}
+        gap={!inline ? 'xxsmall' : undefined}
         width={inline ? 'auto' : undefined}
         ref={ref}
         {...rest}

--- a/packages/components/src/Form/Inputs/OptionsGroup/OptionsGroup.ts
+++ b/packages/components/src/Form/Inputs/OptionsGroup/OptionsGroup.ts
@@ -24,6 +24,7 @@
 
  */
 
+import { ReactNode } from 'react'
 import { FieldsetProps } from '../../Fieldset'
 import { ValidationMessageProps } from '../../ValidationMessage'
 
@@ -31,6 +32,7 @@ export interface OptionsGroupOptionProps {
   label: string
   value: string
   disabled?: boolean
+  detail?: ReactNode
 }
 
 interface OptionsGroupLayout extends Omit<FieldsetProps, 'onChange'> {

--- a/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
@@ -82,6 +82,7 @@ const RadioGroupLayout = forwardRef(
         <FieldRadio
           disabled={option.disabled || disabled}
           key={option.value}
+          detail={option.detail}
           label={option.label}
           name={name}
           onChange={getChangeHandler(option.value)}
@@ -95,6 +96,7 @@ const RadioGroupLayout = forwardRef(
         data-testid="radio-list"
         inline={inline}
         flexWrap={inline ? 'wrap' : undefined}
+        gap={!inline ? 'xxsmall' : undefined}
         width={inline ? 'auto' : undefined}
         ref={ref}
         {...rest}

--- a/packages/components/src/Form/Inputs/Radio/Radio.tsx
+++ b/packages/components/src/Form/Inputs/Radio/Radio.tsx
@@ -35,7 +35,6 @@ export interface RadioProps
   extends SpaceProps,
     Omit<InputProps, 'readonly' | 'type' | 'checked' | 'onClick'> {
   checked?: boolean
-  className?: string
 }
 
 const RadioLayout = forwardRef(
@@ -91,10 +90,10 @@ export const Radio = styled(RadioLayout)`
   }
 
   input:disabled:not(:checked) + ${FauxRadio} {
-    background: transparent;
+    background: ${({ theme }) => theme.colors.ui1};
 
     &::after {
-      background: transparent;
+      background: ${({ theme }) => theme.colors.ui1};
     }
   }
 `

--- a/packages/components/src/Form/Inputs/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Radio/__snapshots__/Radio.test.tsx.snap
@@ -60,11 +60,11 @@ exports[`Radio checked set to false 1`] = `
 }
 
 .c0 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 <div
@@ -141,11 +141,11 @@ exports[`Radio checked set to true 1`] = `
 }
 
 .c0 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 <div
@@ -222,11 +222,11 @@ exports[`Radio default 1`] = `
 }
 
 .c0 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 <div
@@ -287,11 +287,11 @@ exports[`Radio should accept disabled 1`] = `
 }
 
 .c3 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c3 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 {
@@ -330,11 +330,11 @@ exports[`Radio should accept disabled 1`] = `
 }
 
 .c0 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 <div
@@ -411,11 +411,11 @@ exports[`Radio with aria-describedby 1`] = `
 }
 
 .c0 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c3 input:checked + .c1 {
@@ -438,11 +438,11 @@ exports[`Radio with aria-describedby 1`] = `
 }
 
 .c3 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c3 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 <div
@@ -519,11 +519,11 @@ exports[`Radio with name and id 1`] = `
 }
 
 .c0 input:disabled:not(:checked) + .c1 {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 .c0 input:disabled:not(:checked) + .c1::after {
-  background: transparent;
+  background: #F5F6F7;
 }
 
 <div

--- a/packages/components/src/Status/Status.tsx
+++ b/packages/components/src/Status/Status.tsx
@@ -80,9 +80,13 @@ export const getIntentLabel = (intent?: StatusIntent) => {
 }
 
 export const Status = forwardRef(
-  ({ className, intent, size }: StatusProps, ref: Ref<HTMLInputElement>) => (
+  (
+    { className, intent, size, ...props }: StatusProps,
+    ref: Ref<HTMLInputElement>
+  ) => (
     <>
       <Icon
+        {...props}
         className={className}
         ref={ref}
         color={intent}

--- a/packages/design-tokens/src/system/index.ts
+++ b/packages/design-tokens/src/system/index.ts
@@ -29,11 +29,16 @@ export {
   border,
   boxShadow,
   color,
+  display,
   flexbox,
-  position,
+  height,
   layout,
+  overflow,
+  position,
   space,
   typography,
+  verticalAlign,
+  width,
 } from 'styled-system'
 export type {
   BorderProps,

--- a/storybook/src/Forms/Fieldset.stories.tsx
+++ b/storybook/src/Forms/Fieldset.stories.tsx
@@ -25,7 +25,18 @@
  */
 
 import React, { FC } from 'react'
-import { Fieldset, FieldText, FieldCheckbox } from '@looker/components'
+import {
+  Button,
+  Fieldset,
+  FieldText,
+  FieldCheckbox,
+  FieldCheckboxGroup,
+  FieldRadioGroup,
+  Link,
+  Status,
+  Tooltip,
+  Divider,
+} from '@looker/components'
 
 export default {
   title: 'Forms/Fieldset',
@@ -33,9 +44,19 @@ export default {
 
 const Fields: FC<{ inline?: boolean }> = ({ inline }) => (
   <>
-    <FieldText inline={inline} required label="Neat Stuff" />
-    <FieldText inline={inline} label="Neat Stuff" />
-    <FieldText inline={inline} label="Neat Stuff" />
+    <FieldText
+      inline={inline}
+      placeholder="First name"
+      required
+      label="First name"
+    />
+    <FieldText inline={inline} label="Middle" placeholder="Middle" />
+    <FieldText
+      inline={inline}
+      required
+      label="Last name"
+      placeholder="Last name"
+    />
   </>
 )
 
@@ -74,5 +95,101 @@ export const Accordion = () => (
     <FieldCheckbox name="box1" label="you can click here" />
     <FieldCheckbox name="box2" label="here too" />
     <FieldCheckbox name="box3" label="also here" />
+  </Fieldset>
+)
+
+export const AccordionAlt = () => {
+  const options = [
+    {
+      detail: (
+        <Tooltip content="PNW > Wisconsin" placement="right">
+          <Status size="small" intent="neutral" />
+        </Tooltip>
+      ),
+      label: 'Cheddar',
+      required: true,
+      value: 'cheddar',
+    },
+    {
+      detail: (
+        <Tooltip
+          placement="right"
+          content={
+            <>
+              Some helpful explanatory text. <Link>Learn more</Link>
+            </>
+          }
+        >
+          <Status size="small" intent="neutral" />
+
+          {/* <Badge intent="neutral">&gt; 100,000 results</Badge> */}
+        </Tooltip>
+      ),
+      disabled: true,
+      label: 'Green',
+      value: 'blue',
+    },
+    { label: 'Swiss', tooltip: 'Has holes', value: 'swiss' },
+  ]
+
+  const value = 'blue'
+
+  return (
+    <>
+      <Fieldset
+        width="26rem"
+        legend="Advanced Cheese Options"
+        accordion
+        defaultOpen
+      >
+        <FieldRadioGroup
+          defaultValue={value}
+          label="Favorite"
+          options={options}
+        />
+        <FieldRadioGroup defaultValue={value} label="Worst" options={options} />
+        <FieldCheckboxGroup
+          defaultValue={[value]}
+          label="Would Eat"
+          options={options}
+        />
+      </Fieldset>
+      <Divider my="xxlarge" />
+      <Fieldset legend="Advanced Cheese Options" accordion defaultOpen>
+        {' '}
+        <FieldRadioGroup
+          defaultValue={value}
+          label="Favorite"
+          options={options}
+          inline
+        />
+        <FieldCheckboxGroup
+          defaultValue={[value]}
+          label="Edible"
+          options={options}
+          inline
+        />
+      </Fieldset>
+    </>
+  )
+}
+
+export const Nesting = () => (
+  <Fieldset gap="xxlarge">
+    <Button fullWidth>Button A</Button>
+    <Button fullWidth>Button B</Button>
+    <Button fullWidth>Button C</Button>
+
+    <Fieldset gap="none">
+      <Button fullWidth>Button A</Button>
+      <Button fullWidth>Button B</Button>
+      <Button fullWidth>Button C</Button>
+
+      <Fieldset gap="medium">
+        <Button fullWidth>Button A</Button>
+        <Button fullWidth>Button B</Button>
+        <Button fullWidth>Button C</Button>
+      </Fieldset>
+    </Fieldset>
   </Fieldset>
 )

--- a/www/src/documentation/components/forms/fields.mdx
+++ b/www/src/documentation/components/forms/fields.mdx
@@ -20,7 +20,6 @@ The `<FieldCheckbox />` component is composed of a `<Checkbox />` component and 
 <FieldCheckbox
   name="normal-label"
   label="Normal Label"
-  labelFontWeight="normal"
 />
 ```
 


### PR DESCRIPTION
### :sparkles: Changes

- `Badge` now supports `ref` assignment (Tooltip badge is now possible)
- `IconButton` now supports `tooltipTextAlign`

- `Field`
  - No longer supports `labelWidth` property (unused feature)
  - No longer supports `labelFontSize` and `labelFontWeight` properties (all your fonts belong to us)

- `FieldInline` (`FieldCheckbox`, `FieldRadio` & `FieldToggleSwitch`)
  - Now supports `detail` property
  - `:disabled` state slightly more discernable from default state now

- `Radio` & `Checkbox` disabled states corrected
- `OptionsGroup` (`CheckboxGroup`, `RadioGroup`)
  - Now have tighter vertical spacing to feel more connected
  - Supports `detail` on Options array

- `Status` now allows DOM attributes (`aria-*` and the like)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
