### PR TITLE
FieldTextArea now properly links label + textarea via "id" assignment to textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -602,6 +602,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `FieldTextArea` now properly links label + textarea via `id` assignment to textarea
 - `MenuItem` improved for use-case where itemRole="link" interacted poorly with unrelated CSS in applying :hover and :focus pseudo-styles
 
 ## [0.7.13] - 2020-01-16

--- a/packages/components/src/Form/Fields/FieldTextArea/FieldTextArea.tsx
+++ b/packages/components/src/Form/Fields/FieldTextArea/FieldTextArea.tsx
@@ -44,6 +44,7 @@ const FieldTextAreaComponent: FC<FieldTextAreaProps> = ({ ...props }) => {
     >
       <TextArea
         {...omitFieldProps(props)}
+        id={id}
         aria-describedby={`${id}-describedby`}
         validationType={validationMessage && validationMessage.type}
       />

--- a/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`A FieldTextArea with default label 1`] = `
     >
       <textarea
         aria-describedby="FieldTextAreaID-describedby"
+        id="FieldTextAreaID"
       />
     </div>
   </div>
@@ -256,6 +257,7 @@ exports[`A FieldTextArea with label inline 1`] = `
     >
       <textarea
         aria-describedby="FieldTextAreaID-describedby"
+        id="FieldTextAreaID"
       />
     </div>
   </div>


### PR DESCRIPTION
### :sparkles: Changes

- FieldTextArea` now properly links label + textarea via `id` assignment to textarea

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
