### PR TITLE
Elliot/tree focus visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Fieldset` accordion mode auto-indents elements in the inner `AccordionContent`
+- `AccordionDisclosure`, `TreeItem` no longer display purple border on click
+  - This purple border will only display when tabbing onto a `TreeItem` or `AccordionDisclosure` (`Tree`)
 
 ### Fixed
 

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -24,64 +24,81 @@
 
  */
 
-import React, { FC, ReactNode, useContext } from 'react'
+import React, { FC, useContext, useState } from 'react'
 import styled from 'styled-components'
 import { TypographyProps, typography } from '@looker/design-tokens'
 import { AccordionContext } from './AccordionContext'
 import { AccordionDisclosureGrid } from './AccordionDisclosureGrid'
 
 export interface AccordionDisclosureProps extends TypographyProps {
-  children: ReactNode
   className?: string
+  focusVisible?: boolean
 }
 
 export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = ({
   children,
   className,
 }) => {
+  const [isFocusVisible, setFocusVisible] = useState(false)
   const { isOpen, toggleOpen, onClose, onOpen, ...props } = useContext(
     AccordionContext
   )
   const handleOpen = () => onOpen && onOpen()
   const handleClose = () => onClose && onClose()
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.keyCode === 13) {
-      event.currentTarget.click()
-    }
-  }
-  const handleClick = () => {
+  const handleToggle = () => {
     isOpen ? handleClose() : handleOpen()
     toggleOpen(!isOpen)
   }
 
+  const handleKeyUp = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.keyCode === 9 && event.currentTarget === event.target)
+      setFocusVisible(true)
+
+    if (event.keyCode === 13) {
+      handleToggle()
+    }
+  }
+
+  const handleClick = () => {
+    setFocusVisible(false)
+    handleToggle()
+  }
+
+  const handleBlur = () => {
+    setFocusVisible(false)
+  }
+
   return (
-    <div
+    <AccordionDisclosureStyle
       className={className}
+      onBlur={handleBlur}
       onClick={handleClick}
-      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
       tabIndex={0}
+      focusVisible={isFocusVisible}
     >
       <AccordionDisclosureGrid {...props} isOpen={isOpen}>
         {children}
       </AccordionDisclosureGrid>
-    </div>
+    </AccordionDisclosureStyle>
   )
 }
 
-export const AccordionDisclosure = styled(AccordionDisclosureLayout)`
-  ${typography}
-
+export const AccordionDisclosureStyle = styled.div<{ focusVisible: boolean }>`
   align-items: center;
   border: 1px solid transparent;
+  border-color: ${({ focusVisible, theme }) =>
+    focusVisible && theme.colors.keyFocus};
   cursor: pointer;
   display: flex;
+  height: 100%;
   outline: none;
   padding: ${({ theme: { space } }) => `${space.xsmall} ${space.none}`};
+  width: 100%;
+`
 
