### PR TITLE
Use gap for supporting browser (Firefox) fix tooltip interaction issue

### DIFF
--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -16,14 +16,6 @@ exports[`Fieldset 1`] = `
   flex-direction: column;
 }
 
-.c1.c1 > * {
-  margin-top: 1rem;
-}
-
-.c1.c1 > *:first-child {
-  margin-top: 0rem;
-}
-
 .c3 {
   width: 100%;
   display: -webkit-box;
@@ -37,14 +29,6 @@ exports[`Fieldset 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c3.c3 > * {
-  margin-top: 0.75rem;
-}
-
-.c3.c3 > *:first-child {
-  margin-top: 0rem;
 }
 
 .c8 {
@@ -185,6 +169,38 @@ exports[`Fieldset 1`] = `
 
 .c4 .c13 {
   margin-top: 0.5rem;
+}
+
+@supports (-moz-appearance:none) {
+  .c1 {
+    gap: 1rem;
+  }
+}
+
+@supports not (-moz-appearance:none) {
+  .c1.c1 > * {
+    margin-top: 1rem;
+  }
+
+  .c1.c1 > *:first-child {
+    margin-top: 0rem;
+  }
+}
+
+@supports (-moz-appearance:none) {
+  .c3 {
+    gap: 0.75rem;
+  }
+}
+
+@supports not (-moz-appearance:none) {
+  .c3.c3 > * {
+    margin-top: 0.75rem;
+  }
+
+  .c3.c3 > *:first-child {
+    margin-top: 0rem;
+  }
 }
 
 <div

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -16,14 +16,6 @@ exports[`Form with one child 1`] = `
   flex-direction: column;
 }
 
-.c0.c0 > * {
-  margin-top: 1rem;
-}
-
-.c0.c0 > *:first-child {
-  margin-top: 0rem;
-}
-
 .c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -144,6 +136,22 @@ exports[`Form with one child 1`] = `
 
 .c1 .c8 {
   margin-top: 0.5rem;
+}
+
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 1rem;
+  }
+}
+
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-top: 1rem;
+  }
+
+  .c0.c0 > *:first-child {
+    margin-top: 0rem;
+  }
 }
 
 <form

--- a/packages/components/src/Layout/Grid/Grid.tsx
+++ b/packages/components/src/Layout/Grid/Grid.tsx
@@ -25,7 +25,7 @@
  */
 
 import styled from 'styled-components'
-import { defaultSpaceSize, SpaceHelperProps } from '../Space'
+import { defaultGap, SpaceHelperProps } from '../Space'
 import { simpleLayoutCSS } from '../utils/simple'
 
 export interface GridProps extends SpaceHelperProps {
@@ -40,7 +40,7 @@ export const Grid = styled.div<GridProps>`
   ${simpleLayoutCSS}
 
   display: grid;
-  grid-gap: ${({ gap, theme }) => theme.space[gap || defaultSpaceSize]};
+  grid-gap: ${({ gap, theme }) => theme.space[gap || defaultGap]};
   grid-template-columns: ${({ columns }) =>
     `repeat(${columns || 2}, minmax(0, 1fr))`};
 `

--- a/packages/components/src/Layout/Space/SpaceVertical.tsx
+++ b/packages/components/src/Layout/Space/SpaceVertical.tsx
@@ -24,9 +24,9 @@
 
  */
 
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { variant } from 'styled-system'
-import { defaultSpaceSize, spaceCSS, SpaceHelperProps } from './Space'
+import { defaultGap, spaceCSS, SpaceHelperProps } from './Space'
 
 interface SpaceVerticalProps extends Omit<SpaceHelperProps, 'align'> {
   /**
@@ -54,19 +54,28 @@ const align = variant({
   },
 })
 
+const flexGap = ({ gap = defaultGap, reverse }: SpaceVerticalProps) => css`
+  @supports (-moz-appearance: none) {
+    gap: ${({ theme: { space } }) => space[gap]};
+  }
+
+  @supports not (-moz-appearance: none) {
+    && > * {
+      margin-top: ${({ theme: { space } }) => space[gap]};
+    }
+
+    ${({ theme: { space } }) =>
+      reverse
+        ? `&& > *:last-child { margin-top: ${space.none}; }`
+        : `&& > *:first-child { margin-top: ${space.none}; }`}
+  }
+`
+
 export const SpaceVertical = styled.div<SpaceVerticalProps>`
   ${spaceCSS}
   ${align}
+  ${flexGap}
   flex-direction: ${({ reverse }) => (reverse ? 'column-reverse' : 'column')};
-
-  && > * {
-    margin-top: ${({ theme, gap }) => theme.space[gap || defaultSpaceSize]};
-  }
-
-  ${({ theme, reverse }) =>
-    reverse
-      ? `&& > *:last-child { margin-top: ${theme.space.none}; }`
-      : `&& > *:first-child { margin-top: ${theme.space.none}; }`}
 `
 
 SpaceVertical.defaultProps = { align: 'stretch', width: '100%' }

--- a/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
@@ -133,12 +133,20 @@ exports[`Space default 1`] = `
   flex-direction: row;
 }
 
