### PR TITLE
Fix SelectMulti create option & filtering keyboard nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Select`/`SelectMulti` keyboard navigation when filtering options
 - `SelectMulti` create option unnecessary left padding
 
+### Removed
+
+- `ComboboxMultiOption` prop `hideCheckMark` (instead use `indicator={false}`)
+
 ## [0.8.7]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Smaller text in Safari and Firefox
   - White space between highlighted item and border (`ButtonToggle`)
   - Missing horizontal borders in wrapping `ButtonToggle` when `options` are loaded asynchronously
+- `Select`/`SelectMulti` keyboard navigation when filtering options
+- `SelectMulti` create option unnecessary left padding
 
 ## [0.8.7]
 

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiOption.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiOption.tsx
@@ -55,9 +55,8 @@ const ComboboxMultiOptionInternal = forwardRef(
       indicator,
       highlightText = true,
       scrollIntoView,
-      hideCheckMark,
       ...props
-    }: ComboboxOptionProps & { hideCheckMark?: boolean },
+    }: ComboboxOptionProps,
     forwardedRef: Ref<HTMLLIElement>
   ) => {
     const { label, value } = props
@@ -94,12 +93,12 @@ const ComboboxMultiOptionInternal = forwardRef(
         aria-selected={isActive}
       >
         <ComboboxOptionIndicator
-          indicator={indicator || (hideCheckMark ? false : undefined)}
+          indicator={indicator}
           isActive={isActive}
           isSelected={isSelected}
           isMulti={true}
         >
-          {!hideCheckMark && <Checkbox checked={isSelected} />}
+          <Checkbox checked={isSelected} />
         </ComboboxOptionIndicator>
         {children || <ComboboxOptionText highlightText={highlightText} />}
       </ComboboxOptionWrapper>

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiOption.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiOption.tsx
@@ -94,7 +94,7 @@ const ComboboxMultiOptionInternal = forwardRef(
         aria-selected={isActive}
       >
         <ComboboxOptionIndicator
-          indicator={indicator}
+          indicator={indicator || (hideCheckMark ? false : undefined)}
           isActive={isActive}
           isSelected={isSelected}
           isMulti={true}

--- a/packages/components/src/Form/Inputs/Combobox/utils/useAddOptionToContext.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useAddOptionToContext.ts
@@ -57,7 +57,7 @@ export function useAddOptionToContext<
     }
     return () => {
       // Delete option from the array but save the index so it can be re-inserted there
-      if (optionsRefCurrent && !windowedOptionsPropRef) {
+      if (optionsRefCurrent && !windowedOptions) {
         const index = optionsRefCurrent.indexOf(option)
         indexRef.current = index
         optionsRefCurrent.splice(index, 1)

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -293,7 +293,11 @@ function SelectMultiCreateOption({
   }
 
   return (
-    <ComboboxMultiOption value={inputValue} highlightText={false} hideCheckMark>
+    <ComboboxMultiOption
+      value={inputValue}
+      highlightText={false}
+      indicator={false}
+    >
       {formatLabel ? formatLabel(inputValue) : `Create "${inputValue}"`}
     </ComboboxMultiOption>
   )


### PR DESCRIPTION
### :sparkles: Changes

- `SelectMulti`: After the changes for `ComboboxOptionIndicator`, the create option had an awkwardly large space to the left – should've just updated it to `indicator={false}` during that change.
- `Select` & `SelectMulti`: Keyboard navigation was broken when filtering due to a typo-esque error during the performance improvements. Added a new test to catch any future breakage.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Both issues:
![issues](https://user-images.githubusercontent.com/53451193/84734151-0c337000-af55-11ea-97fb-95bcd036d33e.gif)
