### PR TITLE
Allow for key-colored Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Link` now supports explicit `underline` & `keyColor` properties
 - `FactCheck` icon
 
 ### Changed

--- a/packages/components/src/Link/Link.test.tsx
+++ b/packages/components/src/Link/Link.test.tsx
@@ -26,27 +26,57 @@
 
 import 'jest-styled-components'
 import React from 'react'
-import { createWithTheme } from '@looker/components-test-utils'
+import { createWithTheme, renderWithTheme } from '@looker/components-test-utils'
 import { Link } from './Link'
 
-test('A default Link', () => {
-  const component = createWithTheme(<Link href="https://looker.com">🥑</Link>)
-  const tree = component.toJSON()
-  expect(tree).toMatchSnapshot()
-})
+describe('Link', () => {
+  test('Snapshot', () => {
+    const component = createWithTheme(
+      <>
+        <Link href="https://looker.com">Avocado</Link>
+        <Link href="https://looker.com" keyColor>
+          Avocado
+        </Link>
+        <Link href="https://looker.com" underline>
+          Avocado
+        </Link>
+      </>
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 
-test('A external Link', () => {
-  const component = createWithTheme(<Link href="https://looker.com">🥑</Link>)
-  const tree = component.toJSON()
-  expect(tree).toMatchSnapshot()
-})
+  test('ID passes through to DOM', () => {
+    const { getByText } = renderWithTheme(
+      <Link href="https://looker.com" id="link-id">
+        🥑
+      </Link>
+    )
 
-test('A Link with an id', () => {
-  const component = createWithTheme(
-    <Link href="https://looker.com" id="link-id">
-      🥑
-    </Link>
-  )
-  const tree = component.toJSON()
-  expect(tree).toMatchSnapshot()
+    const link = getByText('🥑')
+    expect(link.hasAttribute('id')).toBeTruthy()
+    expect(link.getAttribute('id')).toEqual('link-id')
+  })
+
+  test('target="_blank"', () => {
+    const { getByText } = renderWithTheme(
+      <>
+        <Link href="https://looker.com" rel="pizza">
+          🍕
+        </Link>
+        <Link href="https://looker.com" target="_blank">
+          🥑
+        </Link>
+        <Link href="https://looker.com" target="_blank" rel="pizza">
+          🍕🥑
+        </Link>
+      </>
+    )
+
+    expect(getByText('🍕').getAttribute('rel')).toEqual('pizza')
+    expect(getByText('🥑').getAttribute('rel')).toEqual('noopener noreferrer')
+    expect(getByText('🍕🥑').getAttribute('rel')).toEqual(
+      'pizza noopener noreferrer'
+    )
+  })
 })

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -79,19 +79,13 @@ export const Link = styled(LinkLayout)`
     keyColor ? colors.key : colors.link};
   text-decoration: ${({ underline }) => (underline ? 'underline' : 'none')};
 
-  &:visited {
-    /* @TODO - We should probably support this */
-  }
-
   &:focus,
-  &:hover {
-    color: ${({ keyColor, theme: { colors } }) =>
-      keyColor ? colors.key : colors.link};
-    text-decoration: underline;
-  }
-
+  &:hover,
   &:active,
