### PR TITLE
SelectMulti free form input ++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Icons: `TimeZone`
 - `ComboboxMultiInput` supports `freeInput` to allow inputting of values outside of options, using the behavior of `InputChips`
 - `InputChips` preserves escaped comma and tab characters
+- `InputChips` supports `removeOnBackspace` (true by default)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Icons: `TimeZone`
+- `ComboboxMultiInput` supports `freeInput` to allow inputting of values outside of options, using the behavior of `InputChips`
+- `InputChips` preserves escaped comma and tab characters
 
 ### Fixed
 

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -92,6 +92,10 @@ interface ComboboxListInternalProps extends ComboboxListProps {
   isMulti: boolean
 }
 
+function getElementWidth(element?: HTMLElement | null) {
+  return element && element.getBoundingClientRect().width
+}
+
 const ComboboxListInternal = forwardRef(
   (
     {
@@ -149,15 +153,17 @@ const ComboboxListInternal = forwardRef(
     const handleBlur = useBlur()
     const ref = useForkedRef(listRef, forwardedRef)
 
-    const width =
-      props.width ||
-      (wrapperElement && wrapperElement.getBoundingClientRect().width) ||
-      'auto'
+    // Avoid calling getBoundingClientWidth if width/minWidth are set in props
+    const width = props.width || getElementWidth(wrapperElement) || 'auto'
+    const minWidth =
+      props.minWidth ||
+      (props.width === 'auto' ? getElementWidth(wrapperElement) : undefined)
 
     const content = (
       <ComboboxUl
         {...props}
         width={width}
+        minWidth={minWidth}
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
         ref={ref}

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
@@ -33,6 +33,7 @@ import { useForkedRef } from '../../../utils'
 import {
   InputChips,
   InputChipsBase,
+  InputChipsBaseProps,
   InputChipsCommonProps,
   InputChipsInputControlProps,
 } from '../InputChips'
@@ -54,8 +55,7 @@ export interface ComboboxMultiInputProps
     Partial<InputChipsInputControlProps> {
   onClear?: () => void
   /**
-   * Allows creation of values outside of options
-   * by typing or pasting items separated by commas, tabs, or newlines
+   * Allows inputting of values outside of options via typing or pasting
    * @default false
    */
   freeInput?: boolean
@@ -98,14 +98,13 @@ export const ComboboxMultiInputInternal = forwardRef(
       onClear && onClear()
     }
 
-    // if freeInput = true, this is called when user inputs
     // if freeInput = false, only called when user removes chips from the input
+    // if freeInput = true, this is called when user inputs values via separators (enter key, comma, tab char, newline)
     function handleChange(values: string[]) {
       transition &&
         transition(ComboboxActionType.CHANGE_VALUES, { inputValues: values })
 
       const newOptions = getOptionsFromValues(options, values)
-
       contextOnChange && contextOnChange(newOptions)
     }
 
@@ -180,34 +179,31 @@ export const ComboboxMultiInputInternal = forwardRef(
 
     const inputEvents = useInputEvents(props, ComboboxMultiContext)
 
+    const commonProps: InputChipsBaseProps = {
+      ...rest,
+      ...inputEvents,
+      'aria-activedescendant': navigationOption
+        ? String(makeHash(navigationOption ? navigationOption.value : ''))
+        : undefined,
+      'aria-autocomplete': 'both',
+      autoComplete: 'off',
+      hasOptions: true,
+      id: `listbox-${id}`,
+      inputValue,
+      isVisibleOptions: isVisible,
+      onChange: handleChange,
+      onClear: handleClear,
+      onInputChange: wrappedOnInputChange,
+      readOnly,
+      values: inputValues,
+    }
+
     const ref = useForkedRef<HTMLInputElement>(inputCallbackRef, forwardedRef)
 
-    const InputComponent: typeof InputChips = freeInput
-      ? InputChips
-      : InputChipsBase
-
-    return (
-      <InputComponent
-        {...rest}
-        {...inputEvents}
-        ref={ref}
-        readOnly={readOnly}
-        values={inputValues}
-        onChange={handleChange}
-        onClear={handleClear}
-        inputValue={inputValue}
-        onInputChange={wrappedOnInputChange}
-        id={`listbox-${id}`}
-        hasOptions={true}
-        isVisibleOptions={isVisible}
-        autoComplete="off"
-        aria-autocomplete="both"
-        aria-activedescendant={
-          navigationOption
-            ? String(makeHash(navigationOption ? navigationOption.value : ''))
-            : undefined
-        }
-      />
+    return freeInput ? (
+      <InputChips {...commonProps} ref={ref} />
+    ) : (
+      <InputChipsBase {...commonProps} ref={ref} />
     )
   }
 )

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
@@ -56,6 +56,7 @@ export interface ComboboxMultiInputProps
   onClear?: () => void
   /**
    * Allows inputting of values outside of options via typing or pasting
+   * Not recommended for use when options have labels that are different from their values
    * @default false
    */
   freeInput?: boolean

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxOptionIndicator.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxOptionIndicator.tsx
@@ -108,6 +108,6 @@ export const ComboboxOptionIndicator = styled(ComboboxOptionIndicatorLayout)`
   height: ${(props) => props.theme.space.large};
   flex-shrink: 0;
   margin-right: ${(props) => props.theme.space.xxsmall};
-  flex-basis: ${({ theme, isMulti }) =>
+  width: ${({ theme, isMulti }) =>
     isMulti ? theme.space.xlarge : theme.space.medium};
 `

--- a/packages/components/src/Form/Inputs/Combobox/utils/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/state.ts
@@ -296,8 +296,8 @@ export function getOptionsFromValues(
   })
   // Convert new values into options
   // ****NOTE****
-  // freeInput options may be duplicates of available options
-  // de-duping must be performed at a level where all available options are known, e.g. SelectMulti
+  // freeInput options may be near-duplicates of existing options (different case, value / label mismatch, etc)
+  // this option should be used only when exact matching to existing values is not important or can be handled externally
   const freeInputOptions = freeInputValues.map((value) => ({ value }))
 
   return [...newOptions, ...freeInputOptions]

--- a/packages/components/src/Form/Inputs/Combobox/utils/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/state.ts
@@ -274,6 +274,35 @@ const reducer: Reducer<ComboboxData, ComboboxActionWithPayload> = (
   }
 }
 
+// Update options from as input values are added / removed via InputChips(Base)
+export function getOptionsFromValues(
+  currentOptions: ComboboxOptionObject[],
+  newValues?: string[]
+) {
+  if (!newValues) return []
+  // Save any values not found in current options
+  const freeInputValues = [...newValues]
+
+  const newOptions = currentOptions.filter((option) => {
+    const text = getComboboxText(option)
+    const foundInOptions = newValues.includes(text)
+    if (foundInOptions) {
+      const index = freeInputValues.indexOf(text)
+      if (index > -1) {
+        freeInputValues.splice(index, 1)
+      }
+    }
+    return foundInOptions
+  })
+  // Convert new values into options
+  // ****NOTE****
+  // freeInput options may be duplicates of available options
+  // de-duping must be performed at a level where all available options are known, e.g. SelectMulti
+  const freeInputOptions = freeInputValues.map((value) => ({ value }))
+
+  return [...newOptions, ...freeInputOptions]
+}
+
 const reducerMulti: Reducer<
   ComboboxMultiData,
   ComboboxMultiActionWithPayload
@@ -290,11 +319,7 @@ const reducerMulti: Reducer<
       return {
         ...nextState,
         navigationOption: undefined,
-        options: nextState.options.filter(
-          (option) =>
-            action.inputValues &&
-            action.inputValues.includes(getComboboxText(option))
-        ),
+        options: getOptionsFromValues(nextState.options, action.inputValues),
       }
     case ComboboxActionType.NAVIGATE:
       return {

--- a/packages/components/src/Form/Inputs/Combobox/utils/useFocusManagement.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useFocusManagement.ts
@@ -42,7 +42,10 @@ export function useFocusManagement(lastActionType?: ComboboxActionType) {
       lastActionType === ComboboxActionType.ESCAPE ||
       lastActionType === ComboboxActionType.SELECT_WITH_CLICK
     ) {
-      inputElement && inputElement.focus()
+      if (inputElement) {
+        inputElement.focus()
+        inputElement.scrollLeft = 0
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastActionType])

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
@@ -218,10 +218,6 @@ test('escaped commas and tabs are preserved', () => {
   )
   const input = screen.getByPlaceholderText('type here')
 
-  // value should be trimmed before validation
-  // prettier-ignore
-  /* eslint-disable */
-  fireEvent.change(input, { target: { value: ' tag\,1,tag\	2,' } })
-  /* eslint-enable */
+  fireEvent.change(input, { target: { value: 'tag\\,1,tag\\	2,' } })
   expect(onChangeMock).toHaveBeenCalledWith(['tag,1', 'tag	2'])
 })

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
@@ -30,194 +30,237 @@ import { createEvent, fireEvent, screen } from '@testing-library/react'
 
 import { InputChips } from './InputChips'
 
-test('values are added on Enter keydown', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(
-    <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
-  )
-  const input = screen.getByPlaceholderText('type here')
-  fireEvent.change(input, { target: { value: 'tag1' } })
-  expect(onChangeMock).not.toHaveBeenCalled()
+describe('InputChips', () => {
+  test('values are added on Enter keydown', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
+    )
+    const input = screen.getByPlaceholderText('type here')
+    fireEvent.change(input, { target: { value: 'tag1' } })
+    expect(onChangeMock).not.toHaveBeenCalled()
 
-  fireEvent.keyDown(input, { key: 'Enter' })
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
-  expect(input).toHaveValue('')
-})
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
+    expect(input).toHaveValue('')
+  })
 
-test('values are added when a comma is last character entered', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(
-    <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
-  )
-  const input = screen.getByPlaceholderText('type here')
+  test('values are added when a comma is last character entered', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
+    )
+    const input = screen.getByPlaceholderText('type here')
 
-  // if the last character entered is a comma, values are added
-  fireEvent.change(input, { target: { value: 'tag1,' } })
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
-  expect(input).toHaveValue('')
-})
+    // if the last character entered is a comma, values are added
+    fireEvent.change(input, { target: { value: 'tag1,' } })
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
+    expect(input).toHaveValue('')
+  })
 
