### PR TITLE
Fix OverlaySurface offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+- `Popover` offset issue
+
 ## [0.9.1]- 2020-06-24
 
 ### Changed

--- a/packages/components/src/Overlay/OverlaySurface.tsx
+++ b/packages/components/src/Overlay/OverlaySurface.tsx
@@ -78,7 +78,13 @@ export const OverlaySurface = forwardRef(
     const { closeModal } = useContext(DialogContext)
 
     return (
-      <Outer ref={ref} style={style} {...eventHandlers} tabIndex={-1}>
+      <Outer
+        ref={ref}
+        style={style}
+        {...eventHandlers}
+        tabIndex={-1}
+        data-placement={placement}
+      >
         <HotKeys
           className="hotkeys"
           keyMap={{
@@ -114,8 +120,23 @@ const Outer = styled.div<{ zIndex?: number }>`
   ${reset}
   animation: ${fadeIn} 150ms ease-in;
   overflow: visible;
-  padding: ${({ theme }) => theme.space.xsmall};
   z-index: ${({ theme: { zIndexFloor } }) => zIndexFloor || undefined};
+
+  &[data-placement*='top'] {
+    padding-bottom: ${({ theme: { space } }) => space.xsmall};
+  }
+
+  &[data-placement*='right'] {
+    padding-left: ${({ theme: { space } }) => space.xsmall};
+  }
+
+  &[data-placement*='bottom'] {
+    padding-top: ${({ theme: { space } }) => space.xsmall};
+  }
+
+  &[data-placement*='left'] {
+    padding-right: ${({ theme: { space } }) => space.xsmall};
+  }
 
   &:focus {
     outline: none;


### PR DESCRIPTION
### :sparkles: Changes

- Fixes small offset discrepancy on `OverlaySurface` from `Tooltip` hover fix: https://github.com/looker-open-source/components/pull/1128

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
#### Bad:
![image](https://user-images.githubusercontent.com/53451193/85792317-20f7cc80-b6e8-11ea-9c8b-9051c91653a2.png)
![image](https://user-images.githubusercontent.com/53451193/85792381-3e2c9b00-b6e8-11ea-8ffe-cd050950594f.png)
#### Fixed:
![image](https://user-images.githubusercontent.com/53451193/85792452-5e5c5a00-b6e8-11ea-88ba-15c9cbf0d1ee.png)
![image](https://user-images.githubusercontent.com/53451193/85792485-6e743980-b6e8-11ea-9016-3ed440baab9a.png)
