### PR TITLE
Fix Jest warning for invalid DOM prop on Fieldset

### DIFF
--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -32,6 +32,7 @@ import {
   SpaceProps,
   typography,
   TypographyProps,
+  omitStyledProps,
 } from '@looker/design-tokens'
 import { ButtonSetContext } from './ButtonSetContext'
 
@@ -75,7 +76,7 @@ const ButtonLayout = forwardRef(
         onClick={handleClick}
         value={itemValue}
         disabled={disabled}
-        {...props}
+        {...omitStyledProps(props)}
       >
         {children}
       </button>

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -26,7 +26,11 @@
 
 import React, { forwardRef, ReactNode, Ref } from 'react'
 import styled from 'styled-components'
-import { CompatibleHTMLProps, SpacingSizes } from '@looker/design-tokens'
+import {
+  CompatibleHTMLProps,
+  SpacingSizes,
+  omitStyledProps,
+} from '@looker/design-tokens'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
 import { Space, SpaceHelperProps, SpaceVertical } from '../../Layout'
@@ -134,7 +138,7 @@ const FieldsetLayout = forwardRef(
       content
     )
 
-    return <div {...restProps}>{renderedFieldset}</div>
+    return <div {...omitStyledProps(restProps)}>{renderedFieldset}</div>
   }
 )
 

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -189,8 +189,6 @@ exports[`Fieldset 1`] = `
 
 <div
   className="c0"
-  padding="none"
-  width="100%"
 >
   <div
     className="c1"

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -42,7 +42,11 @@ import {
   minWidth,
   maxWidth,
 } from 'styled-system'
-import { CompatibleHTMLProps, reset } from '@looker/design-tokens'
+import {
+  CompatibleHTMLProps,
+  reset,
+  omitStyledProps,
+} from '@looker/design-tokens'
 import { usePopover } from '../Popover'
 import { MenuContext, MenuItemStyleContext } from './MenuContext'
 import { MenuGroup } from './MenuGroup'
@@ -125,7 +129,7 @@ export const MenuListInternal = forwardRef(
             role="menu"
             id={id}
             aria-labelledby={id && `button-${id}`}
-            {...props}
+            {...omitStyledProps(props)}
           >
             {children}
           </ul>

--- a/packages/components/src/Modal/Confirm/ConfirmLayout.tsx
+++ b/packages/components/src/Modal/Confirm/ConfirmLayout.tsx
@@ -66,7 +66,7 @@ export const ConfirmLayout: FC<ConfirmLayoutProps> = ({
       </ModalHeader>
       <ModalContent innerProps={{ py: 'none' }}>
         {typeof message === 'string' ? (
-          <Paragraph wrap>{message}</Paragraph>
+          <Paragraph breakwords>{message}</Paragraph>
         ) : (
           message
         )}

--- a/packages/components/src/Modal/Confirm/ConfirmLayout.tsx
+++ b/packages/components/src/Modal/Confirm/ConfirmLayout.tsx
@@ -66,7 +66,7 @@ export const ConfirmLayout: FC<ConfirmLayoutProps> = ({
       </ModalHeader>
       <ModalContent innerProps={{ py: 'none' }}>
         {typeof message === 'string' ? (
-          <Paragraph breakwords>{message}</Paragraph>
+          <Paragraph breakword>{message}</Paragraph>
         ) : (
           message
         )}

--- a/packages/components/src/Sidebar/SidebarGroup.tsx
+++ b/packages/components/src/Sidebar/SidebarGroup.tsx
@@ -24,6 +24,7 @@
 
  */
 
+import { omitStyledProps } from '@looker/design-tokens'
 import React, { FC, useState } from 'react'
 import styled from 'styled-components'
 import { Heading } from '../Text'

--- a/packages/components/src/Sidebar/SidebarGroup.tsx
+++ b/packages/components/src/Sidebar/SidebarGroup.tsx
@@ -51,7 +51,7 @@ const InternalSidebarGroup: FC<SidebarGroupProps> = ({
   }
 
   return (
-    <section className={className} {...props}>
+    <section className={className} {...omitStyledProps(props)}>
       <SidebarGroupHeading onClick={toggle}>
         <button aria-expanded={isOpen ? 'true' : 'false'}>
           {label}

--- a/packages/components/src/Text/Paragraph.test.tsx
+++ b/packages/components/src/Text/Paragraph.test.tsx
@@ -75,7 +75,7 @@ test('A Paragraph component text transformed', () => {
 })
 
 test('A Paragraph component wrapped', () => {
-  const component = createWithTheme(<Paragraph wrap>Hello</Paragraph>)
+  const component = createWithTheme(<Paragraph breakword>Hello</Paragraph>)
   const tree = component.toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/packages/components/src/Text/Text.test.tsx
+++ b/packages/components/src/Text/Text.test.tsx
@@ -61,7 +61,7 @@ test('A Text component text transformed', () => {
 })
 
 test('A Text component wrapped', () => {
-  const component = createWithTheme(<Text wrap>Hello</Text>)
+  const component = createWithTheme(<Text breakword>Hello</Text>)
   const tree = component.toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/packages/components/src/Text/TextBase.tsx
+++ b/packages/components/src/Text/TextBase.tsx
@@ -43,7 +43,7 @@ export interface TextBaseProps
   /** Should browser insert line breaks within words to prevent text from overflowing its content box
    * @default: false
    */
-  wrap?: boolean
+  breakword?: boolean
 }
 
 export const TextBase = styled.span.attrs((props: TypographyProps) => ({
@@ -54,5 +54,5 @@ export const TextBase = styled.span.attrs((props: TypographyProps) => ({
   ${space}
   ${color}
   ${textDecoration}
-  ${(props) => props.wrap && 'overflow-wrap: break-word'};
+  ${(props) => props.breakword && 'overflow-wrap: break-word'};
 `

