### PR TITLE
[LENS-926] Condense Slider and RangeSlider layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ButtonGroup` space between rows when wrapping
 - `InputChips` separates chips by newline when pasting
+- `Slider` and `RangeSlider` design tweaks
 
 ## [0.8.6]
 

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -405,7 +405,7 @@ export const RangeSlider = styled(InternalRangeSlider)`
   padding: 1.5rem 0 0.5rem;
 `
 
-RangeSlider.defaultProps = { fontSize: 'small' }
+RangeSlider.defaultProps = { fontSize: 'small', lineHeight: 'xsmall' }
 
 const SliderTrack = styled.div`
   height: 4px;

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -32,7 +32,13 @@ import React, {
   useRef,
   useEffect,
 } from 'react'
-import { SpaceProps, reset, space } from '@looker/design-tokens'
+import {
+  SpaceProps,
+  reset,
+  space,
+  typography,
+  TypographyProps,
+} from '@looker/design-tokens'
 import { WidthProps } from 'styled-system'
 import styled from 'styled-components'
 import sortBy from 'lodash/sortBy'
@@ -49,7 +55,10 @@ import {
 } from '../../../utils'
 import { ValidationType } from '../../ValidationMessage'
 
-export interface RangeSliderProps extends SpaceProps, WidthProps {
+export interface RangeSliderProps
+  extends SpaceProps,
+    WidthProps,
+    TypographyProps {
   'aria-labelledby'?: string
   max?: number
   min?: number
@@ -164,6 +173,7 @@ export const InternalRangeSlider = forwardRef(
       disabled = false,
       readOnly: readOnlyProp = false,
       'aria-labelledby': ariaLabelledby,
+      fontSize,
     }: RangeSliderProps,
     ref: Ref<HTMLDivElement>
   ) => {
@@ -339,6 +349,7 @@ export const InternalRangeSlider = forwardRef(
             position={minPos}
             focus={focusedThumb === 0}
             disabled={disabled}
+            fontSize={fontSize}
           >
             {minValue}
           </ThumbLabel>
@@ -346,6 +357,7 @@ export const InternalRangeSlider = forwardRef(
             position={maxPos}
             focus={focusedThumb === 1}
             disabled={disabled}
+            fontSize={fontSize}
           >
             {maxValue}
           </ThumbLabel>
@@ -392,8 +404,10 @@ InternalRangeSlider.displayName = 'InternalRangeSlider'
 export const RangeSlider = styled(InternalRangeSlider)`
   ${reset}
   ${space}
-  padding: ${({ theme: { space } }) => `${space.xlarge} 0 ${space.small}`};
+  padding: 1.5rem 0 0.5rem;
 `
+
+RangeSlider.defaultProps = { fontSize: 'small' }
 
 const SliderTrack = styled.div`
   height: 4px;
@@ -402,16 +416,17 @@ const SliderTrack = styled.div`
   position: relative;
 `
 
-interface ThumbLabelProps {
+interface ThumbLabelProps extends TypographyProps {
   position: number
   focus: boolean
   disabled: boolean
 }
 
 const ThumbLabel = styled.div<ThumbLabelProps>`
+  ${typography}
   user-select: none;
   position: absolute;
-  top: -30px;
+  top: -24px;
   transform: translateX(calc(${({ position = 0 }) => `${position}px`} - 50%));
   text-align: center;
   color: ${({ theme: { colors }, disabled }) =>

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -173,7 +173,6 @@ export const InternalRangeSlider = forwardRef(
       disabled = false,
       readOnly: readOnlyProp = false,
       'aria-labelledby': ariaLabelledby,
-      fontSize,
     }: RangeSliderProps,
     ref: Ref<HTMLDivElement>
   ) => {
@@ -349,7 +348,6 @@ export const InternalRangeSlider = forwardRef(
             position={minPos}
             focus={focusedThumb === 0}
             disabled={disabled}
-            fontSize={fontSize}
           >
             {minValue}
           </ThumbLabel>
@@ -357,7 +355,6 @@ export const InternalRangeSlider = forwardRef(
             position={maxPos}
             focus={focusedThumb === 1}
             disabled={disabled}
-            fontSize={fontSize}
           >
             {maxValue}
           </ThumbLabel>
@@ -404,6 +401,7 @@ InternalRangeSlider.displayName = 'InternalRangeSlider'
 export const RangeSlider = styled(InternalRangeSlider)`
   ${reset}
   ${space}
+  ${typography}
   padding: 1.5rem 0 0.5rem;
 `
 
@@ -423,7 +421,6 @@ interface ThumbLabelProps extends TypographyProps {
 }
 
 const ThumbLabel = styled.div<ThumbLabelProps>`
-  ${typography}
   user-select: none;
   position: absolute;
   top: -24px;

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -27,7 +27,13 @@
 import React, { forwardRef, Ref, SyntheticEvent, useState } from 'react'
 import isFunction from 'lodash/isFunction'
 import styled, { css } from 'styled-components'
-import { reset, space, SpaceProps } from '@looker/design-tokens'
+import {
+  reset,
+  space,
+  SpaceProps,
+  typography,
+  TypographyProps,
+} from '@looker/design-tokens'
 import { WidthProps, width } from 'styled-system'
 
 import { InputProps } from '../InputProps'
@@ -35,7 +41,8 @@ import { InputProps } from '../InputProps'
 export interface SliderProps
   extends SpaceProps,
     WidthProps,
-    Omit<InputProps, 'type'> {
+    Omit<InputProps, 'type'>,
+    TypographyProps {
   'aria-labelledby'?: string
   max?: number
   min?: number
@@ -250,11 +257,11 @@ const SliderValue = styled.div<SliderValueProps>`
     disabled ? colors.neutral : colors.key};
   line-height: 1;
   user-select: none;
-  transform: translateX(-50%) translateY(-1.3rem);
+  transform: translateX(-50%) translateY(-0.85rem);
   left: ${({ offsetPercent }) => offsetPercent}%;
   position: absolute;
   text-align: center;
-  padding: 0.2rem 0.5rem;
+  padding: 0 0.5rem;
   border-radius: 1rem;
   background: ${({ theme, isFocused }) =>
     isFocused ? theme.colors.keyAccent : theme.colors.keyText};
@@ -270,8 +277,9 @@ export const Slider = styled(SliderInternal)<SliderProps>`
   ${reset}
   ${space}
   ${width}
+  ${typography}
   position: relative;
 `
 
 SliderInternal.displayName = 'Slider'
-Slider.defaultProps = { mt: 'large', width: '100%' }
+Slider.defaultProps = { fontSize: 'small', mt: 'medium', width: '100%' }

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -255,9 +255,8 @@ interface SliderValueProps extends SliderInputProps {
 const SliderValue = styled.div<SliderValueProps>`
   color: ${({ theme: { colors }, disabled }) =>
     disabled ? colors.neutral : colors.key};
-  line-height: 1;
   user-select: none;
-  transform: translateX(-50%) translateY(-0.85rem);
+  transform: translateX(-50%) translateY(-0.9rem);
   left: ${({ offsetPercent }) => offsetPercent}%;
   position: absolute;
   text-align: center;
@@ -282,4 +281,9 @@ export const Slider = styled(SliderInternal)<SliderProps>`
 `
 
 SliderInternal.displayName = 'Slider'
-Slider.defaultProps = { fontSize: 'small', mt: 'medium', width: '100%' }
+Slider.defaultProps = {
+  fontSize: 'small',
+  lineHeight: 'xsmall',
+  mt: 'medium',
+  width: '100%',
+}

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -124,7 +124,7 @@ const SliderInternal = forwardRef(
           name={name}
           onChange={handleChange}
           step={step}
-          type="range"
+          offsetPercent={fillPercent}
           value={displayValue}
           aria-labelledby={restProps['aria-labelledby']}
           data-testid="slider-input"
@@ -139,6 +139,7 @@ const SliderInternal = forwardRef(
 
 interface SliderInputProps {
   isFocused?: boolean
+  offsetPercent: number
 }
 
 const sliderThumbFocusCss = css<SliderInputProps>`
@@ -149,6 +150,10 @@ const sliderThumbCss = css<SliderInputProps>`
   border-radius: 100%;
   cursor: pointer;
   transition: transform 0.25s, box-shadow 0.25s;
+  position: absolute;
+  left: ${({ offsetPercent = 0 }) => `${offsetPercent}%`};
+  transform: translateX(-50%);
+  top: 3px;
   ${({ theme: { colors }, isFocused }) => css`
     border: 3px solid ${colors.key};
     height: 16px;
@@ -163,9 +168,11 @@ const SliderInput = styled.input.attrs({ type: 'range' })<SliderInputProps>`
   display: block;
   height: 22px;
   position: relative;
-  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
   -webkit-appearance: none; /* stylelint-disable-line */
-
+  width: calc(100% - 16px);
+  left: 8px;
   &::-webkit-slider-thumb {
     -webkit-appearance: none; /* stylelint-disable-line */
     ${sliderThumbCss}
@@ -223,14 +230,14 @@ const SliderInput = styled.input.attrs({ type: 'range' })<SliderInputProps>`
 `
 
 const SliderTrack = styled.div`
-  width: calc(100% - 16px);
   height: 4px;
   background: ${({ theme }) => theme.colors.ui2};
   border-radius: ${({ theme }) => theme.radii.small};
   position: absolute;
   top: 50%;
-  left: 8px;
   margin-top: -2px;
+  width: calc(100% - 16px);
+  left: 8px;
 `
 
 interface ControlProps {

--- a/packages/components/src/Form/Inputs/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Slider/__snapshots__/Slider.test.tsx.snap
@@ -6,8 +6,11 @@ exports[`renders focus styles on keypress 1`] = `
   display: block;
   height: 22px;
   position: relative;
-  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
   -webkit-appearance: none;
+  width: calc(100% - 16px);
+  left: 8px;
 }
 
 .c0::-webkit-slider-thumb {
@@ -17,6 +20,12 @@ exports[`renders focus styles on keypress 1`] = `
   -webkit-transition: -webkit-transform 0.25s,box-shadow 0.25s;
   -webkit-transition: transform 0.25s,box-shadow 0.25s;
   transition: transform 0.25s,box-shadow 0.25s;
+  position: absolute;
+  left: 0%;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+  top: 3px;
   border: 3px solid #6C43E0;
   height: 16px;
   width: 16px;
@@ -29,6 +38,12 @@ exports[`renders focus styles on keypress 1`] = `
   -webkit-transition: -webkit-transform 0.25s,box-shadow 0.25s;
   -webkit-transition: transform 0.25s,box-shadow 0.25s;
   transition: transform 0.25s,box-shadow 0.25s;
+  position: absolute;
+  left: 0%;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+  top: 3px;
   border: 3px solid #6C43E0;
   height: 16px;
   width: 16px;
@@ -41,6 +56,12 @@ exports[`renders focus styles on keypress 1`] = `
   -webkit-transition: -webkit-transform 0.25s,box-shadow 0.25s;
   -webkit-transition: transform 0.25s,box-shadow 0.25s;
   transition: transform 0.25s,box-shadow 0.25s;
+  position: absolute;
+  left: 0%;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+  top: 3px;
   border: 3px solid #6C43E0;
   height: 16px;
   width: 16px;


### PR DESCRIPTION
### :sparkles: Changes

- Smaller font size and tighter spacing to make the two slider components fit within a 36px vertical space

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x PR is ideally < ~400LOC

### :camera: Screenshots
<img width="977" alt="Screen Shot 2020-06-11 at 5 45 52 PM" src="https://user-images.githubusercontent.com/238293/84452722-6e197000-ac0b-11ea-93bd-b9d1e9fe90a5.png">
<img width="1158" alt="Screen Shot 2020-06-11 at 5 45 43 PM" src="https://user-images.githubusercontent.com/238293/84452725-6f4a9d00-ac0b-11ea-9dd5-2dee07f40655.png">