-function firePasteEvent(element: HTMLElement, value: string) {
-  const eventProperties = {
-    clipboardData: {
-      getData: () => value,
-    },
+  function firePasteEvent(element: HTMLElement, value: string) {
+    const eventProperties = {
+      clipboardData: {
+        getData: () => value,
+      },
+    }
+
+    const pasteEvent = createEvent.paste(element, eventProperties) as any
+    pasteEvent.clipboardData = eventProperties.clipboardData
+
+    fireEvent(element, pasteEvent)
   }
 
-  const pasteEvent = createEvent.paste(element, eventProperties) as any
-  pasteEvent.clipboardData = eventProperties.clipboardData
-
-  fireEvent(element, pasteEvent)
-}
-
-test('values are added when pasting', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(
-    <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
-  )
-  const input = screen.getByPlaceholderText('type here')
-  // Newlines are stripped when pasting into a text input,
-  // but InputChips saves the clipboard with newlines intact from the onPaste
-  firePasteEvent(
-    input,
-    `tag1
+  test('values are added when pasting', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
+    )
+    const input = screen.getByPlaceholderText('type here')
+    // Newlines are stripped when pasting into a text input,
+    // but InputChips saves the clipboard with newlines intact from the onPaste
+    firePasteEvent(
+      input,
+      `tag1
 tag2`
-  )
-  fireEvent.change(input, { target: { value: 'tag1  tag2' } })
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
+    )
+    fireEvent.change(input, { target: { value: 'tag1  tag2' } })
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
 
-  // If change follows a paste, no need for the last character to be a comma
-  onChangeMock.mockClear()
-  firePasteEvent(input, `tag1,tag2`)
-  fireEvent.change(input, { target: { value: 'tag1, tag2' } })
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
-})
+    // If change follows a paste, no need for the last character to be a comma
+    onChangeMock.mockClear()
+    firePasteEvent(input, `tag1,tag2`)
+    fireEvent.change(input, { target: { value: 'tag1, tag2' } })
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
+  })
 
-test('values are added on blur', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(
-    <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
-  )
-  const input = screen.getByPlaceholderText('type here')
-  fireEvent.change(input, { target: { value: 'tag1' } })
-  expect(onChangeMock).not.toHaveBeenCalled()
+  test('values are added on blur', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
+    )
+    const input = screen.getByPlaceholderText('type here')
+    fireEvent.change(input, { target: { value: 'tag1' } })
+    expect(onChangeMock).not.toHaveBeenCalled()
 
-  fireEvent.blur(input)
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
-  expect(input).toHaveValue('')
-})
+    fireEvent.blur(input)
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
+    expect(input).toHaveValue('')
+  })
 
-test('new values are appended to existing values', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(
-    <InputChips
-      onChange={onChangeMock}
-      values={['tag1']}
-      placeholder="type here"
-    />
-  )
-  const input = screen.getByPlaceholderText('type here')
-  fireEvent.change(input, { target: { value: 'tag2,' } })
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
-  expect(input).toHaveValue('')
-})
+  test('new values are appended to existing values', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips
+        onChange={onChangeMock}
+        values={['tag1']}
+        placeholder="type here"
+      />
+    )
+    const input = screen.getByPlaceholderText('type here')
+    fireEvent.change(input, { target: { value: 'tag2,' } })
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
+    expect(input).toHaveValue('')
+  })
 
-test('values are removed on backspace keydown', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(
-    <InputChips
-      onChange={onChangeMock}
-      values={['tag1']}
-      placeholder="type here"
-    />
-  )
-  const input = screen.getByPlaceholderText('type here')
+  test('values are removed on backspace keydown', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips
+        onChange={onChangeMock}
+        values={['tag1']}
+        placeholder="type here"
+      />
+    )
+    const input = screen.getByPlaceholderText('type here')
 
-  // If there is text in the input, Backspace doesn't remove values
-  fireEvent.change(input, { target: { value: 't' } })
-  fireEvent.keyDown(input, { key: 'Backspace' })
-  expect(onChangeMock).not.toHaveBeenCalled()
+    // If there is text in the input, Backspace doesn't remove values
+    fireEvent.change(input, { target: { value: 't' } })
+    fireEvent.keyDown(input, { key: 'Backspace' })
+    expect(onChangeMock).not.toHaveBeenCalled()
 
-  fireEvent.change(input, { target: { value: '' } })
-  fireEvent.keyDown(input, { key: 'Backspace' })
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith([])
-})
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.keyDown(input, { key: 'Backspace' })
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith([])
+  })
 
-test('values are removed by clicking remove on the chip', () => {
-  const onChangeMock = jest.fn()
-  renderWithTheme(<InputChips onChange={onChangeMock} values={['tag1']} />)
-  const remove = screen.getByText('Delete')
+  test('values are removed by clicking remove on the chip', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(<InputChips onChange={onChangeMock} values={['tag1']} />)
+    const remove = screen.getByText('Delete')
 
-  fireEvent.click(remove)
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith([])
-})
+    fireEvent.click(remove)
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith([])
+  })
 
-test('new values are validated', () => {
-  const onChangeMock = jest.fn()
-  const onValidationFailMock = jest.fn()
-  const onDuplicateMock = jest.fn()
+  test('new values are validated', () => {
+    const onChangeMock = jest.fn()
+    const onValidationFailMock = jest.fn()
+    const onDuplicateMock = jest.fn()
 
-  const validate = jest.fn((value) => value === 'tag1')
-  renderWithTheme(
-    <InputChips
-      onChange={onChangeMock}
-      values={[]}
-      placeholder="type here"
-      validate={validate}
-      onValidationFail={onValidationFailMock}
-      onDuplicate={onDuplicateMock}
-    />
-  )
-  const input = screen.getByPlaceholderText('type here')
-  fireEvent.change(input, { target: { value: 'tag2,' } })
-  // onChange is not called if there are now new valid values
-  expect(onChangeMock).not.toHaveBeenCalled()
-  // invalid value remains in the input
-  expect(input).toHaveValue('tag2')
-  expect(onValidationFailMock).toHaveBeenCalledWith(['tag2'])
+    const validate = jest.fn((value) => value === 'tag1')
+    renderWithTheme(
+      <InputChips
+        onChange={onChangeMock}
+        values={[]}
+        placeholder="type here"
+        validate={validate}
+        onValidationFail={onValidationFailMock}
+        onDuplicate={onDuplicateMock}
+      />
+    )
+    const input = screen.getByPlaceholderText('type here')
+    fireEvent.change(input, { target: { value: 'tag2,' } })
+    // onChange is not called if there are now new valid values
+    expect(onChangeMock).not.toHaveBeenCalled()
+    // invalid value remains in the input
+    expect(input).toHaveValue('tag2')
+    expect(onValidationFailMock).toHaveBeenCalledWith(['tag2'])
 
-  // value should be trimmed before validation
-  fireEvent.change(input, { target: { value: ' tag1,' } })
-  expect(onChangeMock).toHaveBeenCalledTimes(1)
-  expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
-  expect(input).toHaveValue('')
-})
+    // value should be trimmed before validation
+    fireEvent.change(input, { target: { value: ' tag1,' } })
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith(['tag1'])
+    expect(input).toHaveValue('')
+  })
 
-test('duplicate values are not added', () => {
-  const onChangeMock = jest.fn()
-  const onDuplicateMock = jest.fn()
+  test('duplicate values are not added', () => {
+    const onChangeMock = jest.fn()
+    const onDuplicateMock = jest.fn()
 
-  renderWithTheme(
-    <InputChips
-      onChange={onChangeMock}
-      values={['tag1']}
-      placeholder="type here"
-      onDuplicate={onDuplicateMock}
-    />
-  )
-  const input = screen.getByPlaceholderText('type here')
+    renderWithTheme(
+      <InputChips
+        onChange={onChangeMock}
+        values={['tag1']}
+        placeholder="type here"
+        onDuplicate={onDuplicateMock}
+      />
+    )
+    const input = screen.getByPlaceholderText('type here')
 
-  // value should be trimmed before validation
-  fireEvent.change(input, { target: { value: ' tag1,' } })
-  expect(onChangeMock).toHaveBeenCalledTimes(0)
-  expect(onDuplicateMock).toHaveBeenCalledWith(['tag1'])
-  expect(input).toHaveValue('tag1')
-})
+    // value should be trimmed before validation
+    fireEvent.change(input, { target: { value: ' tag1,' } })
+    expect(onChangeMock).toHaveBeenCalledTimes(0)
+    expect(onDuplicateMock).toHaveBeenCalledWith(['tag1'])
+    expect(input).toHaveValue('tag1')
+  })
 
-test('escaped commas and tabs are preserved', () => {
-  const onChangeMock = jest.fn()
+  test('escaped commas and tabs are preserved', () => {
+    const onChangeMock = jest.fn()
 
-  renderWithTheme(
-    <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
-  )
-  const input = screen.getByPlaceholderText('type here')
+    renderWithTheme(
+      <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
+    )
+    const input = screen.getByPlaceholderText('type here')
 
-  fireEvent.change(input, { target: { value: 'tag\\,1,tag\\	2,' } })
-  expect(onChangeMock).toHaveBeenCalledWith(['tag,1', 'tag	2'])
+    fireEvent.change(input, { target: { value: 'tag\\,1,tag\\	2,' } })
+    expect(onChangeMock).toHaveBeenCalledWith(['tag,1', 'tag	2'])
+  })
+
+  describe('removeOnBackspace', () => {
+    test('true by default', () => {
+      const onChangeMock = jest.fn()
+
+      renderWithTheme(
+        <InputChips
+          onChange={onChangeMock}
+          values={['foo', 'bar']}
+          placeholder="type here"
+        />
+      )
+      const input = screen.getByPlaceholderText('type here')
+
+      fireEvent.keyDown(input, {
+        key: 'Backspace',
+      })
+
+      expect(onChangeMock).toHaveBeenCalledWith(['foo'])
+    })
+
+    test('false', () => {
+      const onChangeMock = jest.fn()
+
+      renderWithTheme(
+        <InputChips
+          onChange={onChangeMock}
+          values={['foo', 'bar']}
+          placeholder="type here"
+          removeOnBackspace={false}
+        />
+      )
+      const input = screen.getByPlaceholderText('type here')
+
+      fireEvent.keyDown(input, {
+        key: 'Backspace',
+      })
+
+      expect(onChangeMock).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
@@ -26,16 +26,16 @@
 
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
-import { createEvent, fireEvent } from '@testing-library/react'
+import { createEvent, fireEvent, screen } from '@testing-library/react'
 
 import { InputChips } from './InputChips'
 
 test('values are added on Enter keydown', () => {
   const onChangeMock = jest.fn()
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
   fireEvent.change(input, { target: { value: 'tag1' } })
   expect(onChangeMock).not.toHaveBeenCalled()
 
@@ -47,10 +47,10 @@ test('values are added on Enter keydown', () => {
 
 test('values are added when a comma is last character entered', () => {
   const onChangeMock = jest.fn()
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
 
   // if the last character entered is a comma, values are added
   fireEvent.change(input, { target: { value: 'tag1,' } })
@@ -74,10 +74,10 @@ function firePasteEvent(element: HTMLElement, value: string) {
 
 test('values are added when pasting', () => {
   const onChangeMock = jest.fn()
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
   // Newlines are stripped when pasting into a text input,
   // but InputChips saves the clipboard with newlines intact from the onPaste
   firePasteEvent(
@@ -97,10 +97,10 @@ tag2`
 
 test('values are added on blur', () => {
   const onChangeMock = jest.fn()
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
   fireEvent.change(input, { target: { value: 'tag1' } })
   expect(onChangeMock).not.toHaveBeenCalled()
 
@@ -112,14 +112,14 @@ test('values are added on blur', () => {
 
 test('new values are appended to existing values', () => {
   const onChangeMock = jest.fn()
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips
       onChange={onChangeMock}
       values={['tag1']}
       placeholder="type here"
     />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
   fireEvent.change(input, { target: { value: 'tag2,' } })
   expect(onChangeMock).toHaveBeenCalledTimes(1)
   expect(onChangeMock).toHaveBeenCalledWith(['tag1', 'tag2'])
@@ -128,14 +128,14 @@ test('new values are appended to existing values', () => {
 
 test('values are removed on backspace keydown', () => {
   const onChangeMock = jest.fn()
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips
       onChange={onChangeMock}
       values={['tag1']}
       placeholder="type here"
     />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
 
   // If there is text in the input, Backspace doesn't remove values
   fireEvent.change(input, { target: { value: 't' } })
@@ -150,10 +150,8 @@ test('values are removed on backspace keydown', () => {
 
 test('values are removed by clicking remove on the chip', () => {
   const onChangeMock = jest.fn()
-  const { getByText } = renderWithTheme(
-    <InputChips onChange={onChangeMock} values={['tag1']} />
-  )
-  const remove = getByText('Delete')
+  renderWithTheme(<InputChips onChange={onChangeMock} values={['tag1']} />)
+  const remove = screen.getByText('Delete')
 
   fireEvent.click(remove)
   expect(onChangeMock).toHaveBeenCalledTimes(1)
@@ -166,7 +164,7 @@ test('new values are validated', () => {
   const onDuplicateMock = jest.fn()
 
   const validate = jest.fn((value) => value === 'tag1')
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips
       onChange={onChangeMock}
       values={[]}
@@ -176,7 +174,7 @@ test('new values are validated', () => {
       onDuplicate={onDuplicateMock}
     />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
   fireEvent.change(input, { target: { value: 'tag2,' } })
   // onChange is not called if there are now new valid values
   expect(onChangeMock).not.toHaveBeenCalled()
@@ -195,7 +193,7 @@ test('duplicate values are not added', () => {
   const onChangeMock = jest.fn()
   const onDuplicateMock = jest.fn()
 
-  const { getByPlaceholderText } = renderWithTheme(
+  renderWithTheme(
     <InputChips
       onChange={onChangeMock}
       values={['tag1']}
@@ -203,11 +201,27 @@ test('duplicate values are not added', () => {
       onDuplicate={onDuplicateMock}
     />
   )
-  const input = getByPlaceholderText('type here')
+  const input = screen.getByPlaceholderText('type here')
 
   // value should be trimmed before validation
   fireEvent.change(input, { target: { value: ' tag1,' } })
   expect(onChangeMock).toHaveBeenCalledTimes(0)
   expect(onDuplicateMock).toHaveBeenCalledWith(['tag1'])
   expect(input).toHaveValue('tag1')
+})
+
+test('escaped commas and tabs are preserved', () => {
+  const onChangeMock = jest.fn()
+
+  renderWithTheme(
+    <InputChips onChange={onChangeMock} values={[]} placeholder="type here" />
+  )
+  const input = screen.getByPlaceholderText('type here')
+
+  // value should be trimmed before validation
+  // prettier-ignore
+  /* eslint-disable */
+  fireEvent.change(input, { target: { value: ' tag\,1,tag\	2,' } })
+  /* eslint-enable */
+  expect(onChangeMock).toHaveBeenCalledWith(['tag,1', 'tag	2'])
 })

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -175,7 +175,7 @@ export const InputChipsInternal = forwardRef(
 
     function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
       onKeyDown && onKeyDown(e)
-      if (e.key === 'Enter') {
+      if (!e.defaultPrevented && e.key === 'Enter') {
         // Don't submit a form if there is one
         e.preventDefault()
         // Update values when the user hits return

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -75,8 +75,18 @@ function getUpdatedValues(
   const unusedValues: string[] = []
   const validValues: string[] = []
 
+  // Preserve escaped commas & tabs
+  const commaKey = Math.random() + ''
+  const tabKey = Math.random() + ''
+  const removedEscapes = inputValue
+    .replace(/\\,/, commaKey)
+    .replace(/\\\t/, tabKey)
+
   // Values may be separated by ',' '\t', '\n' and ' '
-  const inputValues: string[] = inputValue.split(/[,\t\n\r]+/)
+  const inputValues: string[] = removedEscapes
+    .split(/[,\t\n\r]+/)
+    .map((value) => value.replace(commaKey, ',').replace(tabKey, '\t'))
+
   inputValues.forEach((val: string) => {
     const trimmedValue = val.trim()
     if (trimmedValue === '') return

--- a/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
@@ -61,7 +61,13 @@ export interface InputChipsControlProps {
 
 export interface InputChipsCommonProps
   extends Omit<InputSearchBaseProps, 'value' | 'defaultValue' | 'onChange'>,
-    MaxHeightProps {}
+    MaxHeightProps {
+  /**
+   * Set to false to disable the removal of the last value on backspace key
+   * @default true
+   */
+  removeOnBackspace?: boolean
+}
 
 export interface InputChipsBaseProps
   extends InputChipsCommonProps,
@@ -82,6 +88,7 @@ export const InputChipsBaseInternal = forwardRef(
       isVisibleOptions,
       hasOptions = false,
       summary,
+      removeOnBackspace = true,
       ...props
     }: InputChipsBaseProps & InputChipsInputControlProps,
     ref: Ref<HTMLInputElement>
@@ -93,7 +100,7 @@ export const InputChipsBaseInternal = forwardRef(
 
     function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
       onKeyDown && onKeyDown(e)
-      if (e.key === 'Backspace' && !e.defaultPrevented) {
+      if (e.key === 'Backspace' && removeOnBackspace && !e.defaultPrevented) {
         // If we hit backspace and there is no text left to delete, remove the last entry instead
         inputValue === '' && handleDeleteChip(values[values.length - 1])
       }

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -140,12 +140,6 @@ const SelectComponent = forwardRef(
       'aria-labelledby': ariaLabelledby,
     }
 
-    const inputProps = {
-      disabled,
-      placeholder,
-      validationType,
-    }
-
     const windowedOptions = useShouldWindowOptions(options, windowedOptionsProp)
 
     return (
@@ -157,8 +151,10 @@ const SelectComponent = forwardRef(
         onClose={handleClose}
       >
         <ComboboxInput
-          {...inputProps}
           {...ariaProps}
+          disabled={disabled}
+          placeholder={placeholder}
+          validationType={validationType}
           isClearable={isClearable}
           autoComplete={false}
           readOnly={!isFilterable}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
@@ -25,7 +25,7 @@
  */
 
 import { renderWithTheme } from '@looker/components-test-utils'
-import { cleanup, fireEvent } from '@testing-library/react'
+import { cleanup, fireEvent, screen } from '@testing-library/react'
 import React from 'react'
 
 import { SelectMulti } from './SelectMulti'
@@ -242,6 +242,45 @@ describe('closeOnSelect', () => {
 
       expect(getByText('Foo')).toBeVisible()
       expect(queryByText('Bar')).toBeVisible()
+    })
+  })
+
+  describe('freeInput', () => {
+    test('false by default', () => {
+      const onChangeMock = jest.fn()
+      renderWithTheme(
+        <SelectMulti
+          options={basicOptions}
+          defaultValues={['FOO', 'BAR']}
+          placeholder="Search"
+          onChange={onChangeMock}
+        />
+      )
+
+      const input = screen.getByPlaceholderText('Search')
+      fireEvent.change(input, { target: { value: 'baz,qux,' } })
+
+      expect(onChangeMock).not.toHaveBeenCalled()
+      expect(input).toHaveValue('baz,qux,')
+    })
+
+    test('true', () => {
+      const onChangeMock = jest.fn()
+      renderWithTheme(
+        <SelectMulti
+          options={basicOptions}
+          defaultValues={['FOO', 'BAR']}
+          placeholder="Search"
+          onChange={onChangeMock}
+          freeInput
+        />
+      )
+
+      const input = screen.getByPlaceholderText('Search')
+      fireEvent.change(input, { target: { value: 'baz,qux,' } })
+
+      expect(onChangeMock).toHaveBeenCalledWith(['FOO', 'BAR', 'baz', 'qux'])
+      expect(input).toHaveValue('')
     })
   })
 })

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -24,14 +24,16 @@
 
  */
 
-import React, { forwardRef, KeyboardEvent, Ref } from 'react'
+import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import {
   ComboboxMulti,
   ComboboxMultiInput,
+  ComboboxMultiInputProps,
   ComboboxMultiList,
   ComboboxMultiProps,
 } from '../Combobox'
+import { InputChipsCommonProps } from '../InputChips'
 import { SelectBaseProps } from './Select'
 import {
   SelectMultiOptionsBaseProps,
@@ -44,6 +46,8 @@ import { useShouldWindowOptions } from './utils/useWindowedOptions'
 export interface SelectMultiProps
   extends Omit<ComboboxMultiProps, 'values' | 'defaultValues' | 'onChange'>,
     Omit<SelectBaseProps, 'isClearable'>,
+    Pick<InputChipsCommonProps, 'removeOnBackspace'>,
+    Pick<ComboboxMultiInputProps, 'freeInput'>,
     SelectMultiOptionsBaseProps {
   /**
    * Values of the current selected option (controlled)
@@ -62,17 +66,6 @@ export interface SelectMultiProps
    * @default false
    */
   closeOnSelect?: boolean
-  /**
-   * Set to false to disable the removal of the last value on backspace key
-   * @default true
-   */
-  removeOnBackspace?: boolean
-  /**
-   * Allows inputting of values outside of options via typing or pasting
-   * Not recommended for use when options have labels that are different from their values
-   * @default false
-   */
-  freeInput?: boolean
 }
 
 const SelectMultiComponent = forwardRef(
@@ -127,13 +120,6 @@ const SelectMultiComponent = forwardRef(
       'aria-labelledby': ariaLabelledby,
     }
 
-    const inputProps = {
-      disabled,
-      placeholder,
-      removeOnBackspace,
-      validationType,
-    }
-
     const windowedOptions = useShouldWindowOptions(options, windowedOptionsProp)
 
     return (
@@ -145,8 +131,11 @@ const SelectMultiComponent = forwardRef(
         onClose={handleClose}
       >
         <ComboboxMultiInput
-          {...inputProps}
           {...ariaProps}
+          disabled={disabled}
+          placeholder={placeholder}
+          removeOnBackspace={removeOnBackspace}
+          validationType={validationType}
           autoComplete={false}
           readOnly={!isFilterable}
           onInputChange={handleInputChange}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -67,6 +67,12 @@ export interface SelectMultiProps
    * @default true
    */
   removeOnBackspace?: boolean
+  /**
+   * Allows inputting of values outside of options via typing or pasting
+   * Not recommended for use when options have labels that are different from their values
+   * @default false
+   */
+  freeInput?: boolean
 }
 
 const SelectMultiComponent = forwardRef(
@@ -92,6 +98,7 @@ const SelectMultiComponent = forwardRef(
       showCreate = false,
       formatCreateLabel,
       removeOnBackspace = true,
+      freeInput = false,
       ...props
     }: SelectMultiProps,
     ref: Ref<HTMLInputElement>
@@ -123,16 +130,8 @@ const SelectMultiComponent = forwardRef(
     const inputProps = {
       disabled,
       placeholder,
+      removeOnBackspace,
       validationType,
-      ...(removeOnBackspace
-        ? {}
-        : {
-            onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-              if (e.currentTarget.value === '' && e.key === 'Backspace') {
-                e.preventDefault()
-              }
-            },
-          }),
     }
 
     const windowedOptions = useShouldWindowOptions(options, windowedOptionsProp)
@@ -152,6 +151,7 @@ const SelectMultiComponent = forwardRef(
           readOnly={!isFilterable}
           onInputChange={handleInputChange}
           selectOnClick={isFilterable}
+          freeInput={freeInput}
           ref={ref}
         />
         {!disabled && (

--- a/storybook/src/Forms/Combobox/Combobox.stories.tsx
+++ b/storybook/src/Forms/Combobox/Combobox.stories.tsx
@@ -73,11 +73,10 @@ export function ComboboxDemo() {
         </Combobox>
         <ComboboxMulti
           width={300}
-          maxHeight={75}
           values={options}
           onChange={handleMultiChange}
         >
-          <ComboboxMultiInput onClear={() => alert('CLEAR')} />
+          <ComboboxMultiInput onClear={() => alert('CLEAR')} freeInput />
           <ComboboxMultiList>
             <ComboboxMultiOption value="Apples" />
             <ComboboxMultiOption value="Oranges" />
@@ -103,7 +102,7 @@ export function ComboboxDemo() {
           </ComboboxList>
         </Combobox>
         <ComboboxMulti width={300}>
-          <ComboboxMultiInput onClear={() => alert('CLEAR')} />
+          <ComboboxMultiInput onClear={() => alert('CLEAR')} freeInput />
           <ComboboxMultiList>
             <ComboboxMultiOption value="Apples" />
             <ComboboxMultiOption value="Oranges" />

--- a/storybook/src/Forms/SelectMulti.stories.tsx
+++ b/storybook/src/Forms/SelectMulti.stories.tsx
@@ -79,6 +79,8 @@ export const Basic = () => (
     label="Label"
     options={selectOptions}
     placeholder="Search fruits"
+    isFilterable
+    freeInput
   />
 )
 

--- a/www/src/documentation/components/forms/input-chips.mdx
+++ b/www/src/documentation/components/forms/input-chips.mdx
@@ -12,7 +12,7 @@ The `values` and `onChange` props are required – `InputChips` is a controlled 
 
 `InputChips` also supports `summary` and `hideControls`, similar to [`InputSearch`](input-search).
 
-```js
+```jsx
 ;() => {
   function ExampleInputChips({ values: initialValues = [], hideControls }) {
     const [values, setValues] = React.useState(initialValues)
@@ -45,7 +45,7 @@ The `values` and `onChange` props are required – `InputChips` is a controlled 
 
 The `inputValue` and `onInputChange` props allow control of the typed value. We also provide an optional `onClear` event hook that can be used for post-event cleanup or rendering helpful undo functionality.
 
-```js
+```jsx
 ;() => {
   const [values, setValues] = React.useState([])
   const previousInputValues = usePreviousValue(values)
@@ -99,7 +99,7 @@ The optional `validate` prop is a function returning a boolean that is called fo
 If it returns false, the value is not added. `onValidationFail` and `onDuplicate` are optional handlers for when
 invalid and duplicate values are entered.
 
-```js
+```jsx
 ;() => {
   const emailValidator = new RegExp(
     /^(([^<>()\[\]\\.,:\s@"]+(\.[^<>()\[\]\\.,:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -141,6 +141,28 @@ invalid and duplicate values are entered.
           : ''}
       </Paragraph>
     </>
+  )
+}
+```
+
+## removeOnBackspace
+
+The `removeOnBackspace` prop defaults to true.
+When set to false, hitting the `Backspace` key while focused in the input will not remove values.
+
+```jsx
+;() => {
+  const [values, setValues] = React.useState(['mango', 'kiwi'])
+  function handleChange(newValues) {
+    setValues(newValues)
+  }
+  return (
+    <InputChips
+      placeholder="Backspace does not remove values"
+      values={values}
+      onChange={handleChange}
+      removeOnBackspace={false}
+    />
   )
 }
 ```

--- a/www/src/documentation/components/forms/select-multi.mdx
+++ b/www/src/documentation/components/forms/select-multi.mdx
@@ -122,47 +122,6 @@ With the `closeOnSelect` prop, the option list closes after an option is selecte
 />
 ```
 
-## removeOnBackspace
-
-The `removeOnBackspace` prop defaults to true.
-When set to false, hitting the `Backspace` key while focused in the input will not remove values.
-
-```jsx
-;() => {
-  const [searchTerm, setSearchTerm] = React.useState('')
-  function handleFilter(term) {
-    setSearchTerm(term)
-  }
-
-  const newOptions = React.useMemo(() => {
-    const options = [
-      { value: 'Cheddar' },
-      { value: 'Gouda' },
-      { value: 'Swiss' },
-      { value: 'Feta' },
-      { value: 'Mascarpone' },
-      { value: 'Brie' },
-      { value: 'Mozzarella' },
-      { value: 'Cotija' },
-      { value: 'Pepperjack' },
-    ]
-    if (searchTerm === '') return options
-    return options.filter((option) => {
-      return option.value.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
-    })
-  }, [searchTerm])
-  return (
-    <SelectMulti
-      options={newOptions}
-      isFilterable
-      onFilter={handleFilter}
-      defaultValues={['Swiss', 'Brie']}
-      removeOnBackspace={false}
-    />
-  )
-}
-```
-
 ## freeInput
 
 Use the `freeInput` prop when the user needs to be able to easily enter values not found in the list of options.
@@ -187,3 +146,7 @@ by the enter key, comma, or tab or newline character when pasting.
   freeInput
 />
 ```
+
+## removeOnBackspace
+
+The `removeOnBackspace` prop inherits from [`InputChips`](/components/forms/input-chips/#removeonbackspace).

--- a/www/src/documentation/components/forms/select-multi.mdx
+++ b/www/src/documentation/components/forms/select-multi.mdx
@@ -162,3 +162,28 @@ When set to false, hitting the `Backspace` key while focused in the input will n
   )
 }
 ```
+
+## freeInput
+
+Use the `freeInput` prop when the user needs to be able to easily enter values not found in the list of options.
+This enables the inputting behavior of [`InputChips`](/components/forms/input-chips/) where values are separated
+by the enter key, comma, or tab or newline character when pasting.
+
+```jsx
+<SelectMulti
+  options={[
+    { value: 'Cheddar' },
+    { value: 'Gouda' },
+    { value: 'Swiss' },
+    { value: 'Feta' },
+    { value: 'Mascarpone' },
+    { value: 'Brie' },
+    { value: 'Mozzarella' },
+    { value: 'Cotija' },
+    { value: 'Pepperjack' },
+  ]}
+  isFilterable
+  placeholder="Type values or select from the list"
+  freeInput
+/>
+```

--- a/www/src/documentation/components/forms/select.mdx
+++ b/www/src/documentation/components/forms/select.mdx
@@ -262,7 +262,7 @@ like width and height, separately from the input.
   <Select
     width={400}
     listLayout={{ width: 'auto' }}
-    placeholder="Accomodate wide options"
+    placeholder="Accommodate wide options"
     options={[
       {
         value: 'short',

--- a/www/src/documentation/components/forms/select.mdx
+++ b/www/src/documentation/components/forms/select.mdx
@@ -258,33 +258,51 @@ Use the `listLayout` prop to control layout properties of the list,
 like width and height, separately from the input.
 
 ```jsx
-<Select
-  width={400}
-  listLayout={{ width: '90vw', maxWidth: 700, maxHeight: 300 }}
-  options={[
-    { value: 'cheddar', label: 'Cheddar' },
-    { value: 'gouda', label: 'Gouda' },
-    { value: 'swiss', label: 'Swiss' },
-    { value: 'string', label: 'String' },
-    { value: 'parmesan', label: 'Parmigiano Reggiano' },
-    { value: 'roquefort', label: 'Roquefort' },
-    { value: 'brie', label: 'Brie' },
-    { value: 'gruyere', label: 'Gruyere' },
-    { value: 'feta', label: 'Feta' },
-    { value: 'mozzarella', label: 'Mozzarella' },
-    { value: 'manchego', label: 'Manchego' },
-    { value: 'gorgonzola', label: 'Gorgonzola' },
-    { value: 'epoisses', label: 'Epoisses' },
-    { value: 'monterey-jack', label: 'Monterey Jack' },
-    { value: 'muenster', label: 'Muenster' },
-    { value: 'provolone', label: 'Provolone' },
-    { value: 'blue', label: 'Blue' },
-    { value: 'camembert', label: 'Camembert' },
-    { value: 'havarti', label: 'Havarti' },
-    { value: 'ricotta', label: 'Ricotta' },
-    { value: 'mascarpone', label: 'Mascarpone' },
-  ]}
-/>
+<Space>
+  <Select
+    width={400}
+    listLayout={{ width: 'auto' }}
+    placeholder="Accomodate wide options"
+    options={[
+      {
+        value: 'short',
+        label: 'Short label',
+      },
+      {
+        value: 'long',
+        label:
+          'Incredibly long label that causes the list to be wider than the input',
+      },
+    ]}
+  />
+  <Select
+    width={400}
+    listLayout={{ width: '90vw', maxWidth: 700, maxHeight: 300 }}
+    options={[
+      { value: 'cheddar', label: 'Cheddar' },
+      { value: 'gouda', label: 'Gouda' },
+      { value: 'swiss', label: 'Swiss' },
+      { value: 'string', label: 'String' },
+      { value: 'parmesan', label: 'Parmigiano Reggiano' },
+      { value: 'roquefort', label: 'Roquefort' },
+      { value: 'brie', label: 'Brie' },
+      { value: 'gruyere', label: 'Gruyere' },
+      { value: 'feta', label: 'Feta' },
+      { value: 'mozzarella', label: 'Mozzarella' },
+      { value: 'manchego', label: 'Manchego' },
+      { value: 'gorgonzola', label: 'Gorgonzola' },
+      { value: 'epoisses', label: 'Epoisses' },
+      { value: 'monterey-jack', label: 'Monterey Jack' },
+      { value: 'muenster', label: 'Muenster' },
+      { value: 'provolone', label: 'Provolone' },
+      { value: 'blue', label: 'Blue' },
+      { value: 'camembert', label: 'Camembert' },
+      { value: 'havarti', label: 'Havarti' },
+      { value: 'ricotta', label: 'Ricotta' },
+      { value: 'mascarpone', label: 'Mascarpone' },
+    ]}
+  />
+</Space>
 ```
 
 ## Indicator


### PR DESCRIPTION
### :sparkles: Changes

This PR's main focus is `SelectMulti` free-form input but also includes a couple other adjacent changes needed for this component to be used successfully as an advanced string filter

- `freeInput` in `ComboboxMultiInput` and `SelectMulti` toggles to `InputChips` instead of `InputChipsBase` (the former supports entering values comma-, enter-, tab-, and newline-separated lists)
  - This isn't enabled by default in order to better validate the user input with available options.
- Preserve escaped comma and tab characters in `InputChips` (requirement for filters)
- Set `ComboboxList` `minWidth` to the wrapper width if `props.width` has been set to `'auto'` to enable the list width to grow to accommodate wide options (the current behavior is to wrap them)
- Move `removeOnBackspace` from `ComboboxMultiInput` to `InputChipsBase` mostly b/c the previous implementation was confusing, but a potentially desirable feature for `InputChips` as well.
- Fix an issue when selecting options that are longer than the input where the beginning of the text isn't visible (see screenshots below)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue:
![input-scroll-issue](https://user-images.githubusercontent.com/53451193/84440148-5e3f6300-abee-11ea-848b-e0282e942d9e.gif)
#### Fix:
![input-scroll](https://user-images.githubusercontent.com/53451193/84440152-613a5380-abee-11ea-9a8a-1369d94b0363.gif)