-  &:focus-within {
-    border-color: ${({ theme }) => theme.colors.keyFocus};
-  }
+export const AccordionDisclosure = styled(AccordionDisclosureLayout)`
+  ${typography}
 `
 
 AccordionDisclosure.defaultProps = {

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -31,6 +31,7 @@ import {
   Accordion,
   AccordionContent,
   AccordionDisclosure,
+  AccordionDisclosureStyle,
   AccordionProps,
   AccordionIndicatorProps,
 } from '../Accordion'
@@ -188,6 +189,9 @@ const TreeStyle = styled.div<TreeStyleProps>`
 
   ${AccordionDisclosure} {
     height: 25px;
+  }
+
+  ${AccordionDisclosureStyle} {
     padding: ${({ theme }) => theme.space.xxsmall};
     ${({ depth, theme }) => generateIndent(depth, theme)}
   }

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -31,6 +31,7 @@ import React, {
   ReactNode,
   useContext,
   useRef,
+  useState,
 } from 'react'
 import styled from 'styled-components'
 import { SpacingSizes, uiTransparencyBlend } from '@looker/design-tokens'
@@ -89,6 +90,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   const itemRef = useRef<HTMLDivElement>(null)
   const detailRef = useRef<HTMLDivElement>(null)
   const [isHovered] = useHovered(itemRef)
+  const [isFocusVisible, setFocusVisible] = useState(false)
 
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     if (detailRef.current && detailRef.current.contains(event.target as Node)) {
@@ -96,19 +98,26 @@ const TreeItemLayout: FC<TreeItemProps> = ({
       return
     }
 
+    setFocusVisible(false)
     onClick && onClick()
   }
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+  const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
     if (detailRef.current && detailRef.current.contains(event.target as Node)) {
       event.stopPropagation()
       return
     }
 
-    if (event.keyCode === 13) {
-      event.currentTarget.click()
-    }
+    if (event.keyCode === 9 && event.currentTarget === event.target)
+      setFocusVisible(true)
+
+    if (event.keyCode === 13) onClick && onClick()
   }
+
+  const handleBlur = () => {
+    setFocusVisible(false)
+  }
+
   const defaultIconSize = 12
 
   const detailAccessory =
@@ -129,11 +138,13 @@ const TreeItemLayout: FC<TreeItemProps> = ({
 
   return (
     <HoverDisclosureContext.Provider value={{ visible: isHovered }}>
-      <Space
+      <TreeItemSpace
         className={props.className}
+        focusVisible={isFocusVisible}
         gap="none"
+        onBlur={handleBlur}
         onClick={handleClick}
-        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
         ref={itemRef}
         tabIndex={onClick ? 0 : -1}
       >
@@ -143,22 +154,26 @@ const TreeItemLayout: FC<TreeItemProps> = ({
           {!detailAccessory && detail}
         </TreeItemLabel>
         {detailAccessory && detail}
-      </Space>
+      </TreeItemSpace>
     </HoverDisclosureContext.Provider>
   )
 }
 
-export const TreeItem = styled(TreeItemLayout)`
+export const TreeItem = styled(TreeItemLayout)``
+
+interface TreeItemSpace {
+  focusVisible: boolean
+}
+
+export const TreeItemSpace = styled(Space)<TreeItemSpace>`
   align-items: center;
   border: 1px solid transparent;
+  border-color: ${({ focusVisible, theme }) =>
+    focusVisible && theme.colors.keyFocus};
   cursor: ${({ onClick }) => onClick && 'pointer'};
   display: flex;
   height: 25px;
   outline: none;
-
-  &:focus-within {
-    border-color: ${({ theme: { colors } }) => colors.keyFocus};
-  }
 `
 
 interface TreeItemLabelProps {

--- a/storybook/src/Tree/FieldPicker.stories.tsx
+++ b/storybook/src/Tree/FieldPicker.stories.tsx
@@ -119,6 +119,7 @@ const PickerItem = () => {
             </>
           }
           detailHoverDisclosure={!overlay}
+          onClick={() => alert('Clicked on cost!')}
           selected={!!overlay}
           icon="FieldNumber"
         >


### PR DESCRIPTION
### :sparkles: Changes

- `TreeItem` and `Tree` / `AccordionDisclosure` no longer display a purple border on click
  - The only time said border will display is when you tab onto a `TreeItem` or `Tree` / `AccordionDisclosure`

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
Purple border on `Tree` / `AccordionDisclosure` after tab traversal:
![Screen Shot 2020-07-01 at 10 29 34 AM](https://user-images.githubusercontent.com/16812885/86274072-fc876e80-bb85-11ea-9cfb-7fde42c46704.png)

Purple border on `TreeItem` after tab traversal:
![Screen Shot 2020-07-01 at 10 29 39 AM](https://user-images.githubusercontent.com/16812885/86274080-001af580-bb86-11ea-97be-27e1fdc9d0d4.png)

No border on click:
![click-no-border](https://user-images.githubusercontent.com/16812885/86274087-04dfa980-bb86-11ea-8142-572bd3fef505.gif)
