### PR TITLE
Stop TSC from emitting test definitions

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,5 +4,5 @@
     "declaration": true,
     "emitDeclarationOnly": true
   },
-  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts",  "**/*.test.tsx"]
 }


### PR DESCRIPTION
### :sparkles: Changes

- Stop TSC from emitting test definitions

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