--- a/packages/components/src/Text/__snapshots__/Paragraph.test.tsx.snap
+++ b/packages/components/src/Text/__snapshots__/Paragraph.test.tsx.snap
@@ -137,7 +137,6 @@ exports[`A Paragraph component wrapped 1`] = `
 <p
   className="c0"
   fontSize="medium"
-  wrap={true}
 >
   Hello
 </p>

--- a/packages/components/src/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/components/src/Text/__snapshots__/Text.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`A Text component wrapped 1`] = `
 <span
   className="c0"
   fontSize="medium"
-  wrap={true}
 >
   Hello
 </span>

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@styled-system/props": "^5.1.5",
     "@types/styled-system": "^5.1.9",
     "lodash": "^4.17.15",
     "polished": "^3.6.4",

--- a/packages/design-tokens/src/utils/omit.ts
+++ b/packages/design-tokens/src/utils/omit.ts
@@ -37,30 +37,30 @@ export const typographyProps = [
 ]
 
 const borderProps = [
-  'BorderWidthProps',
-  'BorderStyleProps',
-  'BorderColorProps',
-  'BorderRadiusProps',
-  'BorderTopProps',
-  'BorderRightProps',
-  'BorderBottomProps',
-  'BorderLeftProps',
+  'borderWidth',
+  'borderStyle',
+  'borderColor',
+  'borderRadius',
+  'borderTop',
+  'borderRight',
+  'borderBottom',
+  'borderLeft',
 ]
 const colorProps = ['backgroundColor', 'bg', 'color', 'opacity']
 const flexProps = [
-  'AlignItemsProps',
-  'AlignContentProps',
-  'JustifyItemsProps',
-  'JustifyContentProps',
-  'FlexWrapProps',
-  'FlexDirectionProps',
-  'FlexProps',
-  'FlexGrowProps',
-  'FlexShrinkProps',
-  'FlexBasisProps',
-  'JustifySelfProps',
-  'AlignSelfProps',
-  'OrderProps',
+  'alignItems',
+  'alignContent',
+  'justifyItems',
+  'justifyContent',
+  'flexWrap',
+  'flexDirection',
+  'flex',
+  'flexGrow',
+  'flexShrink',
+  'flexBasis',
+  'justifySelf',
+  'alignSelf',
+  'order',
 ]
 const positionProps = ['bottom', 'left', 'position', 'right', 'top', 'zIndex']
 const layoutProps = [

--- a/packages/design-tokens/src/utils/styled-system__props.d.ts
+++ b/packages/design-tokens/src/utils/styled-system__props.d.ts
@@ -24,6 +24,6 @@
 
  */
 
-import { omit } from '@styled-system/props'
-
-export const omitStyledProps = omit
+declare module '@styled-system/props' {
+  export function omit(props: any): {}
+}

--- a/www/src/Layout/Navigation/Header.tsx
+++ b/www/src/Layout/Navigation/Header.tsx
@@ -42,8 +42,7 @@ export const HeaderJsx: FC<HeaderProps> = ({ className }) => (
         name="LookerLogo"
         alt="Looker"
         color="text1"
-        width="60px"
-        height="26px"
+        style={{ height: '26px', width: '60px' }}
       />
       <DividerVertical ml="medium" mr="small" />
       <ComponentsLogo />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,6 +2929,13 @@
   dependencies:
     "@styled-system/core" "^5.1.2"
 
+"@styled-system/props@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@styled-system/props/-/props-5.1.5.tgz#f50bf40e8fc8393726f06cbcd096a39a7d779ce4"
+  integrity sha512-FXhbzq2KueZpGaHxaDm8dowIEWqIMcgsKs6tBl6Y6S0njG9vC8dBMI6WSLDnzMoSqIX3nSKHmOmpzpoihdDewg==
+  dependencies:
+    styled-system "^5.1.5"
+
 "@styled-system/shadow@^5.1.2":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@styled-system/shadow/-/shadow-5.1.2.tgz#beddab28d7de03cd0177a87ac4ed3b3b6d9831fd"


### PR DESCRIPTION
### :sparkles: Changes

- Fixed omitStyledProps to properly omit Flex and Border properties on DOM elements

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
