### PR TITLE
Corrects a bug ComponentsProvider where the passed in theme was ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ComponentsProvider` actually uses the `theme` passed in
 - `ButtonGroup` space between rows when wrapping
 - `InputChips` separates chips by newline when pasting
 

--- a/packages/components-providers/src/ComponentsProvider.tsx
+++ b/packages/components-providers/src/ComponentsProvider.tsx
@@ -69,8 +69,9 @@ export const ComponentsProvider: FC<ComponentsProviderProps> = ({
 }) => {
   const baseTheme = props.theme || theme
 
-  const generatedTheme =
-    coreColors && generateThemeFromCoreColors(baseTheme, coreColors)
+  const generatedTheme = coreColors
+    ? generateThemeFromCoreColors(baseTheme, coreColors)
+    : baseTheme
 
   return (
     <ThemeProvider {...props} theme={generatedTheme}>

--- a/packages/components/src/Layout/Box/__snapshots__/Box.test.tsx.snap
+++ b/packages/components/src/Layout/Box/__snapshots__/Box.test.tsx.snap
@@ -349,7 +349,7 @@ exports[`Box flex supports flex properties 1`] = `
 
 exports[`Box fonts font helpers 1`] = `
 .c0 {
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: 'Open Sans','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI',Helvetica,Arial,sans-serif,'Noto Sans';
 }
 
 <div

--- a/storybook/src/Theme/Font.stories.tsx
+++ b/storybook/src/Theme/Font.stories.tsx
@@ -24,9 +24,55 @@
 
  */
 
-import { FontFamilyChoices } from '../../system'
+import {
+  ComponentsProvider,
+  FieldText,
+  Fieldset,
+  SpaceVertical,
+  Heading,
+  Paragraph,
+  theme,
+} from '@looker/components'
+import React, { FC, FormEvent, useState } from 'react'
 
-export const fontFamilies: FontFamilyChoices = {
-  brand: `'Open Sans', 'Noto Sans JP', 'Noto Sans CJK KR', 'Noto Sans Arabic UI', 'Noto Sans Devanagari UI', 'Noto Sans Hebrew', 'Noto Sans Thai UI', Helvetica, Arial, sans-serif, 'Noto Sans'`,
-  code: `'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`,
+export const Font: FC = () => {
+  const [brand, setBrand] = useState('Comic Sans MS')
+
+  const handleBrandChange = (event: FormEvent<HTMLInputElement>) => {
+    setBrand(event.currentTarget.value)
+  }
+
+  const actualTheme = {
+    ...theme,
+    fonts: {
+      ...theme.fonts,
+      brand,
+    },
+  }
+
+  // const coreColors = useState<CoreColors>(theme)
+
+  return (
+    <SpaceVertical>
+      <Fieldset legend={name}>
+        <FieldText
+          label="Brand Font Face"
+          value={brand}
+          onChange={handleBrandChange}
+        />
+      </Fieldset>
+
+      <pre>{String(theme)}</pre>
+
+      <ComponentsProvider theme={actualTheme}>
+        <Heading>A Header</Heading>
+        <Paragraph>Paragraph text.</Paragraph>
+      </ComponentsProvider>
+    </SpaceVertical>
+  )
+}
+
+export default {
+  component: Font,
+  title: 'Theme',
 }

--- a/storybook/src/Theme/Font.stories.tsx
+++ b/storybook/src/Theme/Font.stories.tsx
@@ -62,7 +62,7 @@ export const Font: FC = () => {
         />
       </Fieldset>
 
-      <pre>{String(theme)}</pre>
+      <pre>{JSON.stringify(theme, null, 1)}</pre>
 
       <ComponentsProvider theme={actualTheme}>
         <Heading>A Header</Heading>


### PR DESCRIPTION

### :sparkles: Changes

- Corrects a bug ComponentsProvider where the passed in theme was ignored
- Adds Storybook example (`/?path=/story/theme--font`)
- Also adds additional font support for i18n characters to our default font-stack

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
