### PR TITLE
MenuItem fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [0.9.3] - 2020-06-26
 
-- `MenuItem` properly renders when `[aria-current='false']`
+### Fixed
+
+- `MenuItem`
+  - properly renders when `[aria-current='false']`
+  - is now exported as Styled Component
+  - renders properly in Safari / older Chrome implementations
 
 ## [0.9.2] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+- `MenuItem` properly renders when `[aria-current='false']`
+
 ## [0.9.2] - 2020-06-25
 
 ### Added

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -115,7 +115,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
 
   return (
     <MenuItemLayout
-      aria-current={current && 'page'}
+      aria-current={current && 'true'}
       compact={compact}
       disabled={disabled}
       focusVisible={isFocusVisible}

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -30,7 +30,7 @@ import styled from 'styled-components'
 import React, { FC, ReactNode, useContext, useState, useEffect } from 'react'
 import { Icon } from '../Icon'
 import { MenuContext, MenuItemContext } from './MenuContext'
-import { MenuItemLayout } from './MenuItemLayout'
+import { MenuItemLayout, MenuItemLayoutGrid } from './MenuItemLayout'
 
 export interface MenuItemProps extends CompatibleHTMLProps<HTMLElement> {
   compact?: boolean
@@ -51,9 +51,10 @@ export interface MenuItemProps extends CompatibleHTMLProps<HTMLElement> {
   itemRole?: 'link' | 'button'
 }
 
-export const MenuItem: FC<MenuItemProps> = (props) => {
+const MenuItemInternal: FC<MenuItemProps> = (props) => {
   const {
     children,
+    className,
     compact: propCompact,
     current,
     detail,
@@ -122,15 +123,20 @@ export const MenuItem: FC<MenuItemProps> = (props) => {
       onBlur={handleOnBlur}
       onClick={handleOnClick}
       onKeyUp={handleOnKeyUp}
+      className={className}
     >
       <Component href={href} role="menuitem" target={target}>
-        {renderedIcon}
-        {children}
+        <MenuItemLayoutGrid>
+          {renderedIcon}
+          {children}
+        </MenuItemLayoutGrid>
       </Component>
       {detail && <Detail>{detail}</Detail>}
     </MenuItemLayout>
   )
 }
+
+export const MenuItem = styled(MenuItemInternal)``
 
 const Detail = styled.div`
   color: ${({ theme: { colors } }) => colors.text6};

--- a/packages/components/src/Menu/MenuItemLayout.tsx
+++ b/packages/components/src/Menu/MenuItemLayout.tsx
@@ -40,7 +40,7 @@ export interface MenuListItemProps extends CompatibleHTMLProps<HTMLLIElement> {
  * All of this drama is to deal with SC's behavior of auto-spreading the Element interface
  * used when styled extends a base type. E.g. (styled.li has `color` prop)
  */
-const MenuItemLayoutInternal = forwardRef(
+const MenuItemWrapper = forwardRef(
   (props: MenuListItemProps, ref: Ref<HTMLLIElement>) => {
     return (
       <li {...omit(props, 'compact', 'focusVisible', 'hasIcon')} ref={ref} />
@@ -48,9 +48,15 @@ const MenuItemLayoutInternal = forwardRef(
   }
 )
 
-MenuItemLayoutInternal.displayName = 'MenuItemLayoutInternal'
+MenuItemWrapper.displayName = 'MenuItemWrapper'
 
-export const MenuItemLayout = styled(MenuItemLayoutInternal)`
+/**
+ * Make Safari (and older Chrome) happy.
+ * See: https://github.com/rachelandrew/gridbugs#10-some-html-elements-cant-be-grid-containers
+ **/
+export const MenuItemLayoutGrid = styled.div``
+
+export const MenuItemLayout = styled(MenuItemWrapper)`
   align-items: center;
   color: ${({ theme: { colors } }) => colors.text1};
   display: flex;
@@ -72,12 +78,9 @@ export const MenuItemLayout = styled(MenuItemLayoutInternal)`
     border: none;
     color: inherit;
     cursor: pointer;
-    display: grid;
     flex: 1;
     font-size: inherit;
     font-weight: inherit;
-    grid-gap: 0.5rem;
-    grid-template-columns: ${({ hasIcon }) => (hasIcon ? '20px 1fr' : '1fr')};
     outline: none;
     padding: ${({
       compact,
@@ -92,6 +95,12 @@ export const MenuItemLayout = styled(MenuItemLayoutInternal)`
     &:focus {
       color: inherit;
       text-decoration: none;
+    }
+
+    ${MenuItemLayoutGrid} {
+      display: grid;
+      grid-gap: 0.5rem;
+      grid-template-columns: ${({ hasIcon }) => (hasIcon ? '20px 1fr' : '1fr')};
     }
   }
 

--- a/packages/components/src/Menu/MenuItemLayout.tsx
+++ b/packages/components/src/Menu/MenuItemLayout.tsx
@@ -111,7 +111,7 @@ export const MenuItemLayout = styled(MenuItemLayoutInternal)`
   }
 
   :hover,
-  &[aria-current] {
+  &[aria-current='true'] {
     background: ${({ theme: { colors } }) => colors.ui1};
     color: ${({ theme: { colors } }) => colors.text0};
 
@@ -120,7 +120,7 @@ export const MenuItemLayout = styled(MenuItemLayoutInternal)`
     }
   }
 
-  &[aria-current] {
+  &[aria-current='true'] {
     font-weight: ${({ theme: { fontWeights } }) => fontWeights.semiBold};
   }
 

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -61,14 +61,11 @@ exports[`MenuGroup - JSX label 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -85,24 +82,31 @@ exports[`MenuGroup - JSX label 1`] = `
   text-decoration: none;
 }
 
-.c4 .c5 {
+.c4 button .c5,
+.c4 a .c5 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c4 .c6 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c4:hover,
-.c4[aria-current] {
+.c4[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c4:hover .c5,
-.c4[aria-current] .c5 {
+.c4:hover .c6,
+.c4[aria-current='true'] .c6 {
   color: #262D33;
 }
 
-.c4[aria-current] {
+.c4[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -120,7 +124,7 @@ exports[`MenuGroup - JSX label 1`] = `
   color: #939BA5;
 }
 
-.c4[disabled]:hover .c5 {
+.c4[disabled]:hover .c6 {
   color: #C1C6CC;
 }
 
@@ -154,7 +158,7 @@ exports[`MenuGroup - JSX label 1`] = `
     type="none"
   >
     <li
-      className="c4"
+      className="c4 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -162,11 +166,15 @@ exports[`MenuGroup - JSX label 1`] = `
       <button
         role="menuitem"
       >
-        what?
+        <div
+          className="c5 "
+        >
+          what?
+        </div>
       </button>
     </li>
     <li
-      className="c4"
+      className="c4 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -174,11 +182,15 @@ exports[`MenuGroup - JSX label 1`] = `
       <button
         role="menuitem"
       >
-        who?
+        <div
+          className="c5 "
+        >
+          who?
+        </div>
       </button>
     </li>
     <li
-      className="c4"
+      className="c4 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -186,7 +198,11 @@ exports[`MenuGroup - JSX label 1`] = `
       <button
         role="menuitem"
       >
-        where?
+        <div
+          className="c5 "
+        >
+          where?
+        </div>
       </button>
     </li>
   </ul>
@@ -254,14 +270,11 @@ exports[`MenuGroup - label 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -278,24 +291,31 @@ exports[`MenuGroup - label 1`] = `
   text-decoration: none;
 }
 
-.c4 .c5 {
+.c4 button .c5,
+.c4 a .c5 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c4 .c6 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c4:hover,
-.c4[aria-current] {
+.c4[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c4:hover .c5,
-.c4[aria-current] .c5 {
+.c4:hover .c6,
+.c4[aria-current='true'] .c6 {
   color: #262D33;
 }
 
-.c4[aria-current] {
+.c4[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -313,7 +333,7 @@ exports[`MenuGroup - label 1`] = `
   color: #939BA5;
 }
 
-.c4[disabled]:hover .c5 {
+.c4[disabled]:hover .c6 {
   color: #C1C6CC;
 }
 
@@ -343,7 +363,7 @@ exports[`MenuGroup - label 1`] = `
     type="none"
   >
     <li
-      className="c4"
+      className="c4 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -351,11 +371,15 @@ exports[`MenuGroup - label 1`] = `
       <button
         role="menuitem"
       >
-        what?
+        <div
+          className="c5 "
+        >
+          what?
+        </div>
       </button>
     </li>
     <li
-      className="c4"
+      className="c4 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -363,11 +387,15 @@ exports[`MenuGroup - label 1`] = `
       <button
         role="menuitem"
       >
-        who?
+        <div
+          className="c5 "
+        >
+          who?
+        </div>
       </button>
     </li>
     <li
-      className="c4"
+      className="c4 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -375,7 +403,11 @@ exports[`MenuGroup - label 1`] = `
       <button
         role="menuitem"
       >
-        where?
+        <div
+          className="c5 "
+        >
+          where?
+        </div>
       </button>
     </li>
   </ul>
@@ -423,14 +455,11 @@ exports[`MenuGroup 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -447,24 +476,31 @@ exports[`MenuGroup 1`] = `
   text-decoration: none;
 }
 
-.c2 .c3 {
+.c2 button .c3,
+.c2 a .c3 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c2 .c4 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c2:hover,
-.c2[aria-current] {
+.c2[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c2:hover .c3,
-.c2[aria-current] .c3 {
+.c2:hover .c4,
+.c2[aria-current='true'] .c4 {
   color: #262D33;
 }
 
-.c2[aria-current] {
+.c2[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -482,7 +518,7 @@ exports[`MenuGroup 1`] = `
   color: #939BA5;
 }
 
-.c2[disabled]:hover .c3 {
+.c2[disabled]:hover .c4 {
   color: #C1C6CC;
 }
 
@@ -494,7 +530,7 @@ exports[`MenuGroup 1`] = `
     type="none"
   >
     <li
-      className="c2"
+      className="c2 "
       onBlur={[Function]}
       onClick={[Function]}
       onKeyUp={[Function]}
@@ -502,7 +538,11 @@ exports[`MenuGroup 1`] = `
       <button
         role="menuitem"
       >
-        who!
+        <div
+          className="c3 "
+        >
+          who!
+        </div>
       </button>
     </li>
   </ul>

--- a/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`MenuItem - current 1`] = `
 }
 
 <li
-  aria-current="page"
+  aria-current="true"
   className="c0 "
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MenuItem - current 1`] = `
-.c2 {
+.c3 {
   width: 20px;
   height: 20px;
   margin-right: 0.5rem;
@@ -19,23 +19,30 @@ exports[`MenuItem - current 1`] = `
   flex-shrink: 0;
 }
 
-.c2 svg {
+.c3 svg {
   height: 100%;
   width: 100%;
 }
 
-.c3 .c1 {
+.c4 button .c1,
+.c4 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c4 .c2 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
-.c3:hover .c1,
-.c3[aria-current] .c1 {
+.c4:hover .c2,
+.c4[aria-current='true'] .c2 {
   color: #262D33;
 }
 
-.c3[disabled]:hover .c1 {
+.c4[disabled]:hover .c2 {
   color: #C1C6CC;
 }
 
@@ -71,14 +78,11 @@ exports[`MenuItem - current 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 20px 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -95,24 +99,31 @@ exports[`MenuItem - current 1`] = `
   text-decoration: none;
 }
 
-.c0 .c1 {
+.c0 button .c1,
+.c0 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 20px 1fr;
+}
+
+.c0 .c2 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c0:hover,
-.c0[aria-current] {
+.c0[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c0:hover .c1,
-.c0[aria-current] .c1 {
+.c0:hover .c2,
+.c0[aria-current='true'] .c2 {
   color: #262D33;
 }
 
-.c0[aria-current] {
+.c0[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -130,13 +141,13 @@ exports[`MenuItem - current 1`] = `
   color: #939BA5;
 }
 
-.c0[disabled]:hover .c1 {
+.c0[disabled]:hover .c2 {
   color: #C1C6CC;
 }
 
 <li
   aria-current="page"
-  className="c0"
+  className="c0 "
   onBlur={[Function]}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -145,24 +156,28 @@ exports[`MenuItem - current 1`] = `
     role="menuitem"
   >
     <div
-      className="c1 c2"
+      className="c1 "
     >
-      <svg
-        fill="currentColor"
-        height="100%"
-        viewBox="0 0 24 24"
-        width="100%"
+      <div
+        className="c2 c3"
       >
-        <title>
-          Home
-        </title>
-        <path
-          d="M12 5.69l5 4.5V18h-2v-6H9v6H7V10.19l5-4.5zM12 3L2 12h3v8h6v-6h2v6h6v-8h3L12 3z"
+        <svg
           fill="currentColor"
-        />
-      </svg>
+          height="100%"
+          viewBox="0 0 24 24"
+          width="100%"
+        >
+          <title>
+            Home
+          </title>
+          <path
+            d="M12 5.69l5 4.5V18h-2v-6H9v6H7V10.19l5-4.5zM12 3L2 12h3v8h6v-6h2v6h6v-8h3L12 3z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      who!
     </div>
-    who!
   </button>
 </li>
 `;
@@ -200,14 +215,11 @@ exports[`MenuItem - detail 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -224,24 +236,31 @@ exports[`MenuItem - detail 1`] = `
   text-decoration: none;
 }
 
-.c0 .c2 {
+.c0 button .c1,
+.c0 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c0 .c4 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c0:hover,
-.c0[aria-current] {
+.c0[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c0:hover .c2,
-.c0[aria-current] .c2 {
+.c0:hover .c4,
+.c0[aria-current='true'] .c4 {
   color: #262D33;
 }
 
-.c0[aria-current] {
+.c0[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -259,11 +278,18 @@ exports[`MenuItem - detail 1`] = `
   color: #939BA5;
 }
 
-.c0[disabled]:hover .c2 {
+.c0[disabled]:hover .c4 {
   color: #C1C6CC;
 }
 
-.c1 {
+.c3 button .c1,
+.c3 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 20px 1fr;
+}
+
+.c2 {
   color: #C1C6CC;
   margin-left: auto;
   margin-right: 1rem;
@@ -271,7 +297,7 @@ exports[`MenuItem - detail 1`] = `
 }
 
 <li
-  className="c0"
+  className="c0 "
   onBlur={[Function]}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -279,10 +305,14 @@ exports[`MenuItem - detail 1`] = `
   <button
     role="menuitem"
   >
-    who!
+    <div
+      className="c1 "
+    >
+      who!
+    </div>
   </button>
   <div
-    className="c1"
+    className="c2"
   >
     Is an excellent question
   </div>
@@ -290,7 +320,7 @@ exports[`MenuItem - detail 1`] = `
 `;
 
 exports[`MenuItem - icon 1`] = `
-.c2 {
+.c3 {
   width: 20px;
   height: 20px;
   margin-right: 0.5rem;
@@ -308,23 +338,30 @@ exports[`MenuItem - icon 1`] = `
   flex-shrink: 0;
 }
 
-.c2 svg {
+.c3 svg {
   height: 100%;
   width: 100%;
 }
 
-.c3 .c1 {
+.c4 button .c1,
+.c4 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c4 .c2 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
-.c3:hover .c1,
-.c3[aria-current] .c1 {
+.c4:hover .c2,
+.c4[aria-current='true'] .c2 {
   color: #262D33;
 }
 
-.c3[disabled]:hover .c1 {
+.c4[disabled]:hover .c2 {
   color: #C1C6CC;
 }
 
@@ -360,14 +397,11 @@ exports[`MenuItem - icon 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 20px 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -384,24 +418,31 @@ exports[`MenuItem - icon 1`] = `
   text-decoration: none;
 }
 
-.c0 .c1 {
+.c0 button .c1,
+.c0 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 20px 1fr;
+}
+
+.c0 .c2 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c0:hover,
-.c0[aria-current] {
+.c0[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c0:hover .c1,
-.c0[aria-current] .c1 {
+.c0:hover .c2,
+.c0[aria-current='true'] .c2 {
   color: #262D33;
 }
 
-.c0[aria-current] {
+.c0[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -419,12 +460,12 @@ exports[`MenuItem - icon 1`] = `
   color: #939BA5;
 }
 
-.c0[disabled]:hover .c1 {
+.c0[disabled]:hover .c2 {
   color: #C1C6CC;
 }
 
 <li
-  className="c0"
+  className="c0 "
   onBlur={[Function]}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -433,24 +474,28 @@ exports[`MenuItem - icon 1`] = `
     role="menuitem"
   >
     <div
-      className="c1 c2"
+      className="c1 "
     >
-      <svg
-        fill="currentColor"
-        height="100%"
-        viewBox="0 0 24 24"
-        width="100%"
+      <div
+        className="c2 c3"
       >
-        <title>
-          Beaker
-        </title>
-        <path
-          d="M15.75 4.502a1.249 1.249 0 100-2.5 1.25 1.25 0 100 2.5zM12 5.752a1.25 1.25 0 10-.002-2.501A1.25 1.25 0 0012 5.753zm7.22 15.01c-1.254-2.415-3.47-7.511-3.47-7.511v-5h.625a.626.626 0 000-1.25h-7.5a.626.626 0 000 1.25H9.5v5s-2.168 5.276-3.393 7.633c-.58 1.118-.58 1.118.803 1.118h11.747c.56 0 1.21 0 .565-1.24h-.001zm-8.47-7.51v-5h3.75v5l.535 1.25h-4.793c.3-.733.508-1.25.508-1.25zm6.172 7.5h-8.33c-1.153 0-1.153 0-.67-.957.513-1.015 1.223-2.658 1.803-4.043h5.855c.59 1.338 1.3 2.917 1.814 3.935.536 1.064-.005 1.064-.471 1.064z"
+        <svg
           fill="currentColor"
-        />
-      </svg>
+          height="100%"
+          viewBox="0 0 24 24"
+          width="100%"
+        >
+          <title>
+            Beaker
+          </title>
+          <path
+            d="M15.75 4.502a1.249 1.249 0 100-2.5 1.25 1.25 0 100 2.5zM12 5.752a1.25 1.25 0 10-.002-2.501A1.25 1.25 0 0012 5.753zm7.22 15.01c-1.254-2.415-3.47-7.511-3.47-7.511v-5h.625a.626.626 0 000-1.25h-7.5a.626.626 0 000 1.25H9.5v5s-2.168 5.276-3.393 7.633c-.58 1.118-.58 1.118.803 1.118h11.747c.56 0 1.21 0 .565-1.24h-.001zm-8.47-7.51v-5h3.75v5l.535 1.25h-4.793c.3-.733.508-1.25.508-1.25zm6.172 7.5h-8.33c-1.153 0-1.153 0-.67-.957.513-1.015 1.223-2.658 1.803-4.043h5.855c.59 1.338 1.3 2.917 1.814 3.935.536 1.064-.005 1.064-.471 1.064z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      who!
     </div>
-    who!
   </button>
 </li>
 `;
@@ -488,14 +533,11 @@ exports[`MenuItem 1`] = `
   border: none;
   color: inherit;
   cursor: pointer;
-  display: grid;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   font-size: inherit;
   font-weight: inherit;
-  grid-gap: 0.5rem;
-  grid-template-columns: 1fr;
   outline: none;
   padding: 0.75rem 1rem;
   text-align: left;
@@ -512,24 +554,31 @@ exports[`MenuItem 1`] = `
   text-decoration: none;
 }
 
-.c0 .c1 {
+.c0 button .c1,
+.c0 a .c1 {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+.c0 .c2 {
   color: #C1C6CC;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
 
 .c0:hover,
-.c0[aria-current] {
+.c0[aria-current='true'] {
   background: #F5F6F7;
   color: #262D33;
 }
 
-.c0:hover .c1,
-.c0[aria-current] .c1 {
+.c0:hover .c2,
+.c0[aria-current='true'] .c2 {
   color: #262D33;
 }
 
-.c0[aria-current] {
+.c0[aria-current='true'] {
   font-weight: 600;
 }
 
@@ -547,12 +596,12 @@ exports[`MenuItem 1`] = `
   color: #939BA5;
 }
 
-.c0[disabled]:hover .c1 {
+.c0[disabled]:hover .c2 {
   color: #C1C6CC;
 }
 
 <li
-  className="c0"
+  className="c0 "
   onBlur={[Function]}
   onClick={[Function]}
   onKeyUp={[Function]}
@@ -560,7 +609,11 @@ exports[`MenuItem 1`] = `
   <button
     role="menuitem"
   >
-    who!
+    <div
+      className="c1 "
+    >
+      who!
+    </div>
   </button>
 </li>
 `;


### PR DESCRIPTION
### :sparkles: Changes

- `MenuItem`
  - properly renders when `[aria-current='false']`
  - is now exported as Styled Component
  - renders properly in Safari / older Chrome implementations

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
