### PR TITLE
Tooltip: add Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- `Tooltip` now renders in a `Portal`
+
 ### Fixed
 
 - `DialogContent` with `borderBottom` prop CSS output error (no border, no flex: 8)

--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -153,20 +153,22 @@ test('IconButton renders focus ring on tab input but not on click', () => {
 
 test('IconButton has built-in tooltip', async () => {
   const label = 'Mark as my Favorite'
-  const { getByTitle, container } = renderWithTheme(
+  const { getByTitle, getAllByText } = renderWithTheme(
     <IconButton id="test-iconButton" label={label} icon="Favorite" />
   )
 
-  const notTooltip = container.querySelector('p') // Get Tooltip content
-  expect(notTooltip).toBeNull()
+  const notTooltip = getAllByText(label)
+  expect(notTooltip).toHaveLength(1) // accessibility text
 
   const icon = getByTitle('Favorite')
   fireEvent.mouseOver(icon)
-  const tooltip = container.querySelector('p') // Get Tooltip content
-  expect(tooltip).toHaveTextContent(label)
+
+  const tooltip = getAllByText(label)
+  expect(tooltip).toHaveLength(2)
+  expect(tooltip[1]).toBeVisible()
 
   fireEvent.mouseOut(icon)
-  await waitForElementToBeRemoved(() => container.querySelector('p'))
+  await waitForElementToBeRemoved(() => getAllByText(label)[1])
 })
 
 test('IconButton tooltipDisabled actually disables tooltip', () => {
@@ -189,9 +191,9 @@ test('IconButton tooltipDisabled actually disables tooltip', () => {
 test('IconButton built-in tooltip defers to outer tooltip', async () => {
   const tooltip = 'Add to favorites'
   const label = 'Mark as my Favorite'
-  const { container, getByText, getByTitle } = renderWithTheme(
+  const { getByText, getByTitle } = renderWithTheme(
     <Tooltip content={tooltip}>
-      <IconButton tooltipDisabled label={label} icon="Favorite" />
+      <IconButton label={label} icon="Favorite" />
     </Tooltip>
   )
 
@@ -203,9 +205,9 @@ test('IconButton built-in tooltip defers to outer tooltip', async () => {
   const iconLabel = getByText(label)
   expect(iconLabel).toBeInTheDocument()
 
-  const tooltipContents = container.querySelectorAll('p') // Get all Tooltip contents
-  expect(tooltipContents.length).toEqual(1)
+  const tooltipContents = getByText(tooltip) // Get all Tooltip contents
+  expect(tooltipContents).toBeVisible()
 
   fireEvent.mouseOut(icon)
-  await waitForElementToBeRemoved(() => container.querySelector('p'))
+  await waitForElementToBeRemoved(() => getByText(tooltip))
 })

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -44,6 +44,7 @@ import {
   useForkedRef,
 } from '../utils'
 import { OverlaySurface, SurfaceStyleProps } from '../Overlay/OverlaySurface'
+import { Portal } from '../Portal'
 import { TooltipContent } from './TooltipContent'
 
 export interface UseTooltipProps {
@@ -203,28 +204,30 @@ export function useTooltip({
 
   const popper =
     isOpen && content && !disabled ? (
-      <OverlaySurface
-        arrow={arrow}
-        arrowProps={arrowProps}
-        eventHandlers={{ onMouseOut: handleMouseOut }}
-        placement={placement}
-        ref={ref}
-        style={style}
-        backgroundColor="inverse"
-        borderRadius="medium"
-        boxShadow={3}
-        color="inverseOn"
-        {...surfaceStyles}
-      >
-        <TooltipContent
-          role="tooltip"
-          id={guaranteedId}
-          width={width}
-          textAlign={textAlign}
+      <Portal>
+        <OverlaySurface
+          arrow={arrow}
+          arrowProps={arrowProps}
+          eventHandlers={{ onMouseOut: handleMouseOut }}
+          placement={placement}
+          ref={ref}
+          style={style}
+          backgroundColor="inverse"
+          borderRadius="medium"
+          boxShadow={3}
+          color="inverseOn"
+          {...surfaceStyles}
         >
-          {content}
-        </TooltipContent>
-      </OverlaySurface>
+          <TooltipContent
+            role="tooltip"
+            id={guaranteedId}
+            width={width}
+            textAlign={textAlign}
+          >
+            {content}
+          </TooltipContent>
+        </OverlaySurface>
+      </Portal>
     ) : null
 
   return {

--- a/storybook/src/Overlays/Tooltip.stories.tsx
+++ b/storybook/src/Overlays/Tooltip.stories.tsx
@@ -25,14 +25,17 @@
  */
 
 import React from 'react'
-import { Space, IconButton, Tooltip } from '@looker/components'
+import { Card, Space, IconButton, Tooltip, Text } from '@looker/components'
 
 export const All = () => (
-  <Space>
-    <Basic />
-    <Placement />
-    <RenderProp />
-  </Space>
+  <>
+    <Space mb="large">
+      <Basic />
+      <Placement />
+      <RenderProp />
+    </Space>
+    <LargeTrigger />
+  </>
 )
 
 export default {
@@ -40,17 +43,29 @@ export default {
   title: 'Overlays/Tooltip',
 }
 
-const Basic = () => <Tooltip content="I'm a little teapot">Some Text</Tooltip>
+const Basic = () => (
+  <Tooltip content="I'm a little teapot">
+    <Text>Some Text</Text>
+  </Tooltip>
+)
 const Placement = () => (
   <Tooltip content="I'm a little teapot" placement="top">
-    Some Text
+    <Text>Some Text</Text>
   </Tooltip>
 )
 
 const RenderProp = () => (
-  <Tooltip content="Start editing" placement="top">
+  <Tooltip content="Start editing" placement="right">
     {(tooltipProps) => (
       <IconButton icon="Edit" label="Edit something" {...tooltipProps} />
     )}
+  </Tooltip>
+)
+
+const LargeTrigger = () => (
+  <Tooltip content="See what happens when you scroll" placement="right">
+    <Card width={500} height={800} raised p="large">
+      Very large trigger
+    </Card>
   </Tooltip>
 )


### PR DESCRIPTION
### :sparkles: Changes

- Tooltip being rendered next to its trigger keeps causing issues: unwanted margin in `Space`/`SpaceVertical` and being blocked by `Menu`/`Popover`
- The only reason I can remember to _not_ use `Portal` for `Tooltip` was that it might be awkward when scrolling, but PopperJS seems to handle this well

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue:
![tooltip-portal-issue](https://user-images.githubusercontent.com/53451193/86084000-977e2c80-ba50-11ea-9fc5-e91d9510c679.gif)
#### Fixed:
![tooltip-portal](https://user-images.githubusercontent.com/53451193/86084021-9fd66780-ba50-11ea-8b87-72858564a8dc.gif)
#### It's not weird when you scroll:
![scrolling](https://user-images.githubusercontent.com/53451193/86084041-acf35680-ba50-11ea-8ff8-2fed9a40a6b9.gif)

