### PR TITLE
Fix ComboboxOption checkmark size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select` selected option check mark icon size
 - `ButtonGroup` space between rows when wrapping
 - `InputChips` separates chips by newline when pasting
 

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxOption.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxOption.tsx
@@ -186,7 +186,7 @@ const ComboboxOptionInternal = forwardRef(
           isActive={isActive}
           isSelected={isSelected}
         >
-          {isSelected && <Icon name="Check" mr={0} />}
+          {isSelected && <Icon name="Check" size="1rem" mr={0} />}
         </ComboboxOptionIndicator>
         {children || <ComboboxOptionText highlightText={highlightText} />}
       </ComboboxOptionWrapper>

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxOption.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxOption.tsx
@@ -186,7 +186,7 @@ const ComboboxOptionInternal = forwardRef(
           isActive={isActive}
           isSelected={isSelected}
         >
-          {isSelected && <Icon name="Check" size="1rem" mr={0} />}
+          {isSelected && <Icon name="Check" size="xsmall" mr={0} />}
         </ComboboxOptionIndicator>
         {children || <ComboboxOptionText highlightText={highlightText} />}
       </ComboboxOptionWrapper>


### PR DESCRIPTION
### :sparkles: Changes

- Explicitly set the `ComboboxOption` checkmark icon size to 1rem (this was the default before tshirt sizing was added)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC
