### PR TITLE
IconButton improved hover/active states and no background on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Switch from using defaultProps to `css` block to share common styles with other components
 - `TextArea` interface simplified / narrowed
   - No longer supports border or typography props
+- `IconButton` improved hover/active states and no background on hover
 
 ### Fixed
 

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -50,6 +50,8 @@ import { VisuallyHidden } from '../VisuallyHidden'
 import { ButtonBase, ButtonBaseProps, buttonCSS } from './ButtonBase'
 import { buttonSizeMap } from './size'
 
+const iconButtonDefaultColor = 'default'
+
 interface IconButtonVariantProps {
   /**
    * Defines the color of the button. Can be the string name of a color listed in the color theme, or a color object.
@@ -195,7 +197,7 @@ const IconButtonComponent = forwardRef(
 IconButtonComponent.displayName = 'IconButtonComponent'
 
 const outlineCSS = (props: IconButtonProps) => {
-  const { shape, color } = props
+  const { shape, color = iconButtonDefaultColor } = props
 
   return css`
     border: 1px solid ${({ theme: { colors } }) => colors.ui3};
@@ -222,29 +224,27 @@ const outlineCSS = (props: IconButtonProps) => {
   `
 }
 
-export const IconButton = styled(IconButtonComponent).attrs((props) => {
-  return {
-    color: props.color || 'neutral',
-  }
-})<IconButtonProps>`
+export const IconButton = styled(IconButtonComponent)<IconButtonProps>`
   ${reset}
   ${space}
   /* remove padding applied to transparent buttons, so icon size is preserved correctly */
 
   background: none;
   border: none;
-  color: ${({ theme, color }) => theme.colors[color]};
+  color: ${({ theme, color = iconButtonDefaultColor }) => theme.colors[color]};
   padding: 0;
 
   &:hover,
   &:focus,
   &.hover {
-    color: ${({ theme, color }) => theme.colors[`${color}Interactive`]};
+    color: ${({ theme, color = iconButtonDefaultColor }) =>
+      theme.colors[`${color}Interactive`]};
   }
 
   &:active,
   &.active {
-    color: ${({ theme, color }) => theme.colors[`${color}Pressed`]};
+    color: ${({ theme, color = iconButtonDefaultColor }) =>
+      theme.colors[`${color}Pressed`]};
   }
 
   ${(props) => props.outline && outlineCSS}

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -47,8 +47,7 @@ import { Icon } from '../Icon'
 import { useTooltip } from '../Tooltip'
 import { useForkedRef, useWrapEvent } from '../utils'
 import { VisuallyHidden } from '../VisuallyHidden'
-import { ButtonBaseProps, buttonCSS } from './ButtonBase'
-import { ButtonTransparent } from './ButtonTransparent'
+import { ButtonBase, ButtonBaseProps, buttonCSS } from './ButtonBase'
 import { buttonSizeMap } from './size'
 
 interface IconButtonVariantProps {
@@ -175,7 +174,7 @@ const IconButtonComponent = forwardRef(
     const actualRef = useForkedRef<HTMLButtonElement>(forwardRef, ref)
 
     return (
-      <ButtonTransparent
+      <ButtonBase
         aria-describedby={ariaDescribedBy}
         ref={actualRef}
         color={color}
@@ -188,7 +187,7 @@ const IconButtonComponent = forwardRef(
         <VisuallyHidden>{label}</VisuallyHidden>
         <Icon name={icon} size={buttonSizeMap[size] - 6} aria-hidden={true} />
         {tooltip}
-      </ButtonTransparent>
+      </ButtonBase>
     )
   }
 )
@@ -196,10 +195,11 @@ const IconButtonComponent = forwardRef(
 IconButtonComponent.displayName = 'IconButtonComponent'
 
 const outlineCSS = (props: IconButtonProps) => {
-  const { color = 'key' } = props
+  const { shape, color = 'key' } = props
 
   return css`
     border: 1px solid ${({ theme: { colors } }) => colors.ui3};
+    ${shape === 'round' && 'border-radius: 100%;'}
 
     &:hover,
     &:focus,
@@ -226,13 +226,29 @@ export const IconButton = styled(IconButtonComponent)<IconButtonProps>`
   ${reset}
   ${space}
   /* remove padding applied to transparent buttons, so icon size is preserved correctly */
+
+  background: none;
+  border: none;
+  color: ${({ theme, color = 'neutral' }) => theme.colors[color]};
   padding: 0;
+
+  &:hover,
+  &:focus,
+  &.hover {
+    color: ${({ theme, color = 'neutral' }) =>
+      theme.colors[`${color}Interactive`]};
+  }
+
+  &:active,
+  &.active {
+    color: ${({ theme, color = 'neutral' }) => theme.colors[`${color}Pressed`]};
+  }
+
   ${(props) => props.outline && outlineCSS}
-  ${({ shape }) => shape === 'round' && 'border-radius: 100%;'}
 
   svg {
     pointer-events: none;
   }
 `
 
-IconButton.defaultProps = { color: 'neutral', type: 'button' }
+IconButton.defaultProps = { type: 'button' }

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -50,7 +50,7 @@ import { VisuallyHidden } from '../VisuallyHidden'
 import { ButtonBase, ButtonBaseProps, buttonCSS } from './ButtonBase'
 import { buttonSizeMap } from './size'
 
-const iconButtonDefaultColor = 'default'
+const iconButtonDefaultColor = 'neutral'
 
 interface IconButtonVariantProps {
   /**

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -195,7 +195,7 @@ const IconButtonComponent = forwardRef(
 IconButtonComponent.displayName = 'IconButtonComponent'
 
 const outlineCSS = (props: IconButtonProps) => {
-  const { shape, color = 'key' } = props
+  const { shape, color } = props
 
   return css`
     border: 1px solid ${({ theme: { colors } }) => colors.ui3};
@@ -222,26 +222,29 @@ const outlineCSS = (props: IconButtonProps) => {
   `
 }
 
-export const IconButton = styled(IconButtonComponent)<IconButtonProps>`
+export const IconButton = styled(IconButtonComponent).attrs((props) => {
+  return {
+    color: props.color || 'neutral',
+  }
+})<IconButtonProps>`
   ${reset}
   ${space}
   /* remove padding applied to transparent buttons, so icon size is preserved correctly */
 
   background: none;
   border: none;
-  color: ${({ theme, color = 'neutral' }) => theme.colors[color]};
+  color: ${({ theme, color }) => theme.colors[color]};
   padding: 0;
 
   &:hover,
   &:focus,
   &.hover {
-    color: ${({ theme, color = 'neutral' }) =>
-      theme.colors[`${color}Interactive`]};
+    color: ${({ theme, color }) => theme.colors[`${color}Interactive`]};
   }
 
   &:active,
   &.active {
-    color: ${({ theme, color = 'neutral' }) => theme.colors[`${color}Pressed`]};
+    color: ${({ theme, color }) => theme.colors[`${color}Pressed`]};
   }
 
   ${(props) => props.outline && outlineCSS}

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -769,12 +769,12 @@ exports[`IconButton outline 1`] = `
 .c2:hover,
 .c2:focus,
 .c2.hover {
-  border-color: #6C43E0;
+  border-color: #939BA5;
 }
 
 .c2:active,
 .c2.active {
-  border-color: #4F2ABA;
+  border-color: #707781;
 }
 
 .c2[disabled]:hover,

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`IconButton accepts events 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
+  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -368,6 +369,7 @@ exports[`IconButton accepts events 2`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
+  color="neutral"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -504,6 +506,7 @@ exports[`IconButton allows for ARIA attributes 1`] = `
   aria-describedby="test-iconButton-tooltip"
   aria-haspopup={true}
   className="c0 c1 c2"
+  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -638,6 +641,7 @@ exports[`IconButton default 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
+  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -790,6 +794,7 @@ exports[`IconButton outline 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
+  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -1194,6 +1199,7 @@ exports[`IconButton resized 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
+  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -59,39 +59,9 @@ exports[`IconButton accepts color 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #CC1F36;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FFF2F4;
-  border-color: #FFF2F4;
-  color: #ED3B53;
-}
-
-.c1:active,
-.c1.active {
-  background: #FFE5E9;
-  border-color: #FFE5E9;
-  color: #ED3B53;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #CC1F36;
 }
 
 .c3 {
@@ -104,7 +74,21 @@ exports[`IconButton accepts color 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #CC1F36;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #B2121F;
+}
+
+.c2:active,
+.c2.active {
+  color: #990F14;
 }
 
 .c2 svg {
@@ -210,39 +194,9 @@ exports[`IconButton accepts events 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c1:active,
-.c1.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c3 {
@@ -255,7 +209,21 @@ exports[`IconButton accepts events 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -265,7 +233,6 @@ exports[`IconButton accepts events 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -362,39 +329,9 @@ exports[`IconButton accepts events 2`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c1:active,
-.c1.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c3 {
@@ -407,7 +344,21 @@ exports[`IconButton accepts events 2`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -417,7 +368,6 @@ exports[`IconButton accepts events 2`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -514,39 +464,9 @@ exports[`IconButton allows for ARIA attributes 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c1:active,
-.c1.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c3 {
@@ -559,7 +479,21 @@ exports[`IconButton allows for ARIA attributes 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -570,7 +504,6 @@ exports[`IconButton allows for ARIA attributes 1`] = `
   aria-describedby="test-iconButton-tooltip"
   aria-haspopup={true}
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -666,39 +599,9 @@ exports[`IconButton default 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c1:active,
-.c1.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c3 {
@@ -711,7 +614,21 @@ exports[`IconButton default 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -721,7 +638,6 @@ exports[`IconButton default 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -817,39 +733,9 @@ exports[`IconButton outline 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c1:active,
-.c1.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c3 {
@@ -862,6 +748,9 @@ exports[`IconButton outline 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
   border: 1px solid #C1C6CC;
 }
@@ -869,12 +758,23 @@ exports[`IconButton outline 1`] = `
 .c2:hover,
 .c2:focus,
 .c2.hover {
-  border-color: #939BA5;
+  color: #707781;
 }
 
 .c2:active,
 .c2.active {
-  border-color: #707781;
+  color: #4C535B;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  border-color: #6C43E0;
+}
+
+.c2:active,
+.c2.active {
+  border-color: #4F2ABA;
 }
 
 .c2[disabled]:hover,
@@ -890,7 +790,6 @@ exports[`IconButton outline 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -986,39 +885,9 @@ exports[`IconButton renders focus ring on tab input but not on click 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #CC1F36;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FFF2F4;
-  border-color: #FFF2F4;
-  color: #ED3B53;
-}
-
-.c1:active,
-.c1.active {
-  background: #FFE5E9;
-  border-color: #FFE5E9;
-  color: #ED3B53;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #CC1F36;
 }
 
 .c3 {
@@ -1031,7 +900,21 @@ exports[`IconButton renders focus ring on tab input but not on click 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #CC1F36;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #B2121F;
+}
+
+.c2:active,
+.c2.active {
+  color: #990F14;
 }
 
 .c2 svg {
@@ -1137,39 +1020,9 @@ exports[`IconButton renders focus ring on tab input but not on click 2`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #CC1F36;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 12px;
   width: 12px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FFF2F4;
-  border-color: #FFF2F4;
-  color: #ED3B53;
-}
-
-.c1:active,
-.c1.active {
-  background: #FFE5E9;
-  border-color: #FFE5E9;
-  color: #ED3B53;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #CC1F36;
 }
 
 .c3 {
@@ -1182,7 +1035,21 @@ exports[`IconButton renders focus ring on tab input but not on click 2`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #CC1F36;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #B2121F;
+}
+
+.c2:active,
+.c2.active {
+  color: #990F14;
 }
 
 .c2 svg {
@@ -1288,39 +1155,9 @@ exports[`IconButton resized 1`] = `
   opacity: 0.25;
 }
 
-.c1 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c1 .c5 {
   height: 20px;
   width: 20px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c1:active,
-.c1.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c1[disabled]:hover,
-.c1[disabled]:active,
-.c1[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c3 {
@@ -1333,7 +1170,21 @@ exports[`IconButton resized 1`] = `
 }
 
 .c2 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -1343,7 +1194,6 @@ exports[`IconButton resized 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -211,19 +211,7 @@ exports[`IconButton accepts events 1`] = `
 .c2 {
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  color: #707781;
-}
-
-.c2:active,
-.c2.active {
-  color: #4C535B;
 }
 
 .c2 svg {
@@ -233,7 +221,6 @@ exports[`IconButton accepts events 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -347,19 +334,7 @@ exports[`IconButton accepts events 2`] = `
 .c2 {
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  color: #707781;
-}
-
-.c2:active,
-.c2.active {
-  color: #4C535B;
 }
 
 .c2 svg {
@@ -369,7 +344,6 @@ exports[`IconButton accepts events 2`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -483,19 +457,7 @@ exports[`IconButton allows for ARIA attributes 1`] = `
 .c2 {
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  color: #707781;
-}
-
-.c2:active,
-.c2.active {
-  color: #4C535B;
 }
 
 .c2 svg {
@@ -506,7 +468,6 @@ exports[`IconButton allows for ARIA attributes 1`] = `
   aria-describedby="test-iconButton-tooltip"
   aria-haspopup={true}
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -619,19 +580,7 @@ exports[`IconButton default 1`] = `
 .c2 {
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  color: #707781;
-}
-
-.c2:active,
-.c2.active {
-  color: #4C535B;
 }
 
 .c2 svg {
@@ -641,7 +590,6 @@ exports[`IconButton default 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -754,31 +702,8 @@ exports[`IconButton outline 1`] = `
 .c2 {
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
   border: 1px solid #C1C6CC;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  color: #707781;
-}
-
-.c2:active,
-.c2.active {
-  color: #4C535B;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  border-color: #939BA5;
-}
-
-.c2:active,
-.c2.active {
-  border-color: #707781;
 }
 
 .c2[disabled]:hover,
@@ -794,7 +719,6 @@ exports[`IconButton outline 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}
@@ -1177,19 +1101,7 @@ exports[`IconButton resized 1`] = `
 .c2 {
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
-}
-
-.c2:hover,
-.c2:focus,
-.c2.hover {
-  color: #707781;
-}
-
-.c2:active,
-.c2.active {
-  color: #4C535B;
 }
 
 .c2 svg {
@@ -1199,7 +1111,6 @@ exports[`IconButton resized 1`] = `
 <button
   aria-describedby="test-iconButton-tooltip"
   className="c0 c1 c2"
-  color="neutral"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyUp={[Function]}

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -211,7 +211,19 @@ exports[`IconButton accepts events 1`] = `
 .c2 {
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -334,7 +346,19 @@ exports[`IconButton accepts events 2`] = `
 .c2 {
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -457,7 +481,19 @@ exports[`IconButton allows for ARIA attributes 1`] = `
 .c2 {
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -580,7 +616,19 @@ exports[`IconButton default 1`] = `
 .c2 {
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {
@@ -702,8 +750,31 @@ exports[`IconButton outline 1`] = `
 .c2 {
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
   border: 1px solid #C1C6CC;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  border-color: #939BA5;
+}
+
+.c2:active,
+.c2.active {
+  border-color: #707781;
 }
 
 .c2[disabled]:hover,
@@ -1101,7 +1172,19 @@ exports[`IconButton resized 1`] = `
 .c2 {
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c2:hover,
+.c2:focus,
+.c2.hover {
+  color: #707781;
+}
+
+.c2:active,
+.c2.active {
+  color: #4C535B;
 }
 
 .c2 svg {

--- a/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -413,8 +413,6 @@ exports[`MessageBar can be dismissed 1`] = `
   padding: 0;
 }
 
-<<<<<<< HEAD
-=======
 .c6:hover,
 .c6:focus,
 .c6.hover {
@@ -426,12 +424,6 @@ exports[`MessageBar can be dismissed 1`] = `
   color: #4C535B;
 }
 
-.c6:hover {
-  background: none;
-  border: none;
-}
-
->>>>>>> IconButton improved hover/active states and no background on hover
 .c6 svg {
   pointer-events: none;
 }
@@ -516,6 +508,7 @@ exports[`MessageBar can be dismissed 1`] = `
     aria-describedby="test-message-bar-iconButton-tooltip"
     aria-hidden={true}
     className="c4 c5 c6"
+    color="neutral"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyUp={[Function]}

--- a/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -409,19 +409,7 @@ exports[`MessageBar can be dismissed 1`] = `
   margin-left: auto;
   background: none;
   border: none;
-  color: #939BA5;
   padding: 0;
-}
-
-.c6:hover,
-.c6:focus,
-.c6.hover {
-  color: #707781;
-}
-
-.c6:active,
-.c6.active {
-  color: #4C535B;
 }
 
 .c6 svg {
@@ -508,7 +496,6 @@ exports[`MessageBar can be dismissed 1`] = `
     aria-describedby="test-message-bar-iconButton-tooltip"
     aria-hidden={true}
     className="c4 c5 c6"
-    color="neutral"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyUp={[Function]}

--- a/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -391,39 +391,9 @@ exports[`MessageBar can be dismissed 1`] = `
   opacity: 0.25;
 }
 
-.c5 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c5 .c10 {
   height: 16px;
   width: 16px;
-}
-
-.c5:hover,
-.c5:focus,
-.c5.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c5:active,
-.c5.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c5[disabled]:hover,
-.c5[disabled]:active,
-.c5[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c2 {
@@ -437,9 +407,31 @@ exports[`MessageBar can be dismissed 1`] = `
 
 .c6 {
   margin-left: auto;
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
 }
 
+<<<<<<< HEAD
+=======
+.c6:hover,
+.c6:focus,
+.c6.hover {
+  color: #707781;
+}
+
+.c6:active,
+.c6.active {
+  color: #4C535B;
+}
+
+.c6:hover {
+  background: none;
+  border: none;
+}
+
+>>>>>>> IconButton improved hover/active states and no background on hover
 .c6 svg {
   pointer-events: none;
 }
@@ -524,7 +516,6 @@ exports[`MessageBar can be dismissed 1`] = `
     aria-describedby="test-message-bar-iconButton-tooltip"
     aria-hidden={true}
     className="c4 c5 c6"
-    color="neutral"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyUp={[Function]}

--- a/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/components/src/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -409,7 +409,19 @@ exports[`MessageBar can be dismissed 1`] = `
   margin-left: auto;
   background: none;
   border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c6:hover,
+.c6:focus,
+.c6.hover {
+  color: #707781;
+}
+
+.c6:active,
+.c6.active {
+  color: #4C535B;
 }
 
 .c6 svg {

--- a/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
+++ b/packages/components/src/Modal/Layout/__snapshots__/ModalHeader.test.tsx.snap
@@ -59,39 +59,9 @@ exports[`ModalHeader 1`] = `
   opacity: 0.25;
 }
 
-.c3 {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #939BA5;
-  padding: 0 0.5rem;
-}
-
 .c3 .c7 {
   height: 16px;
   width: 16px;
-}
-
-.c3:hover,
-.c3:focus,
-.c3.hover {
-  background: #FBFBFC;
-  border-color: #FBFBFC;
-  color: #939BA5;
-}
-
-.c3:active,
-.c3.active {
-  background: #F5F6F7;
-  border-color: #F5F6F7;
-  color: #939BA5;
-}
-
-.c3[disabled]:hover,
-.c3[disabled]:active,
-.c3[disabled]:focus {
-  background-color: transparent;
-  border-color: transparent;
-  color: #939BA5;
 }
 
 .c1 {
@@ -127,7 +97,21 @@ exports[`ModalHeader 1`] = `
 }
 
 .c4 {
+  background: none;
+  border: none;
+  color: #939BA5;
   padding: 0;
+}
+
+.c4:hover,
+.c4:focus,
+.c4.hover {
+  color: #707781;
+}
+
+.c4:active,
+.c4.active {
+  color: #4C535B;
 }
 
 .c4 svg {

--- a/www/src/documentation/components/actions/icon-button.mdx
+++ b/www/src/documentation/components/actions/icon-button.mdx
@@ -34,6 +34,16 @@ If you need an icon for purely decorative purposes use an `<Icon />` instead.
 </Space>
 ```
 
+## States
+
+```jsx
+<Space evenly>
+  <IconButton icon="Favorite" label="Add to Favorites" />
+  <IconButton icon="Favorite" label="Add to Favorites" className="hover" />
+  <IconButton icon="Favorite" label="Add to Favorites" className="active" />
+</Space>
+```
+
 ## Shapes
 
 - `round` | `square` (default)


### PR DESCRIPTION


### :sparkles: Changes

- IconButton improved hover/active states and no background on hover
- Refined IconButton to remove the need for common overrides used to suppress default :hover background as well as provide more distinct :hover & :active psuedo states.
- Also addressed a weird bug where a border would be momentarily rendered when the cursor removed focus from a IconButton with no border specified

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/34253496/84944527-be288480-b09a-11ea-80a5-af46d8ddd18c.png)

