### PR TITLE
Fail Jest tests if an underlying library (e.g.: React) is throwing co…

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -24,6 +24,7 @@
 
  */
 
+import { format } from 'util'
 import Adapter from 'enzyme-adapter-react-16'
 import { configure } from 'enzyme'
 
@@ -45,6 +46,17 @@ globalAny.IntersectionObserver = observeMock
 
 // js-dom doesn't do scrollIntoView
 Element.prototype.scrollIntoView = jest.fn()
+
+/**
+ * Throw a hard-error if an underlying library (e.g.: React) is throwing console.error
+ * Inspired by: https://github.com/facebook/jest/issues/6121#issuecomment-529591574
+ */
+const error = global.console.error
+
+global.console.error = function (...args) {
+  error(...args)
+  throw new Error(format(...args))
+}
 
 beforeAll(() => {
   jest.resetAllMocks()


### PR DESCRIPTION
### :sparkles: Changes

- Fail Jest tests if an underlying library (e.g.: React) is throwing console.error

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
