### PR TITLE
InputTimeSelect tab key behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- InputTimeSelect tab key behavior
+
 ## [0.9.2] - 2020-06-25
 
 ### Added

--- a/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.test.tsx
+++ b/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.test.tsx
@@ -121,10 +121,16 @@ describe('text input', () => {
 
     const inputBox = getByPlaceholderText('Select time')
     fireEvent.click(inputBox)
+
+    // Enter key input
     fireEvent.change(inputBox, { target: { value: '2pm' } })
     fireEvent.keyDown(inputBox, { key: 'Enter' })
-
     expect(handleChange).toHaveBeenLastCalledWith('14:00')
+
+    // Tab key input
+    fireEvent.change(inputBox, { target: { value: '3:3' } }) // incomplete time string
+    fireEvent.keyDown(inputBox, { key: 'Tab' })
+    expect(handleChange).toHaveBeenLastCalledWith('03:03')
 
     fireEvent.click(document)
   })

--- a/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.tsx
+++ b/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.tsx
@@ -298,7 +298,7 @@ const InputTimeSelectLayout = forwardRef(
     }
 
     const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' || e.key === 'Tab') {
         if (inputTextValue.length) {
           // allow entering shortcuts like `2pm` to select `02:00 pm` on enter
           const option = createOptionFromLabel(format, inputTextValue)


### PR DESCRIPTION
### :sparkles: Changes

- Updates InputTimeSelect to fire the onChange event when users `tab` out of the text input box. This is to ensure that users don't lose their selection (i.e. manually typing `3:07 pm`) when tabbing over to the next field.  

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC
