### PR TITLE
Fix act warnings in all tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Missing horizontal borders in wrapping `ButtonToggle` when `options` are loaded asynchronously
 - `Select`/`SelectMulti` keyboard navigation when filtering options
 - `SelectMulti` create option unnecessary left padding
+- `FieldSelect`/`FieldSelectMulti` missing `aria-labelledby` attribute on the input
 
 ### Removed
 

--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -28,7 +28,11 @@ import 'jest-styled-components'
 import React from 'react'
 import noop from 'lodash/noop'
 import { assertSnapshot, renderWithTheme } from '@looker/components-test-utils'
-import { fireEvent, wait } from '@testing-library/react'
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import { Tooltip } from '../Tooltip'
 import { IconButton } from './IconButton'
 
@@ -151,7 +155,7 @@ test('IconButton renders focus ring on tab input but not on click', () => {
   )
 })
 
-test('IconButton has built-in tooltip', () => {
+test('IconButton has built-in tooltip', async () => {
   const label = 'Mark as my Favorite'
   const { getByTitle, container } = renderWithTheme(
     <IconButton id="test-iconButton" label={label} icon="Favorite" />
@@ -160,11 +164,13 @@ test('IconButton has built-in tooltip', () => {
   const notTooltip = container.querySelector('p') // Get Tooltip content
   expect(notTooltip).toBeNull()
 
-  wait(() => {
-    fireEvent.mouseOver(getByTitle('Favorite'))
-    const tooltip = container.querySelector('p') // Get Tooltip content
-    expect(tooltip).toHaveTextContent(label)
-  })
+  const icon = getByTitle('Favorite')
+  fireEvent.mouseOver(icon)
+  const tooltip = container.querySelector('p') // Get Tooltip content
+  expect(tooltip).toHaveTextContent(label)
+
+  fireEvent.mouseOut(icon)
+  await waitForElementToBeRemoved(() => container.querySelector('p'))
 })
 
 test('IconButton tooltipDisabled actually disables tooltip', () => {
@@ -180,13 +186,11 @@ test('IconButton tooltipDisabled actually disables tooltip', () => {
 
   fireEvent.mouseOver(getByTitle('Favorite'))
 
-  wait(() => {
-    const notTooltip = container.querySelector('p') // Get Tooltip content
-    expect(notTooltip).toBeNull()
-  })
+  const notTooltip = container.querySelector('p') // Get Tooltip content
+  expect(notTooltip).toBeNull()
 })
 
-test('IconButton built-in tooltip defers to outer tooltip', () => {
+test('IconButton built-in tooltip defers to outer tooltip', async () => {
   const tooltip = 'Add to favorites'
   const label = 'Mark as my Favorite'
   const { container, getByText, getByTitle } = renderWithTheme(
@@ -195,15 +199,17 @@ test('IconButton built-in tooltip defers to outer tooltip', () => {
     </Tooltip>
   )
 
-  fireEvent.mouseOver(getByTitle('Favorite'))
+  const icon = getByTitle('Favorite')
+  fireEvent.mouseOver(icon)
 
-  wait(() => {
-    expect(getByText(tooltip)).toBeInTheDocument()
+  expect(getByText(tooltip)).toBeInTheDocument()
 
-    const iconLabel = getByText(label)
-    expect(iconLabel).toBeInTheDocument()
+  const iconLabel = getByText(label)
+  expect(iconLabel).toBeInTheDocument()
 
-    const tooltipContents = container.querySelectorAll('p') // Get all Tooltip contents
-    expect(tooltipContents.length).toEqual(1)
-  })
+  const tooltipContents = container.querySelectorAll('p') // Get all Tooltip contents
+  expect(tooltipContents.length).toEqual(1)
+
+  fireEvent.mouseOut(icon)
+  await waitForElementToBeRemoved(() => container.querySelector('p'))
 })

--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -28,11 +28,7 @@ import 'jest-styled-components'
 import React from 'react'
 import noop from 'lodash/noop'
 import { assertSnapshot, renderWithTheme } from '@looker/components-test-utils'
-import {
-  fireEvent,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
 import { Tooltip } from '../Tooltip'
 import { IconButton } from './IconButton'
 

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.test.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.test.tsx
@@ -84,7 +84,7 @@ test('A required FieldSelect', () => {
 })
 
 test('A FieldSelect with an error validation aligned to the bottom', () => {
-  const { getByLabelText, getByText } = renderWithTheme(
+  const { getAllByLabelText, getByText } = renderWithTheme(
     <FieldSelect
       label="thumbs up"
       name="thumbsUp"
@@ -92,7 +92,7 @@ test('A FieldSelect with an error validation aligned to the bottom', () => {
       validationMessage={{ message: 'This is an error', type: 'error' }}
     />
   )
-  expect(getByLabelText('thumbs up')).toBeVisible()
+  expect(getAllByLabelText('thumbs up')[1]).toBeVisible()
   expect(getByText('This is an error')).toBeVisible()
 })
 

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.tsx
@@ -46,6 +46,7 @@ const FieldSelectComponent = forwardRef(
         <Select
           {...omitFieldProps(props)}
           aria-describedby={`${id}-describedby`}
+          aria-labelledby={`${id}-labelledby`}
           id={id}
           validationType={validationMessage && validationMessage.type}
           ref={ref}

--- a/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldSelect/__snapshots__/FieldSelect.test.tsx.snap
@@ -270,6 +270,7 @@ exports[`A FieldSelect 1`] = `
           <input
             aria-autocomplete="both"
             aria-describedby="thumbs-up-describedby"
+            aria-labelledby="thumbs-up-labelledby"
             autoComplete="off"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -648,6 +649,7 @@ exports[`A FieldSelect with an error validation aligned to the right 1`] = `
           <input
             aria-autocomplete="both"
             aria-describedby="thumbs-up-describedby"
+            aria-labelledby="thumbs-up-labelledby"
             autoComplete="off"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -1013,6 +1015,7 @@ exports[`A required FieldSelect 1`] = `
           <input
             aria-autocomplete="both"
             aria-describedby="thumbs-up-describedby"
+            aria-labelledby="thumbs-up-labelledby"
             autoComplete="off"
             id="listbox-thumbs-up"
             onBlur={[Function]}
@@ -1326,6 +1329,7 @@ exports[`FieldSelect supports labelWeight 1`] = `
           <input
             aria-autocomplete="both"
             aria-describedby="thumbs-up-describedby"
+            aria-labelledby="thumbs-up-labelledby"
             autoComplete="off"
             id="listbox-thumbs-up"
             onBlur={[Function]}

--- a/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.test.tsx
+++ b/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.test.tsx
@@ -25,90 +25,98 @@
  */
 
 import React from 'react'
-import { mountWithTheme, renderWithTheme } from '@looker/components-test-utils'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { fireEvent, screen } from '@testing-library/react'
 import { FieldSelectMulti } from './FieldSelectMulti'
 
-const FieldSelectMultiOptions = [
+const fieldSelectMultiOptions = [
   { label: 'Apples', value: '1' },
   { label: 'Bananas', value: '2' },
   { label: 'Oranges', value: '3' },
 ]
 
 test('FieldSelectMulti should accept detail and description attributes', () => {
-  const { getByLabelText } = renderWithTheme(
+  renderWithTheme(
     <FieldSelectMulti
       detail="5/50"
       description="this is the description"
       label="👍"
       name="thumbsUp"
       id="thumbs-up"
-      options={FieldSelectMultiOptions}
+      options={fieldSelectMultiOptions}
     />
   )
 
-  const input = getByLabelText('👍')
+  const input = screen.getAllByLabelText('👍')[1]
   expect(input.getAttribute('detail')).toBeDefined()
   expect(input.getAttribute('description')).toBeDefined()
 })
 
 test('FieldSelectMulti should accept a disabled prop', () => {
-  const { getByLabelText } = renderWithTheme(
+  renderWithTheme(
     <FieldSelectMulti
       disabled
       id="test"
       label="Test Label"
       name="test"
-      options={FieldSelectMultiOptions}
+      options={fieldSelectMultiOptions}
     />
   )
 
-  const input = getByLabelText('Test Label')
+  const input = screen.getAllByLabelText('Test Label')[1]
   expect(input.getAttribute('disabled')).toBeDefined()
 })
 
 test('FieldSelectMulti should accept required attributes', () => {
-  const { getByText } = renderWithTheme(
+  renderWithTheme(
     <FieldSelectMulti
       label="👍"
       name="thumbsUp"
       id="thumbs-up"
-      options={FieldSelectMultiOptions}
+      options={fieldSelectMultiOptions}
       required
     />
   )
-  expect(getByText('required')).toBeVisible()
+  expect(screen.getByText('required')).toBeVisible()
 })
 
 test('FieldSelectMulti should display error message', () => {
   const errorMessage = 'This is an error'
 
-  const { getByText } = renderWithTheme(
+  renderWithTheme(
     <FieldSelectMulti
       id="testFieldSelectMulti"
       label="Label"
       name="test"
-      options={FieldSelectMultiOptions}
+      options={fieldSelectMultiOptions}
       validationMessage={{ message: errorMessage, type: 'error' }}
     />
   )
 
-  expect(getByText('This is an error')).toBeVisible()
+  expect(screen.getByText('This is an error')).toBeVisible()
 })
 
 test('FieldSelectMulti Should trigger onChange handler', () => {
   const handleChange = jest.fn()
 
-  const wrapper = mountWithTheme(
+  renderWithTheme(
     <FieldSelectMulti
       label="👍"
       name="thumbsUp"
       id="thumbs-up"
       onChange={handleChange}
-      options={FieldSelectMultiOptions}
+      options={fieldSelectMultiOptions}
     />
   )
 
-  wrapper.find('input').simulate('mousedown')
-  wrapper.find('li').at(0).simulate('click')
+  // The combobox container and the input share the label
+  const input = screen.getAllByLabelText('👍')[1]
+  fireEvent.click(input)
+
+  const apples = screen.getByText('Apples')
+  fireEvent.click(apples)
+
   expect(handleChange).toHaveBeenCalledTimes(1)
+
+  fireEvent.click(document)
 })

--- a/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.tsx
+++ b/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.tsx
@@ -47,6 +47,7 @@ const FieldSelectMultiComponent = forwardRef(
         <SelectMulti
           {...omitFieldProps(props)}
           aria-describedby={`${id}-describedby`}
+          aria-labelledby={`${id}-labelledby`}
           id={id}
           validationType={validationMessage && validationMessage.type}
           ref={ref}

--- a/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.test.tsx
+++ b/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.test.tsx
@@ -76,11 +76,13 @@ describe('prop: format', () => {
   test('formats options in 12 hour time', () => {
     const domList = renderListContent({ format: '12h' })
     expect(extractTextFromDomList(domList)).toMatchSnapshot()
+    fireEvent.click(document)
   })
 
   test('formats options in 24 hour time', () => {
     const domList = renderListContent({ format: '24h' })
     expect(extractTextFromDomList(domList)).toMatchSnapshot()
+    fireEvent.click(document)
   })
 })
 
@@ -88,19 +90,23 @@ describe('prop: interval', () => {
   test('renders 5-minute intervals', () => {
     const domList = renderListContent({ interval: 5 })
     expect(extractTextFromDomList(domList)).toMatchSnapshot()
+    fireEvent.click(document)
   })
 
   test('renders 10-minute intervals', () => {
     const domList = renderListContent({ interval: 10 })
     expect(extractTextFromDomList(domList)).toMatchSnapshot()
+    fireEvent.click(document)
   })
   test('renders 15-minute intervals', () => {
     const domList = renderListContent({ interval: 15 })
     expect(extractTextFromDomList(domList)).toMatchSnapshot()
+    fireEvent.click(document)
   })
   test('renders 30-minute intervals', () => {
     const domList = renderListContent({ interval: 30 })
     expect(extractTextFromDomList(domList)).toMatchSnapshot()
+    fireEvent.click(document)
   })
 })
 
@@ -119,6 +125,8 @@ describe('text input', () => {
     fireEvent.keyDown(inputBox, { key: 'Enter' })
 
     expect(handleChange).toHaveBeenLastCalledWith('14:00')
+
+    fireEvent.click(document)
   })
 })
 
@@ -128,6 +136,7 @@ describe('keyboard nav ux', () => {
     const domList = renderListContent({})
     const selected = domList.querySelector('[aria-selected="true"]')
     expect((selected as HTMLElement).textContent).toMatchSnapshot()
+    fireEvent.click(document)
   })
 
   test('highlights selected value when list is opened', () => {
@@ -137,11 +146,13 @@ describe('keyboard nav ux', () => {
     })
     const selected = domList.querySelector('[aria-selected="true"]')
     expect((selected as HTMLElement).textContent).toMatchSnapshot()
+    fireEvent.click(document)
   })
 
   test('highlights closest time to selected value when list is opened but value does not match provided options', () => {
     const domList = renderListContent({ onChange: jest.fn(), value: '16:38' })
     const selected = domList.querySelector('[aria-selected="true"]')
     expect((selected as HTMLElement).textContent).toMatchSnapshot()
+    fireEvent.click(document)
   })
 })

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
@@ -174,7 +174,6 @@ describe('closeOnSelect', () => {
     expect(getByText('Foo')).toBeVisible()
     expect(getAllByText('Bar')).toHaveLength(2)
 
-    // Close popover to silence act() warning
     fireEvent.click(document)
   })
 
@@ -196,6 +195,8 @@ describe('closeOnSelect', () => {
     expect(getByText('Bar')).toBeVisible()
     // list has closed
     expect(queryByText('Foo')).not.toBeInTheDocument()
+
+    fireEvent.click(document)
   })
 
   describe('removeOnBackspace', () => {
@@ -262,6 +263,8 @@ describe('closeOnSelect', () => {
 
       expect(onChangeMock).not.toHaveBeenCalled()
       expect(input).toHaveValue('baz,qux,')
+
+      fireEvent.click(document)
     })
 
     test('true', () => {
@@ -281,6 +284,8 @@ describe('closeOnSelect', () => {
 
       expect(onChangeMock).toHaveBeenCalledWith(['FOO', 'BAR', 'baz', 'qux'])
       expect(input).toHaveValue('')
+
+      fireEvent.click(document)
     })
   })
 })

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -25,7 +25,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
 import React, { useRef } from 'react'
 
 import { renderWithTheme } from '@looker/components-test-utils'
@@ -44,7 +44,6 @@ const menu = (
   </Menu>
 )
 
-// Note to self: use "yarn jest Menu.test" to run Menu.test.tsx
 describe('<Menu />', () => {
   test('Menu Opens and Closes', () => {
     const { getByText, queryByText } = renderWithTheme(menu)
@@ -62,16 +61,22 @@ describe('<Menu />', () => {
     expect(queryByText('Swiss')).not.toBeInTheDocument()
   })
 
-  test('Menu Button has the tooltip', () => {
+  test('Menu Button has the tooltip', async () => {
     const { getByText, queryByText } = renderWithTheme(menu)
 
     const button = getByText('Cheese')
 
     expect(queryByText('Select your favorite kind')).not.toBeInTheDocument()
 
-    button.focus()
+    fireEvent.mouseOver(button)
 
     expect(queryByText('Select your favorite kind')).toBeInTheDocument()
+
+    fireEvent.mouseOut(button)
+
+    await waitForElementToBeRemoved(() =>
+      queryByText('Select your favorite kind')
+    )
   })
 
   test('closes on MenuItem click', () => {
@@ -110,6 +115,8 @@ describe('<Menu />', () => {
 
     expect(defaultPreventedItem).not.toBeInTheDocument()
     expect(item).not.toBeInTheDocument()
+
+    fireEvent.click(document)
   })
 
   test('Disabled Menu does not open when clicked and has disabled prop', () => {
@@ -134,6 +141,8 @@ describe('<Menu />', () => {
     fireEvent.click(button)
 
     expect(queryByText('Swiss')).not.toBeInTheDocument()
+
+    fireEvent.click(document)
   })
 
   test('Starting with Menu open', () => {
@@ -150,6 +159,8 @@ describe('<Menu />', () => {
     )
 
     expect(getByText('Swiss')).toBeInTheDocument()
+
+    fireEvent.click(document)
   })
 
   test('MenuDisclosure is shown/hidden on hover of hoverDisclosureRef', () => {
@@ -188,5 +199,7 @@ describe('<Menu />', () => {
     expect(queryByText('Gouda')).not.toBeInTheDocument()
     fireEvent.click(triggerNew) // open Menu
     expect(queryByText('Gouda')).toBeInTheDocument()
+
+    fireEvent.click(document)
   })
 })

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -115,6 +115,8 @@ describe('Popover', () => {
     fireEvent.click(trigger)
     expect(getByText('simple content')).toBeInTheDocument()
     expect(mockContainerOnClick).not.toHaveBeenCalled()
+
+    fireEvent.click(document)
   })
 
   test('Open popover cancels event on "dismissal click"', () => {
@@ -205,5 +207,7 @@ describe('Popover', () => {
     expect(queryByText('simple content')).not.toBeInTheDocument()
     fireEvent.click(triggerNew) // open Popover
     expect(queryByText('simple content')).toBeInTheDocument()
+
+    fireEvent.click(document)
   })
 })

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -55,8 +55,8 @@ describe('Tooltip', () => {
 
     fireEvent.mouseOver(trigger)
 
-    const tooltip = screen.queryByText('Hello world')
-    expect(tooltip).toBeVisible()
+    const tooltip = screen.getByText('Hello world')
+    expect(tooltip.parentNode).toMatchSnapshot()
 
     fireEvent.mouseOut(trigger)
     expect(tooltip).not.toBeInTheDocument()

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -46,7 +46,7 @@ describe('Tooltip', () => {
 
   test('trigger: open on mouseover, close on mouseout', () => {
     renderWithTheme(
-      <Tooltip content="Hello world">
+      <Tooltip content="Hello world" id="stable-id">
         <Button>Test</Button>
       </Tooltip>
     )

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -26,18 +26,10 @@
 
 import 'jest-styled-components'
 import React from 'react'
-import {
-  mountWithTheme,
-  assertSnapshotShallow,
-} from '@looker/components-test-utils'
-
-import { Box } from '../Layout'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { fireEvent, screen } from '@testing-library/react'
 import { Button } from '../Button'
-import { OverlaySurface } from '../Overlay/OverlaySurface'
-import { Popover } from '../Popover'
 import { Tooltip } from './Tooltip'
-import { TooltipContent } from './TooltipContent'
-import { mouseEventSimulator } from './tooltip.test.helpers'
 
 describe('Tooltip', () => {
   let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>
@@ -52,157 +44,91 @@ describe('Tooltip', () => {
     rafSpy.mockRestore()
   })
 
-  test('snapshot', () => {
-    assertSnapshotShallow(
-      <Tooltip content="Hello world" isOpen>
-        <Button>Example</Button>
-      </Tooltip>
-    )
-  })
-
-  test('Tooltip can hide its arrow', () => {
-    assertSnapshotShallow(
-      <Tooltip content="Hello world" arrow={false} isOpen>
-        <Button>Example</Button>
-      </Tooltip>
-    )
-  })
-
   test('trigger: open on mouseover, close on mouseout', () => {
-    const tooltip = mountWithTheme(
+    renderWithTheme(
       <Tooltip content="Hello world">
         <Button>Test</Button>
       </Tooltip>
     )
 
-    const trigger = tooltip.find(Button)
+    const trigger = screen.getByText('Test')
 
-    trigger.simulate('mouseover', mouseEventSimulator)
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.exists()).toBeTruthy()
+    fireEvent.mouseOver(trigger)
 
-    trigger.simulate('mouseout', mouseEventSimulator)
-    const postMouseoutSurface = tooltip.find(OverlaySurface)
-    expect(postMouseoutSurface.exists()).toBeFalsy()
+    const tooltip = screen.queryByText('Hello world')
+    expect(tooltip).toBeVisible()
+
+    fireEvent.mouseOut(trigger)
+    expect(tooltip).not.toBeInTheDocument()
   })
 
   test('close on surface mouseout', () => {
-    const tooltip = mountWithTheme(
+    renderWithTheme(
       <Tooltip content="Hello world" isOpen>
         <Button>Test</Button>
       </Tooltip>
     )
 
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.exists()).toBeTruthy()
-    surface.simulate('mouseout', mouseEventSimulator)
+    const trigger = screen.getByText('Test')
 
-    const postMouseoutSurface = tooltip.find(OverlaySurface)
-    expect(postMouseoutSurface.exists()).toBeFalsy()
-  })
+    fireEvent.mouseOver(trigger)
 
-  test('contains content', () => {
-    const tooltip = mountWithTheme(
-      <Tooltip content="Hello world">
-        <Button>Test</Button>
-      </Tooltip>
-    )
+    const tooltip = screen.getByText('Hello world')
+    expect(tooltip).toBeVisible()
 
-    const trigger = tooltip.find(Button)
-    trigger.simulate('mouseover', mouseEventSimulator)
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.text()).toEqual('Hello world')
+    fireEvent.mouseOut(tooltip)
+    expect(tooltip).not.toBeInTheDocument()
   })
 
   test('open initially, collapse on mouseout', () => {
-    const tooltip = mountWithTheme(
+    renderWithTheme(
       <Tooltip content="Hello world" isOpen>
         <Button>Test</Button>
       </Tooltip>
     )
 
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.exists()).toBeTruthy()
+    const trigger = screen.getByText('Test')
+    const tooltip = screen.queryByText('Hello world')
+    expect(tooltip).toBeVisible()
 
-    const trigger = tooltip.find(Button)
-    trigger.simulate('mouseout', mouseEventSimulator)
-
-    const postMouseoutSurface = tooltip.find(OverlaySurface)
-    expect(postMouseoutSurface.exists()).toBeFalsy()
+    fireEvent.mouseOut(trigger)
+    expect(tooltip).not.toBeInTheDocument()
   })
 
   test('supports styling props', () => {
-    const tooltip = mountWithTheme(
+    renderWithTheme(
       <Tooltip content="Hello world" width="20rem" textAlign="right">
         <Button>Test</Button>
       </Tooltip>
     )
 
-    const trigger = tooltip.find(Button)
+    const trigger = screen.getByText('Test')
 
-    trigger.simulate('mouseover', mouseEventSimulator)
+    fireEvent.mouseOver(trigger)
 
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.exists()).toBeTruthy()
+    const tooltip = screen.queryByText('Hello world')
+    expect(tooltip).toBeVisible()
 
-    const content = surface.find(TooltipContent)
-    expect(content.props().width).toEqual('20rem')
-    expect(content.props().textAlign).toEqual('right')
-  })
-
-  test('tooltip can exceed bounds of containing overlay', () => {
-    const tooltip = (
-      <Tooltip content="Great knowledge here!" isOpen>
-        <Box>I wish I knew more about this...</Box>
-      </Tooltip>
-    )
-
-    const popover = (
-      <Popover isOpen content={tooltip}>
-        {(onClick, ref) => (
-          <Button onClick={onClick} ref={ref}>
-            Test
-          </Button>
-        )}
-      </Popover>
-    )
-
-    assertSnapshotShallow(popover)
+    expect(tooltip).toHaveStyle('max-width: 20rem')
+    expect(tooltip).toHaveStyle('text-align: right')
+    fireEvent.mouseOut(trigger)
   })
 
   test('Render props version works', () => {
-    const tooltip = mountWithTheme(
+    renderWithTheme(
       <Tooltip content="Hello world">
         {(props) => <Button {...props}>Test</Button>}
       </Tooltip>
     )
 
-    const trigger = tooltip.find(Button)
+    const trigger = screen.getByText('Test')
 
-    trigger.simulate('mouseover', mouseEventSimulator)
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.exists()).toBeTruthy()
+    fireEvent.mouseOver(trigger)
 
-    trigger.simulate('mouseout', mouseEventSimulator)
-    const postMouseoutSurface = tooltip.find(OverlaySurface)
-    expect(postMouseoutSurface.exists()).toBeFalsy()
-  })
+    const tooltip = screen.queryByText('Hello world')
+    expect(tooltip).toBeVisible()
 
-  test('Render props version works', () => {
-    const tooltip = mountWithTheme(
-      <Tooltip content="Hello world">
-        {(props) => <Button {...props}>Test</Button>}
-      </Tooltip>
-    )
-
-    const trigger = tooltip.find(Button)
-
-    trigger.simulate('mouseover', mouseEventSimulator)
-    const surface = tooltip.find(OverlaySurface)
-    expect(surface.exists()).toBeTruthy()
-
-    trigger.simulate('mouseout', mouseEventSimulator)
-    const postMouseoutSurface = tooltip.find(OverlaySurface)
-    expect(postMouseoutSurface.exists()).toBeFalsy()
+    fireEvent.mouseOut(trigger)
+    expect(tooltip).not.toBeInTheDocument()
   })
 })

--- a/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
   <p
     class="c1"
     font-size="xsmall"
-    id="0ac6327b-c4f0-4e71-aba9-b55376f5e344"
+    id="stable-id"
     role="tooltip"
     width="auto"
   >

--- a/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Tooltip Tooltip can hide its arrow 1`] = `ShallowWrapper {}`;
-
-exports[`Tooltip snapshot 1`] = `ShallowWrapper {}`;
-
-exports[`Tooltip tooltip can exceed bounds of containing overlay 1`] = `ShallowWrapper {}`;

--- a/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
   <p
     class="c1"
     font-size="xsmall"
-    id="28a44c81-38f5-4c22-80b3-bfe37f24ab86"
+    id="0ac6327b-c4f0-4e71-aba9-b55376f5e344"
     role="tooltip"
     width="auto"
   >

--- a/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
+.c2 {
+  position: absolute;
+}
+
+.c2::before {
+  content: '';
+  display: block;
+  margin: auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: #262D33;
+  color: #FFFFFF;
+  border-radius: 0.25rem;
+  border-top: none;
+  border-left: none;
+  border-radius: 0;
+}
+
+.c2[data-placement*='top'] {
+  bottom: -0.25rem;
+}
+
+.c2[data-placement*='top']::before {
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c2[data-placement*='right'] {
+  left: -0.25rem;
+}
+
+.c2[data-placement*='right']::before {
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+}
+
+.c2[data-placement*='bottom'] {
+  top: -0.25rem;
+}
+
+.c2[data-placement*='bottom']::before {
+  -webkit-transform: rotate(225deg);
+  -ms-transform: rotate(225deg);
+  transform: rotate(225deg);
+}
+
+.c2[data-placement*='left'] {
+  right: -0.25rem;
+}
+
+.c2[data-placement*='left']::before {
+  -webkit-transform: rotate(315deg);
+  -ms-transform: rotate(315deg);
+  transform: rotate(315deg);
+}
+
+.c0 {
+  border-radius: 0.25rem;
+  box-shadow: 0 3px 18px rgba(0,0,0,0.12),0 1px 4px rgba(0,0,0,0.04);
+  background-color: #262D33;
+  color: #FFFFFF;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c1 {
+  text-align: center;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  margin: 0rem;
+  padding: 0.5rem;
+  width: auto;
+  max-width: 16rem;
+  white-space: normal;
+  text-transform: none;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  overflow-wrap: anywhere;
+}
+
+.c1 .c3 {
+  color: #E8E5FF;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1 .c3:focus,
+.c1 .c3:hover {
+  color: #F3F2FF;
+}
+
+.c1 .c3:active {
+  color: #FFFFFF;
+}
+
+<div
+  class="c0"
+  color="inverseOn"
+>
+  <p
+    class="c1"
+    font-size="xsmall"
+    id="28a44c81-38f5-4c22-80b3-bfe37f24ab86"
+    role="tooltip"
+    width="auto"
+  >
+    Hello world
+  </p>
+  <div
+    class="c2"
+    color="inverseOn"
+    data-placement="bottom"
+    style="position: absolute;"
+  />
+</div>
+`;


### PR DESCRIPTION
### :sparkles: Changes

- Fixed act warnings in all tests
- Added an `aria-label` to `FieldSelect` & `FieldSelectMulti` when fixing the test revealed that the input couldn't be found via the label.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
