### PR TITLE
Focus Trap: fix return focus & Popover > Dialog > Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `DialogContent` with `borderBottom` prop CSS output error (no border, no flex: 8)
+- `Dialog` focus not returning to trigger when closed
+- `Select` not opening when rendered in a `Dialog` opened from a `Popover`
 
 ## [0.9.4] - 2020-06-29
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -429,8 +429,13 @@ export function usePopover({
         // need to manually disable any parent focus trap
         parentFocusTrapRef &&
           parentFocusTrapRef.current &&
-          parentFocusTrapRef.current.deactivate({ returnFocus: false })
+          parentFocusTrapRef.current.pause()
       }
+    } else if (!focusTrap) {
+      // need to manually re-enable any parent focus trap
+      parentFocusTrapRef &&
+        parentFocusTrapRef.current &&
+        parentFocusTrapRef.current.unpause()
     }
   }, [focusTrap, parentFocusTrapRef, isOpen, enableFocusTrap])
 

--- a/storybook/src/Overlays/Popovers/Testing.stories.tsx
+++ b/storybook/src/Overlays/Popovers/Testing.stories.tsx
@@ -30,7 +30,7 @@ import {
   Button,
   ButtonOutline,
   ButtonTransparent,
-  DialogManager,
+  Dialog,
   FieldSelect,
   Heading,
   Menu,
@@ -41,7 +41,7 @@ import {
   Paragraph,
   Popover,
   PopoverContent,
-  Select,
+  SpaceVertical,
   usePopover,
   useToggle,
 } from '@looker/components'
@@ -86,7 +86,7 @@ export const PopoverFocusTrap = () => {
         content={
           <PopoverContent p="large" width="360px">
             <Paragraph>
-              Does tabbing focus only loop through these 3 buttons?
+              Does tabbing focus only loop through these 3 buttons &amp; Select?
             </Paragraph>
             <Paragraph>
               Does clicking (or mousedown) each trigger an alert?
@@ -111,6 +111,9 @@ export const PopoverFocusTrap = () => {
               aria-label="Fruits"
               defaultValue="1"
             />
+            <Paragraph>
+              Does it scroll here when the Select is closed?
+            </Paragraph>
             <Paragraph>Long text</Paragraph>
             <Paragraph>Long text</Paragraph>
             <Paragraph>Long text</Paragraph>
@@ -129,56 +132,84 @@ export const PopoverFocusTrap = () => {
       >
         <Button mt="medium">Open Focus Trap Test Popover</Button>
       </Popover>
+      <Paragraph>Does it scroll here when the Popover is closed?</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
+      <Paragraph>Long text</Paragraph>
     </Box>
   )
 }
 
-export const MenuOpenDialog = () => {
-  const { value, toggle } = useToggle(true)
-  function togglePopovers() {
-    toggle()
+export const OverlayOpenDialog = () => {
+  const { value, setOn, setOff } = useToggle()
+  function openAlert() {
+    alert(`It's working!`)
   }
-  useEffect(() => {
-    const int = window.setInterval(() => toggle(), 2000)
-    return () => {
-      window.clearInterval(int)
-    }
-  }, [toggle])
   return (
-    <Box mt="large">
-      <Heading>Menu Opening Dialog</Heading>
+    <SpaceVertical mt="large" align="start">
+      <Heading>Popover Opening a Dialog</Heading>
+      <Popover
+        content={
+          <Button m="large" onClick={setOn}>
+            Open Dialog
+          </Button>
+        }
+      >
+        <Button>Open Popover</Button>
+      </Popover>
+      <Dialog isOpen={value} onClose={setOff}>
+        <DialogContent>
+          <SpaceVertical align="start">
+            <Paragraph>Try opening the Select and picking an option:</Paragraph>
+            <FieldSelect
+              label="Default Value"
+              width={300}
+              options={options}
+              aria-label="Fruits"
+              defaultValue="1"
+            />
+            <Paragraph>Try clicking the button:</Paragraph>
+            <Button onClick={openAlert}>Open Alert</Button>
+          </SpaceVertical>
+        </DialogContent>
+      </Dialog>
+      <Heading>Menu Opening a Dialog</Heading>
       <Menu>
         <MenuDisclosure tooltip="Select your favorite kind">
           <Button mr="small" mt="medium">
             Open Menu
           </Button>
         </MenuDisclosure>
-        <DialogManager
-          content={
-            <DialogContent>
-              <Paragraph>Some content inside the Dialog</Paragraph>
-              <Button onClick={togglePopovers}>Open Alert</Button>
-              {value && <Placement />}
-            </DialogContent>
-          }
-        >
-          <MenuList>
-            <MenuItem>Open Dialog</MenuItem>
-          </MenuList>
-        </DialogManager>
+        <MenuList>
+          <MenuItem onClick={setOn}>Open Dialog</MenuItem>
+        </MenuList>
       </Menu>
-      <DialogManager
-        content={
-          <DialogContent>
-            <Paragraph>Some content inside the Dialog</Paragraph>
-            <Button onClick={togglePopovers}>Open Alert</Button>
-            {value && <Placement />}
-          </DialogContent>
-        }
-      >
-        {(onClick) => <Button onClick={onClick}>Open Modal</Button>}
-      </DialogManager>
-    </Box>
+    </SpaceVertical>
   )
 }
 
@@ -197,7 +228,7 @@ export const RenderProps = () => (
 
 export const RenderPropsSpread = () => (
   <Popover content={popoverContent}>
-    {(...props) => <button {...props}>Test</button>}
+    {(props) => <button {...props}>Test</button>}
   </Popover>
 )
 
@@ -206,9 +237,6 @@ export const Placement = () => {
     <PopoverContent>
       <Paragraph width={300} p="xxlarge">
         👋 Hello, I am a popover!
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Select options={[{ value: 'Apples' }, { value: 'Oranges' }]} />
       </Paragraph>
     </PopoverContent>
   )
@@ -221,8 +249,8 @@ export const Placement = () => {
           <Button>Default</Button>
         </Popover>
 
-        <Popover placement="top" content={popoverContent}>
-          <Button>Top</Button>
+        <Popover content={popoverContent}>
+          <Button>Default</Button>
         </Popover>
       </Box>
     </Box>

--- a/storybook/src/Overlays/Popovers/Testing.stories.tsx
+++ b/storybook/src/Overlays/Popovers/Testing.stories.tsx
@@ -41,6 +41,7 @@ import {
   Paragraph,
   Popover,
   PopoverContent,
+  Select,
   usePopover,
   useToggle,
 } from '@looker/components'
@@ -133,9 +134,16 @@ export const PopoverFocusTrap = () => {
 }
 
 export const MenuOpenDialog = () => {
-  function openAlert() {
-    alert(`It's working!`)
+  const { value, toggle } = useToggle(true)
+  function togglePopovers() {
+    toggle()
   }
+  useEffect(() => {
+    const int = window.setInterval(() => toggle(), 2000)
+    return () => {
+      window.clearInterval(int)
+    }
+  }, [toggle])
   return (
     <Box mt="large">
       <Heading>Menu Opening Dialog</Heading>
@@ -149,7 +157,8 @@ export const MenuOpenDialog = () => {
           content={
             <DialogContent>
               <Paragraph>Some content inside the Dialog</Paragraph>
-              <Button onClick={openAlert}>Open Alert</Button>
+              <Button onClick={togglePopovers}>Open Alert</Button>
+              {value && <Placement />}
             </DialogContent>
           }
         >
@@ -158,6 +167,17 @@ export const MenuOpenDialog = () => {
           </MenuList>
         </DialogManager>
       </Menu>
+      <DialogManager
+        content={
+          <DialogContent>
+            <Paragraph>Some content inside the Dialog</Paragraph>
+            <Button onClick={togglePopovers}>Open Alert</Button>
+            {value && <Placement />}
+          </DialogContent>
+        }
+      >
+        {(onClick) => <Button onClick={onClick}>Open Modal</Button>}
+      </DialogManager>
     </Box>
   )
 }
@@ -186,6 +206,9 @@ export const Placement = () => {
     <PopoverContent>
       <Paragraph width={300} p="xxlarge">
         👋 Hello, I am a popover!
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Select options={[{ value: 'Apples' }, { value: 'Oranges' }]} />
       </Paragraph>
     </PopoverContent>
   )
@@ -198,8 +221,8 @@ export const Placement = () => {
           <Button>Default</Button>
         </Popover>
 
-        <Popover content={popoverContent}>
-          <Button>Default</Button>
+        <Popover placement="top" content={popoverContent}>
+          <Button>Top</Button>
         </Popover>
       </Box>
     </Box>


### PR DESCRIPTION
### :sparkles: Changes

- This started off with the goal of getting the "return focus to trigger on Dialog close" behavior working again
- In the meantime, another bug presented itself where you can't open pick from (or sometimes even open) a `Select` rendered in a `Dialog` that was opened from a (still open) `Popover` – instead that original `Popover` inappropriately regains focus.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Select bug:
![overflow-edit-bug](https://user-images.githubusercontent.com/53451193/86205669-4f7a0b00-bb1f-11ea-84df-95bb8ef35d72.gif)

#### Fixed:
![overflow-edit-bug-fixed](https://user-images.githubusercontent.com/53451193/86205816-b5ff2900-bb1f-11ea-839a-1bf402c803ba.gif)
