### PR TITLE
Fix ButtonGroup & ButtonToggle display issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- `ButtonGroup`/`ButtonToggle` display issues
+  - Smaller text in Safari and Firefox
+  - White space between highlighted item and border (`ButtonToggle`)
+  - Missing horizontal borders in wrapping `ButtonToggle` when `options` are loaded asynchronously
+
 ## [0.8.7]
 
 ### Added

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -88,6 +88,8 @@ ButtonLayout.displayName = 'ButtonLayout'
 export const buttonItemHeight = 36
 
 export const ButtonItem = styled(ButtonLayout)`
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  margin: 0;
   cursor: pointer;
   height: ${buttonItemHeight}px;
   display: inline-flex;

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -101,20 +101,24 @@ export const ButtonSetLayout = forwardRef(
     }
 
     const [isWrapping, setIsWrapping] = useState(false)
-    const measureRef = useCallback((node: HTMLElement | null) => {
-      if (node) {
-        const { height } = node.getBoundingClientRect()
-        const firstItem = node.childNodes[0] as HTMLElement
-        const rowHeight = firstItem
-          ? firstItem.getBoundingClientRect().height
-          : buttonItemHeight
-        if (height >= rowHeight * 2) {
-          setIsWrapping(true)
-        } else {
-          setIsWrapping(false)
+    const measureRef = useCallback(
+      (node: HTMLElement | null) => {
+        if (node) {
+          const { height } = node.getBoundingClientRect()
+          const firstItem = node.childNodes[0] as HTMLElement
+          const rowHeight = firstItem
+            ? firstItem.getBoundingClientRect().height
+            : buttonItemHeight
+          if (height >= rowHeight * 2) {
+            setIsWrapping(true)
+          } else {
+            setIsWrapping(false)
+          }
         }
-      }
-    }, [])
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [options]
+    )
 
     const ref = useForkedRef(measureRef, forwardedRef)
 

--- a/packages/components/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`ButtonGroup controlled 1`] = `
 .c3 {
+  font-size: 0.875rem;
+  margin: 0;
   cursor: pointer;
   height: 36px;
   display: -webkit-inline-box;

--- a/packages/components/src/Button/__snapshots__/ButtonToggle.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonToggle.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`ButtonToggle controlled 1`] = `
 .c3 {
+  font-size: 0.875rem;
+  margin: 0;
   cursor: pointer;
   height: 36px;
   display: -webkit-inline-box;

--- a/storybook/src/Buttons/ButtonGroup.stories.tsx
+++ b/storybook/src/Buttons/ButtonGroup.stories.tsx
@@ -34,7 +34,7 @@ import {
   Divider,
   ButtonToggle,
 } from '@looker/components'
-import React, { useState, FormEvent } from 'react'
+import React, { useEffect, useState, FormEvent } from 'react'
 
 export const All = () => (
   <Grid columns={1}>
@@ -84,6 +84,59 @@ export const Options = () => {
   return <ButtonGroup options={options} value={value} onChange={setValue} />
 }
 
+const stateOptions = [
+  { label: 'Alabama', value: 'Alabama' },
+  { label: 'Alaska', value: 'Alaska' },
+  { label: 'Arizona', value: 'Arizona' },
+  { label: 'Arkansas', value: 'Arkansas' },
+  { label: 'California', value: 'California' },
+  { label: 'Colorado', value: 'Colorado' },
+  { label: 'Connecticut', value: 'Connecticut' },
+  { label: 'Delaware', value: 'Delaware' },
+  { label: 'Florida', value: 'Florida' },
+  { label: 'Georgia', value: 'Georgia' },
+  { label: 'Hawaii', value: 'Hawaii' },
+  { label: 'Idaho', value: 'Idaho' },
+  { label: 'Illinois', value: 'Illinois' },
+  { label: 'Indiana', value: 'Indiana' },
+  { label: 'Iowa', value: 'Iowa' },
+  { label: 'Kansas', value: 'Kansas' },
+  { label: 'Kentucky', value: 'Kentucky' },
+  { label: 'Louisiana', value: 'Louisiana' },
+  { label: 'Maine', value: 'Maine' },
+  { label: 'Maryland', value: 'Maryland' },
+  { label: 'Massachusetts', value: 'Massachusetts' },
+  { label: 'Michigan', value: 'Michigan' },
+  { label: 'Minnesota', value: 'Minnesota' },
+  { label: 'Mississippi', value: 'Mississippi' },
+  { label: 'Missouri', value: 'Missouri' },
+  { label: 'Montana', value: 'Montana' },
+  { label: 'Nebraska', value: 'Nebraska' },
+  { label: 'Nevada', value: 'Nevada' },
+  { label: 'New Hampshire', value: 'New Hampshire' },
+  { label: 'New Jersey', value: 'New Jersey' },
+  { label: 'New Mexico', value: 'New Mexico' },
+  { label: 'New York', value: 'New York' },
+  { label: 'North Carolina', value: 'North Carolina' },
+  { label: 'North Dakota', value: 'North Dakota' },
+  { label: 'Ohio', value: 'Ohio' },
+  { label: 'Oklahoma', value: 'Oklahoma' },
+  { label: 'Oregon', value: 'Oregon' },
+  { label: 'Pennsylvania', value: 'Pennsylvania' },
+  { label: 'Rhode Island', value: 'Rhode Island' },
+  { label: 'South Carolina', value: 'South Carolina' },
+  { label: 'South Dakota', value: 'South Dakota' },
+  { label: 'Tennessee', value: 'Tennessee' },
+  { label: 'Texas', value: 'Texas' },
+  { label: 'Utah', value: 'Utah' },
+  { label: 'Vermont', value: 'Vermont' },
+  { label: 'Virginia', value: 'Virginia' },
+  { label: 'Washington', value: 'Washington' },
+  { label: 'West Virginia', value: 'West Virginia' },
+  { label: 'Wisconsin', value: 'Wisconsin' },
+  { label: 'Wyoming', value: 'Wyoming' },
+]
+
 export const Wrapping = () => {
   const [border, setBorder] = useState(false)
   const [value, setValue] = useState<string[]>([])
@@ -93,6 +146,16 @@ export const Wrapping = () => {
   function handleChange(e: FormEvent<HTMLInputElement>) {
     setBorder(e.currentTarget.checked)
   }
+
+  const [states, setStates] = useState<Array<{ label: string; value: string }>>(
+    []
+  )
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setStates(stateOptions)
+    }, 1000)
+    return () => clearTimeout(t)
+  }, [])
   return (
     <Space>
       <Box flex={1} border={border ? '1px solid' : 'none'}>
@@ -139,58 +202,12 @@ export const Wrapping = () => {
         </ButtonGroup>
         Inline text
         <Divider my="large" />
-        <ButtonToggle value={toggle2} onChange={setToggle2} nullable>
-          <ButtonItem>Alabama</ButtonItem>
-          <ButtonItem>Alaska</ButtonItem>
-          <ButtonItem>Arizona</ButtonItem>
-          <ButtonItem>Arkansas</ButtonItem>
-          <ButtonItem disabled>California</ButtonItem>
-          <ButtonItem>Colorado</ButtonItem>
-          <ButtonItem>Connecticut</ButtonItem>
-          <ButtonItem>Delaware</ButtonItem>
-          <ButtonItem>Florida</ButtonItem>
-          <ButtonItem>Georgia</ButtonItem>
-          <ButtonItem>Hawaii</ButtonItem>
-          <ButtonItem>Idaho</ButtonItem>
-          <ButtonItem>Illinois</ButtonItem>
-          <ButtonItem>Indiana</ButtonItem>
-          <ButtonItem>Iowa</ButtonItem>
-          <ButtonItem>Kansas</ButtonItem>
-          <ButtonItem>Kentucky</ButtonItem>
-          <ButtonItem>Louisiana</ButtonItem>
-          <ButtonItem>Maine</ButtonItem>
-          <ButtonItem>Maryland</ButtonItem>
-          <ButtonItem>Massachusetts</ButtonItem>
-          <ButtonItem>Michigan</ButtonItem>
-          <ButtonItem>Minnesota</ButtonItem>
-          <ButtonItem>Mississippi</ButtonItem>
-          <ButtonItem>Missouri</ButtonItem>
-          <ButtonItem>Montana</ButtonItem>
-          <ButtonItem>Nebraska</ButtonItem>
-          <ButtonItem>Nevada</ButtonItem>
-          <ButtonItem>New Hampshire</ButtonItem>
-          <ButtonItem>New Jersey</ButtonItem>
-          <ButtonItem>New Mexico</ButtonItem>
-          <ButtonItem>New York</ButtonItem>
-          <ButtonItem>North Carolina</ButtonItem>
-          <ButtonItem>North Dakota</ButtonItem>
-          <ButtonItem>Ohio</ButtonItem>
-          <ButtonItem>Oklahoma</ButtonItem>
-          <ButtonItem>Oregon</ButtonItem>
-          <ButtonItem>Pennsylvania</ButtonItem>
-          <ButtonItem>Rhode Island</ButtonItem>
-          <ButtonItem>South Carolina</ButtonItem>
-          <ButtonItem>South Dakota</ButtonItem>
-          <ButtonItem>Tennessee</ButtonItem>
-          <ButtonItem>Texas</ButtonItem>
-          <ButtonItem>Utah</ButtonItem>
-          <ButtonItem>Vermont</ButtonItem>
-          <ButtonItem>Virginia</ButtonItem>
-          <ButtonItem>Washington</ButtonItem>
-          <ButtonItem>West Virginia</ButtonItem>
-          <ButtonItem>Wisconsin</ButtonItem>
-          <ButtonItem>Wyoming</ButtonItem>
-        </ButtonToggle>
+        <ButtonToggle
+          value={toggle2}
+          onChange={setToggle2}
+          nullable
+          options={states}
+        />
         Inline text
       </Box>
     </Space>


### PR DESCRIPTION
### :sparkles: Changes

- Fixed: Font-size was too small in FF & Safari (browser default)
- Fixed: Awkward white space after highlighted item in `ButtonToggle` (browser default margin)
- Update the "wrapping" check to re-run if `options` prop changes (if it was empty on initial render then enough options were added to make it wrap, the wrapping styles were not applied)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Too-small font:
![image](https://user-images.githubusercontent.com/53451193/84699720-e5e6e380-af06-11ea-8bae-55d34c5af979.png)
#### Awkward white space:
![image](https://user-images.githubusercontent.com/53451193/84699586-9f918480-af06-11ea-943e-1c08324c08d1.png)
#### Missing horizontal border:
![image](https://user-images.githubusercontent.com/53451193/84699672-ca7bd880-af06-11ea-8c28-7a893fc29a2a.png)
