### PR TITLE
Fix tooltip hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Major CSS linting clean-up
 - `CheckboxGroup` & `RadioGroup` options now properly wrap when the exceed the container width
 - `Select` & `SelectMulti` option group label alignment
+- `Tooltip` closing when mouse moves from trigger element to tooltip
 
 ### Removed
 

--- a/packages/components/src/Overlay/OverlaySurface.tsx
+++ b/packages/components/src/Overlay/OverlaySurface.tsx
@@ -78,7 +78,13 @@ export const OverlaySurface = forwardRef(
     const { closeModal } = useContext(DialogContext)
 
     return (
-      <Outer ref={ref} style={style} {...eventHandlers} tabIndex={-1}>
+      <Outer
+        ref={ref}
+        style={style}
+        {...eventHandlers}
+        tabIndex={-1}
+        data-placement={placement}
+      >
         <HotKeys
           className="hotkeys"
           keyMap={{
@@ -116,6 +122,7 @@ const Outer = styled.div<{ zIndex?: number }>`
   ${reset}
   animation: ${fadeIn} 150ms ease-in;
   overflow: visible;
+  padding: ${({ theme }) => theme.space.xsmall};
   z-index: ${({ theme: { zIndexFloor } }) => zIndexFloor || undefined};
 
   &:focus {

--- a/packages/components/src/Overlay/OverlaySurface.tsx
+++ b/packages/components/src/Overlay/OverlaySurface.tsx
@@ -78,13 +78,7 @@ export const OverlaySurface = forwardRef(
     const { closeModal } = useContext(DialogContext)
 
     return (
-      <Outer
-        ref={ref}
-        style={style}
-        {...eventHandlers}
-        tabIndex={-1}
-        data-placement={placement}
-      >
+      <Outer ref={ref} style={style} {...eventHandlers} tabIndex={-1}>
         <HotKeys
           className="hotkeys"
           keyMap={{

--- a/packages/components/src/Overlay/OverlaySurfaceArrow.tsx
+++ b/packages/components/src/Overlay/OverlaySurfaceArrow.tsx
@@ -63,28 +63,28 @@ export const OverlaySurfaceArrow = styled.div.attrs(
   }
 
   &[data-placement*='top'] {
-    bottom: -0.25rem;
+    bottom: ${({ theme: { space } }) => space.xxsmall};
     &::before {
       transform: rotate(45deg);
     }
   }
 
   &[data-placement*='right'] {
-    left: -0.25rem;
+    left: ${({ theme: { space } }) => space.xxsmall};
     &::before {
       transform: rotate(135deg);
     }
   }
 
   &[data-placement*='bottom'] {
-    top: -0.25rem;
+    top: ${({ theme: { space } }) => space.xxsmall};
     &::before {
       transform: rotate(225deg);
     }
   }
 
   &[data-placement*='left'] {
-    right: -0.25rem;
+    right: ${({ theme: { space } }) => space.xxsmall};
     &::before {
       transform: rotate(315deg);
     }

--- a/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
 }
 
 .c2[data-placement*='top'] {
-  bottom: -0.25rem;
+  bottom: 0.25rem;
 }
 
 .c2[data-placement*='top']::before {
@@ -30,7 +30,7 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
 }
 
 .c2[data-placement*='right'] {
-  left: -0.25rem;
+  left: 0.25rem;
 }
 
 .c2[data-placement*='right']::before {
@@ -40,7 +40,7 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
 }
 
 .c2[data-placement*='bottom'] {
-  top: -0.25rem;
+  top: 0.25rem;
 }
 
 .c2[data-placement*='bottom']::before {
@@ -50,7 +50,7 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
 }
 
 .c2[data-placement*='left'] {
-  right: -0.25rem;
+  right: 0.25rem;
 }
 
 .c2[data-placement*='left']::before {

--- a/packages/components/src/utils/usePopper.ts
+++ b/packages/components/src/utils/usePopper.ts
@@ -107,13 +107,6 @@ export function usePopper({
               padding: 8,
             },
           },
-          {
-            name: 'offset',
-            options: {
-              // 8px away from anchor element
-              offset: [0, 8],
-            },
-          },
         ]),
         strategy: 'fixed',
       }),


### PR DESCRIPTION
### :sparkles: Changes

- https://github.com/looker-open-source/components/pull/712 replaced padding on `OverlaySurface` > `Outer` with an offset in `usePopper` ("it seemed like a cool feature")
- This broke the `Tooltip` logic that checks on mouse out of the trigger whether the element that has been "mouse entered"  (`relatedTarget`) is the tooltip itself because the `relatedTarget` was whatever was underneath the offset gap.
- This PR removes the offset and reinstates the padding

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue:
![tooltip-hover-issue](https://user-images.githubusercontent.com/53451193/85487395-56ce7100-b581-11ea-899c-98bbce2ecabd.gif)

#### Fix:
![tooltip-hover](https://user-images.githubusercontent.com/53451193/85486748-1d493600-b580-11ea-90fa-84214e8ca16c.gif)