-  &.active {
-    /* @TODO - We should probably support this */
+  &.active,
+  &:visited {
+    color: ${({ keyColor, theme: { colors } }) =>
+      keyColor ? colors.keyInteractive : colors.linkInteractive};
+    text-decoration: underline;
   }
 `

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -31,6 +31,7 @@ import {
   TypographyProps,
 } from '@looker/design-tokens'
 import styled from 'styled-components'
+import React, { forwardRef, Ref } from 'react'
 
 export interface LinkProps
   extends CompatibleHTMLProps<HTMLAnchorElement>,
@@ -49,7 +50,28 @@ export interface LinkProps
   underline?: boolean
 }
 
-export const Link = styled.a<LinkProps>`
+/**
+ * `target="_blank" can be used to reverse tab-nab
+ * https://owasp.org/www-community/attacks/Reverse_Tabnabbing
+ */
+const noTabNab = 'noopener noreferrer'
+
+const LinkLayout = forwardRef(
+  ({ ...props }: LinkProps, ref: Ref<HTMLAnchorElement>) => {
+    const rel =
+      props.target === '_blank'
+        ? props.rel
+          ? `${props.rel} ${noTabNab}`
+          : noTabNab
+        : props.rel
+
+    return <a {...props} ref={ref} rel={rel} />
+  }
+)
+
+LinkLayout.displayName = 'LinkLayout'
+
+export const Link = styled(LinkLayout)`
   ${reset}
   ${typography}
 

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -26,11 +26,7 @@
 
 import {
   CompatibleHTMLProps,
-  ColorProps,
-  color,
   reset,
-  textDecoration,
-  TextDecorationProps,
   typography,
   TypographyProps,
 } from '@looker/design-tokens'
@@ -38,23 +34,42 @@ import styled from 'styled-components'
 
 export interface LinkProps
   extends CompatibleHTMLProps<HTMLAnchorElement>,
-    ColorProps,
-    TextDecorationProps,
-    TypographyProps {}
+    TypographyProps {
+  /**
+   * Use the theme `key` color rather than `link`
+   * @default false
+   */
+  keyColor?: boolean
+
+  /**
+   * Display underline.
+   * NOTE: Underline is displayed when Link has :hover or :focus
+   * @default false
+   */
+  underline?: boolean
+}
 
 export const Link = styled.a<LinkProps>`
   ${reset}
-  ${color}
   ${typography}
-  ${textDecoration}
+
+  color: ${({ keyColor, theme: { colors } }) =>
+    keyColor ? colors.key : colors.link};
+  text-decoration: ${({ underline }) => (underline ? 'underline' : 'none')};
+
+  &:visited {
+    /* @TODO - We should probably support this */
+  }
 
   &:focus,
   &:hover {
+    color: ${({ keyColor, theme: { colors } }) =>
+      keyColor ? colors.key : colors.link};
     text-decoration: underline;
   }
-`
 
-Link.defaultProps = {
-  color: 'link',
-  textDecoration: 'none',
-}
+  &:active,
+  &.active {
+    /* @TODO - We should probably support this */
+  }
+`

--- a/packages/components/src/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`A Link with an id 1`] = `
-.c0 {
+exports[`Link Snapshot 1`] = `
+Array [
+  .c0 {
   color: #0059b2;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9,63 +10,56 @@ exports[`A Link with an id 1`] = `
 
 .c0:focus,
 .c0:hover {
+  color: #0059b2;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 <a
-  className="c0"
-  color="link"
-  href="https://looker.com"
-  id="link-id"
-  textDecoration="none"
->
-  🥑
-</a>
-`;
-
-exports[`A default Link 1`] = `
-.c0 {
-  color: #0059b2;
+    className="c0"
+    href="https://looker.com"
+  >
+    Avocado
+  </a>,
+  .c0 {
+  color: #6C43E0;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .c0:focus,
 .c0:hover {
+  color: #6C43E0;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 <a
-  className="c0"
-  color="link"
-  href="https://looker.com"
-  textDecoration="none"
->
-  🥑
-</a>
-`;
-
-exports[`A external Link 1`] = `
-.c0 {
+    className="c0"
+    href="https://looker.com"
+    keyColor={true}
+  >
+    Avocado
+  </a>,
+  .c0 {
   color: #0059b2;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .c0:focus,
 .c0:hover {
+  color: #0059b2;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
 <a
-  className="c0"
-  color="link"
-  href="https://looker.com"
-  textDecoration="none"
->
-  🥑
-</a>
+    className="c0"
+    href="https://looker.com"
+    underline={true}
+  >
+    Avocado
+  </a>,
+]
 `;

--- a/packages/components/src/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.test.tsx.snap
@@ -9,8 +9,11 @@ Array [
 }
 
 .c0:focus,
-.c0:hover {
-  color: #0059b2;
+.c0:hover,
+.c0:active,
+.c0.active,
+.c0:visited {
+  color: #00418c;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -28,8 +31,11 @@ Array [
 }
 
 .c0:focus,
-.c0:hover {
-  color: #6C43E0;
+.c0:hover,
+.c0:active,
+.c0.active,
+.c0:visited {
+  color: #4F2ABA;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -48,8 +54,11 @@ Array [
 }
 
 .c0:focus,
-.c0:hover {
-  color: #0059b2;
+.c0:hover,
+.c0:active,
+.c0.active,
+.c0:visited {
+  color: #00418c;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/packages/design-tokens/src/system/color/specifiable.ts
+++ b/packages/design-tokens/src/system/color/specifiable.ts
@@ -60,6 +60,12 @@ export interface IntentColors {
    */
   link: string
   /**
+   * Link text color on interaction
+   * Used for: Link :active, :focused and :hover states
+   * @default blue700
+   */
+  linkInteractive: string
+  /**
    * Critical intent color
    * Used for: Delete button, error and validation messages
    * @default red500

--- a/packages/design-tokens/src/tokens/color/index.ts
+++ b/packages/design-tokens/src/tokens/color/index.ts
@@ -31,6 +31,7 @@ import { fallbackBlends, fallbackStateful } from './fallbacks'
 import {
   blue500,
   blue600,
+  blue700,
   charcoal400,
   charcoal800,
   green500,
@@ -50,6 +51,7 @@ export const defaultCoreColors: CoreColors = {
 
 export const defaultIntentColors: IntentColors = {
   link: blue600,
+  linkInteractive: blue700,
   critical: red500,
   warn: yellow500,
   neutral: charcoal400,


### PR DESCRIPTION
@jhardy While working on this I realized that we don't provide `:visited` and `:active` states. Any thoughts on that?

### :sparkles: Changes

- A few places in the product have links the leverage the `key` color and have to manually override styles

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
