### PR TITLE
Expose `wrap` option on Fieldset for use by OptionsGroup(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SelectMulti` create option unnecessary left padding
 - `FieldSelect`/`FieldSelectMulti` missing `aria-labelledby` attribute on the input
 - Major CSS linting clean-up
+- `CheckboxGroup` & `RadioGroup` options now properly wrap when the exceed the container width
 
 ### Removed
 

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -46,18 +46,28 @@ import {
 
 export interface FieldsetProps
   extends SpaceHelperProps,
-    CompatibleHTMLProps<HTMLDivElement>,
+    Omit<CompatibleHTMLProps<HTMLDivElement>, 'wrap'>,
     AccordionControlProps {
-  /** If true, the Fieldset will be wrapped by an Accordion structure (i.e. a collapsible section)
+  /**
+   * If true, the Fieldset will be wrapped by an Accordion structure (i.e. a collapsible section)
    * @default false
    */
   accordion?: boolean
   ariaLabeledby?: string
-  /** Determines where to place the label in relation to the input.
+  /**
+   * Determines where to place the label in relation to the input.
    * @default false
    */
   inline?: boolean
-  /** Displayed above the children of Fieldset
+
+  /**
+   * Allowed fields to wrap if they exceed the container width
+   * @default false
+   */
+  wrap?: boolean
+
+  /**
+   *  Displayed above the children of Fieldset
    */
   legend?: ReactNode
   /*
@@ -98,6 +108,7 @@ const FieldsetLayout = forwardRef(
       legend,
       fieldsHideLabel,
       children,
+      wrap,
       ...restProps
     } = omit(props, [...AccordionControlPropKeys])
 
@@ -123,6 +134,7 @@ const FieldsetLayout = forwardRef(
         ref={ref}
         role="group"
         align="start"
+        flexWrap={wrap ? 'wrap' : undefined}
       >
         {children}
       </LayoutComponent>

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -33,7 +33,8 @@ import {
 } from '@looker/design-tokens'
 import omit from 'lodash/omit'
 import pick from 'lodash/pick'
-import { Space, SpaceHelperProps, SpaceVertical } from '../../Layout'
+import { Space, SpaceVertical } from '../../Layout'
+import { SimpleLayoutProps, simpleLayoutCSS } from '../../Layout/utils/simple'
 import { Legend } from '../Legend'
 import {
   Accordion,
@@ -45,8 +46,8 @@ import {
 } from '../../Accordion'
 
 export interface FieldsetProps
-  extends SpaceHelperProps,
-    Omit<CompatibleHTMLProps<HTMLDivElement>, 'wrap'>,
+  extends Omit<CompatibleHTMLProps<HTMLDivElement>, 'wrap'>,
+    SimpleLayoutProps,
     AccordionControlProps {
   /**
    * If true, the Fieldset will be wrapped by an Accordion structure (i.e. a collapsible section)
@@ -178,19 +179,18 @@ const FieldsetLayout = forwardRef(
 FieldsetLayout.displayName = 'FieldsetLayout'
 
 export const Fieldset = styled(FieldsetLayout)`
+  ${simpleLayoutCSS}
+
+  ${AccordionContent} {
+    padding-top: ${({ theme }) => theme.space.medium};
+  }
+
   ${AccordionDisclosure} {
     font-size: ${({ theme }) => theme.fontSizes.small};
     font-weight: ${({ theme }) => theme.fontWeights.semiBold};
     height: 24px;
     padding: ${({ theme: { space } }) => space.xxsmall} 0;
   }
-
-  ${AccordionContent} {
-    padding-top: ${({ theme }) => theme.space.medium};
-  }
 `
 
-Fieldset.defaultProps = {
-  padding: 'none',
-  width: '100%',
-}
+Fieldset.defaultProps = { width: '100%' }

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -126,15 +126,19 @@ exports[`Fieldset 1`] = `
   font-weight: 600;
 }
 
+.c0 {
+  width: 100%;
+}
+
+.c0 .c12 {
+  padding-top: 1rem;
+}
+
 .c0 .c11 {
   font-size: 0.875rem;
   font-weight: 600;
   height: 24px;
   padding: 0.25rem 0;
-}
-
-.c0 .c12 {
-  padding-top: 1rem;
 }
 
 .c6 {

--- a/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
@@ -102,7 +102,7 @@ const CheckboxGroupLayout = forwardRef(
       <Fieldset
         data-testid="checkbox-list"
         inline={inline}
-        flexWrap={inline ? 'wrap' : undefined}
+        wrap={inline}
         gap={!inline ? 'xxsmall' : undefined}
         width={inline ? 'auto' : undefined}
         ref={ref}

--- a/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
@@ -95,7 +95,7 @@ const RadioGroupLayout = forwardRef(
       <Fieldset
         data-testid="radio-list"
         inline={inline}
-        flexWrap={inline ? 'wrap' : undefined}
+        wrap={inline}
         gap={!inline ? 'xxsmall' : undefined}
         width={inline ? 'auto' : undefined}
         ref={ref}

--- a/storybook/src/Forms/CheckboxGroup.stories.tsx
+++ b/storybook/src/Forms/CheckboxGroup.stories.tsx
@@ -61,6 +61,40 @@ const options = [
     label: 'Roquefort',
     value: 'roquefort',
   },
+  {
+    label: 'Cheddar',
+    value: 'cheddar',
+  },
+  {
+    label: 'Gouda',
+    value: 'gouda',
+  },
+  {
+    disabled: true,
+    label: 'Swiss',
+    value: 'swiss',
+  },
+  {
+    label: 'Roquefort',
+    value: 'roquefort',
+  },
+  {
+    label: 'Cheddar',
+    value: 'cheddar',
+  },
+  {
+    label: 'Gouda',
+    value: 'gouda',
+  },
+  {
+    disabled: true,
+    label: 'Swiss',
+    value: 'swiss',
+  },
+  {
+    label: 'Roquefort',
+    value: 'roquefort',
+  },
 ]
 
 const defaultValueCheckbox = ['swiss', 'cheddar']


### PR DESCRIPTION
### :sparkles: Changes

- Expose `wrap` option on Fieldset and use OptionsGroup(s)
- `CheckboxGroup` & `RadioGroup` options now properly wrap when the exceed the container width

![image](https://user-images.githubusercontent.com/34253496/85102084-bced7980-b1b8-11ea-935c-71fc4ec25140.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
