### PR TITLE
Fieldset: Accordion mode auto-indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- `Fieldset` accordion mode auto-indents elements in the inner `AccordionContent`
+
 ### Fixed
 
 - `DialogContent` with `borderBottom` prop CSS output error (no border, no flex: 8)

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -182,6 +182,13 @@ export const Fieldset = styled(FieldsetLayout)`
   ${simpleLayoutCSS}
 
   ${AccordionContent} {
+    padding-left: ${({ theme }) => {
+      const borderWidth = '1px'
+      const defaultIndicatorSize = theme.space.medium
+      const defaultIndicatorGap = theme.space.xsmall
+
+      return `calc(${borderWidth} + ${defaultIndicatorSize} + ${defaultIndicatorGap})`
+    }};
     padding-top: ${({ theme }) => theme.space.medium};
   }
 

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`Fieldset 1`] = `
 }
 
 .c0 .c12 {
+  padding-left: calc(1px + 1rem + 0.5rem);
   padding-top: 1rem;
 }
 


### PR DESCRIPTION
### :sparkles: Changes

- `Fieldset` accordion mode now auto-indents children within inner `AccordionContent`

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="619" alt="Screen Shot 2020-06-30 at 3 16 19 PM" src="https://user-images.githubusercontent.com/16812885/86182370-af9f8b80-bae4-11ea-9810-51199e493d0e.png">