-.c0.c0 > * {
-  margin-left: 1rem;
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 1rem;
+  }
 }
 
-.c0.c0 > *:first-child {
-  margin-left: 0rem;
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-right: 1rem;
+  }
+
+  .c0.c0 > *:last-child {
+    margin-right: 0rem;
+  }
 }
 
 <div
@@ -215,12 +223,20 @@ exports[`Space reversed 1`] = `
   flex-direction: row-reverse;
 }
 
-.c0.c0 > * {
-  margin-left: 1rem;
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 1rem;
+  }
 }
 
-.c0.c0 > *:last-child {
-  margin-left: 0rem;
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-right: 1rem;
+  }
+
+  .c0.c0 > *:first-child {
+    margin-right: 0rem;
+  }
 }
 
 <div
@@ -258,12 +274,20 @@ exports[`Space with specified gap 1`] = `
   flex-direction: row;
 }
 
-.c0.c0 > * {
-  margin-left: 2rem;
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 2rem;
+  }
 }
 
-.c0.c0 > *:first-child {
-  margin-left: 0rem;
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-right: 2rem;
+  }
+
+  .c0.c0 > *:last-child {
+    margin-right: 0rem;
+  }
 }
 
 <div

--- a/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/SpaceVertical.test.tsx.snap
@@ -16,12 +16,20 @@ exports[`SpaceVertical default 1`] = `
   flex-direction: column;
 }
 
-.c0.c0 > * {
-  margin-top: 1rem;
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 1rem;
+  }
 }
 
-.c0.c0 > *:first-child {
-  margin-top: 0rem;
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-top: 1rem;
+  }
+
+  .c0.c0 > *:first-child {
+    margin-top: 0rem;
+  }
 }
 
 <div
@@ -59,12 +67,20 @@ exports[`SpaceVertical reversed 1`] = `
   flex-direction: column-reverse;
 }
 
-.c0.c0 > * {
-  margin-top: 1rem;
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 1rem;
+  }
 }
 
-.c0.c0 > *:last-child {
-  margin-top: 0rem;
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-top: 1rem;
+  }
+
+  .c0.c0 > *:last-child {
+    margin-top: 0rem;
+  }
 }
 
 <div
@@ -102,12 +118,20 @@ exports[`SpaceVertical with specified gap 1`] = `
   flex-direction: column;
 }
 
-.c0.c0 > * {
-  margin-top: 2rem;
+@supports (-moz-appearance:none) {
+  .c0 {
+    gap: 2rem;
+  }
 }
 
-.c0.c0 > *:first-child {
-  margin-top: 0rem;
+@supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-top: 2rem;
+  }
+
+  .c0.c0 > *:first-child {
+    margin-top: 0rem;
+  }
 }
 
 <div

--- a/packages/components/src/Modal/Layout/__snapshots__/ModalFooter.test.tsx.snap
+++ b/packages/components/src/Modal/Layout/__snapshots__/ModalFooter.test.tsx.snap
@@ -39,12 +39,20 @@ exports[`ModalFooter with Button 1`] = `
   flex-direction: row-reverse;
 }
 
-.c1.c1 > * {
-  margin-left: 1rem;
+@supports (-moz-appearance:none) {
+  .c1 {
+    gap: 1rem;
+  }
 }
 
-.c1.c1 > *:last-child {
-  margin-left: 0rem;
+@supports not (-moz-appearance:none) {
+  .c1.c1 > * {
+    margin-right: 1rem;
+  }
+
+  .c1.c1 > *:first-child {
+    margin-right: 0rem;
+  }
 }
 
 <footer
@@ -101,12 +109,20 @@ exports[`ModalFooter with ModalContext 1`] = `
   flex-direction: row-reverse;
 }
 
-.c1.c1 > * {
-  margin-left: 1rem;
+@supports (-moz-appearance:none) {
+  .c1 {
+    gap: 1rem;
+  }
 }
 
-.c1.c1 > *:last-child {
-  margin-left: 0rem;
+@supports not (-moz-appearance:none) {
+  .c1.c1 > * {
+    margin-right: 1rem;
+  }
+
+  .c1.c1 > *:first-child {
+    margin-right: 0rem;
+  }
 }
 
 <footer

--- a/storybook/src/Layout/Space.stories.tsx
+++ b/storybook/src/Layout/Space.stories.tsx
@@ -31,6 +31,7 @@ import {
   Icon,
   Paragraph,
   Status,
+  IconButton,
 } from '@looker/components'
 import React from 'react'
 
@@ -103,4 +104,50 @@ export const SpaceCrush = () => (
       est laborum.
     </Paragraph>
   </Space>
+)
+
+export const SpaceWrap = () => (
+  <>
+    <Space maxWidth="20rem" flexWrap="wrap">
+      <IconButton label="boo" icon="Trash" />
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+    </Space>
+
+    <Space reverse maxWidth="20rem" flexWrap="wrap">
+      <IconButton label="boo" icon="Trash" />
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+      <button>boo</button>
+    </Space>
+  </>
 )


### PR DESCRIPTION
### :sparkles: Changes

- Use gap for supporting browser (Firefox) 
- Fix tooltip interaction issue

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
