### PR TITLE
InputText + theme.reset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DialogContent` with `borderBottom` prop CSS output error (no border, no flex: 8)
 - `Dialog` focus not returning to trigger when closed
+- `InputText` interacts poorly with `theme.reset` property in narrow cases
 - `Select` not opening when rendered in a `Dialog` opened from a `Popover`
 
 ## [0.9.4] - 2020-06-29

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -27,15 +27,18 @@
 import pick from 'lodash/pick'
 import omit from 'lodash/omit'
 import { IconNames } from '@looker/icons'
-import { omitStyledProps, space, SpaceProps } from '@looker/design-tokens'
+import {
+  omitStyledProps,
+  space,
+  SpaceProps,
+  reset,
+  layout,
+} from '@looker/design-tokens'
 import React, { forwardRef, MouseEvent, ReactNode, Ref, useRef } from 'react'
 import styled, { css } from 'styled-components'
 import { InputProps, inputPropKeys, InputTextTypeProps } from '../InputProps'
 import { innerInputStyle } from '../innerInputStyle'
-import {
-  SimpleLayoutProps,
-  simpleLayoutCSS,
-} from '../../../Layout/utils/simple'
+import { SimpleLayoutProps } from '../../../Layout/utils/simple'
 import { Icon } from '../../../Icon'
 import { Text } from '../../../Text'
 import { useForkedRef, useWrapEvent } from '../../../utils'
@@ -268,6 +271,8 @@ export const inputCSS = css`
 `
 
 export const InputText = styled(InputTextLayout)<InputTextProps>`
+  ${reset}
+
   align-items: center;
   cursor: text;
   display: inline-flex;
@@ -275,7 +280,8 @@ export const InputText = styled(InputTextLayout)<InputTextProps>`
   padding: ${({ theme: { space } }) => `${space.xxxsmall} ${space.xxsmall}`};
   width: ${({ autoResize }) => (autoResize ? 'auto' : '100%')};
 
-  ${simpleLayoutCSS}
+  ${layout}
+  ${space}
   ${inputCSS}
 
   ${InlineInputTextBase} {


### PR DESCRIPTION
### :sparkles: Changes

- Fixes output order of theme.reset within `InputText` this could cause situations where reset overrides default parameters.

##### Screenshot

![Screen Shot 2020-06-30 at 11 24 59 PM](https://user-images.githubusercontent.com/34253496/86210556-a84ea100-bb29-11ea-81e6-ead8278713dc.png)

Note that `InputChips` is not quite correct height.

##### CSS Problem

![Screen Shot 2020-06-30 at 11 25 02 PM](https://user-images.githubusercontent.com/34253496/86210523-9cfb7580-bb29-11ea-9509-033ffb329ee5.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
