### PR TITLE
MenuItem disabled, MenuList group dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2020-06-25
+
+### Added
+
+- `MenuList` now supports `disabled` property
+
+### Fixed
+
+- `MenuList` `groupDividers` now displayed correctly
+
 ## [0.9.1]- 2020-06-24
 
 ### Changed

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -57,6 +57,7 @@ export const MenuItem: FC<MenuItemProps> = (props) => {
     compact: propCompact,
     current,
     detail,
+    disabled,
     href,
     icon,
     itemRole,
@@ -115,6 +116,7 @@ export const MenuItem: FC<MenuItemProps> = (props) => {
     <MenuItemLayout
       aria-current={current && 'page'}
       compact={compact}
+      disabled={disabled}
       focusVisible={isFocusVisible}
       hasIcon={Boolean(renderedIcon)}
       onBlur={handleOnBlur}

--- a/packages/components/src/Menu/MenuItemLayout.tsx
+++ b/packages/components/src/Menu/MenuItemLayout.tsx
@@ -123,4 +123,22 @@ export const MenuItemLayout = styled(MenuItemLayoutInternal)`
   &[aria-current] {
     font-weight: ${({ theme: { fontWeights } }) => fontWeights.semiBold};
   }
+
+  &[disabled] {
+    color: ${({ theme: { colors } }) => colors.text5};
+
+    button,
+    a {
+      cursor: not-allowed;
+    }
+
+    &:hover {
+      background: ${({ theme: { colors } }) => colors.background};
+      color: ${({ theme: { colors } }) => colors.text5};
+
+      ${Icon} {
+        color: ${({ theme: { colors } }) => colors.text6};
+      }
+    }
+  }
 `

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -25,6 +25,7 @@
  */
 
 import { Placement } from '@popperjs/core'
+import omit from 'lodash/omit'
 import React, { Ref, useRef, forwardRef, useContext, useState } from 'react'
 import { HotKeys } from 'react-hotkeys'
 import styled, { css } from 'styled-components'
@@ -61,6 +62,11 @@ export interface MenuListProps
     MinWidthProps,
     WidthProps {
   compact?: boolean
+
+  /**
+   * Display a horizonal rule between each MenuGroup item
+   * @default true
+   */
   groupDividers?: boolean
 
   /**
@@ -118,7 +124,7 @@ export const MenuListInternal = forwardRef(
             role="menu"
             id={id}
             aria-labelledby={id && `button-${id}`}
-            {...omitStyledProps(props)}
+            {...omitStyledProps(omit(props, 'groupDividers'))}
           >
             {children}
           </ul>
@@ -144,7 +150,7 @@ export const MenuListInternal = forwardRef(
   }
 )
 
-const dividersStyle = ({ groupDividers }: MenuListProps) =>
+const dividersStyle = ({ groupDividers = true }: MenuListProps) =>
   groupDividers &&
   css`
   ${MenuGroup} ~ ${MenuGroup} {

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -106,6 +106,24 @@ exports[`MenuGroup - JSX label 1`] = `
   font-weight: 600;
 }
 
+.c4[disabled] {
+  color: #939BA5;
+}
+
+.c4[disabled] button,
+.c4[disabled] a {
+  cursor: not-allowed;
+}
+
+.c4[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c4[disabled]:hover .c5 {
+  color: #C1C6CC;
+}
+
 <li
   className="c0"
 >
@@ -281,6 +299,24 @@ exports[`MenuGroup - label 1`] = `
   font-weight: 600;
 }
 
+.c4[disabled] {
+  color: #939BA5;
+}
+
+.c4[disabled] button,
+.c4[disabled] a {
+  cursor: not-allowed;
+}
+
+.c4[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c4[disabled]:hover .c5 {
+  color: #C1C6CC;
+}
+
 <li
   className="c0"
 >
@@ -430,6 +466,24 @@ exports[`MenuGroup 1`] = `
 
 .c2[aria-current] {
   font-weight: 600;
+}
+
+.c2[disabled] {
+  color: #939BA5;
+}
+
+.c2[disabled] button,
+.c2[disabled] a {
+  cursor: not-allowed;
+}
+
+.c2[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c2[disabled]:hover .c3 {
+  color: #C1C6CC;
 }
 
 <li

--- a/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -35,6 +35,10 @@ exports[`MenuItem - current 1`] = `
   color: #262D33;
 }
 
+.c3[disabled]:hover .c1 {
+  color: #C1C6CC;
+}
+
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -110,6 +114,24 @@ exports[`MenuItem - current 1`] = `
 
 .c0[aria-current] {
   font-weight: 600;
+}
+
+.c0[disabled] {
+  color: #939BA5;
+}
+
+.c0[disabled] button,
+.c0[disabled] a {
+  cursor: not-allowed;
+}
+
+.c0[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c0[disabled]:hover .c1 {
+  color: #C1C6CC;
 }
 
 <li
@@ -223,6 +245,24 @@ exports[`MenuItem - detail 1`] = `
   font-weight: 600;
 }
 
+.c0[disabled] {
+  color: #939BA5;
+}
+
+.c0[disabled] button,
+.c0[disabled] a {
+  cursor: not-allowed;
+}
+
+.c0[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c0[disabled]:hover .c2 {
+  color: #C1C6CC;
+}
+
 .c1 {
   color: #C1C6CC;
   margin-left: auto;
@@ -282,6 +322,10 @@ exports[`MenuItem - icon 1`] = `
 .c3:hover .c1,
 .c3[aria-current] .c1 {
   color: #262D33;
+}
+
+.c3[disabled]:hover .c1 {
+  color: #C1C6CC;
 }
 
 .c0 {
@@ -359,6 +403,24 @@ exports[`MenuItem - icon 1`] = `
 
 .c0[aria-current] {
   font-weight: 600;
+}
+
+.c0[disabled] {
+  color: #939BA5;
+}
+
+.c0[disabled] button,
+.c0[disabled] a {
+  cursor: not-allowed;
+}
+
+.c0[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c0[disabled]:hover .c1 {
+  color: #C1C6CC;
 }
 
 <li
@@ -469,6 +531,24 @@ exports[`MenuItem 1`] = `
 
 .c0[aria-current] {
   font-weight: 600;
+}
+
+.c0[disabled] {
+  color: #939BA5;
+}
+
+.c0[disabled] button,
+.c0[disabled] a {
+  cursor: not-allowed;
+}
+
+.c0[disabled]:hover {
+  background: #FFFFFF;
+  color: #939BA5;
+}
+
+.c0[disabled]:hover .c1 {
+  color: #C1C6CC;
 }
 
 <li

--- a/www/src/documentation/components/overlays/menu.mdx
+++ b/www/src/documentation/components/overlays/menu.mdx
@@ -200,6 +200,15 @@ Use the `detail` prop to provide explanatory detail to a given item.
 </MenuItem>
 ```
 
+### Disabled
+
+Use the `disabled` to indicate an option that is not currently available.
+
+```jsx
+<MenuItem icon="Beaker" disabled>Disabled</MenuItem>
+<MenuItem icon="Beaker">Enabled</MenuItem>
+```
+
 ## MenuGroup
 
 <Props of="MenuItem" />


### PR DESCRIPTION
### :sparkles: Changes

- MenuItem disabled
- MenuList group dividers

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
