### PR TITLE
Select/SelectMulti: fix filtering keyboard nav, onBlur behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Select`/`SelectMulti` keyboard navigation when filtering and going from > 100 to < 100 options
+- `SelectMulti` with `freeInput` not saving input value on tab key
 
 ## [0.9.5] - 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Select`/`SelectMulti` keyboard navigation when filtering and going from > 100 to < 100 options
 - `SelectMulti` with `freeInput` not saving input value on tab key
+- `SelectMulti` list not closing on blur
 
 ## [0.9.5] - 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+
+- `Select`/`SelectMulti` keyboard navigation when filtering and going from > 100 to < 100 options
+
 ## [0.9.5] - 2020-07-01
 
 ### Added

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -151,7 +151,9 @@ const ComboboxListInternal = forwardRef(
     }, [optionsRef, isVisible, windowedOptions, windowedOptionsPropRef])
 
     const handleKeyDown = useKeyDown()
-    const handleBlur = useBlur()
+    const handleBlur = isMulti
+      ? useBlur(ComboboxMultiContext)
+      : useBlur(ComboboxContext)
     const ref = useForkedRef(listRef, forwardedRef)
 
     // Avoid calling getBoundingClientWidth if width/minWidth are set in props

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -133,7 +133,6 @@ const ComboboxListInternal = forwardRef(
     if (persistSelectionPropRef)
       persistSelectionPropRef.current = persistSelection
     if (closeOnSelectPropRef) closeOnSelectPropRef.current = closeOnSelect
-    if (windowedOptionsPropRef) windowedOptionsPropRef.current = windowedOptions
     if (indicatorPropRef) indicatorPropRef.current = indicator
 
     // WEIRD? Reset the options ref every render so that they are always
@@ -141,13 +140,15 @@ const ComboboxListInternal = forwardRef(
     // effect to schedule this effect before the ComboboxOptions push into
     // the array
     useLayoutEffect(() => {
+      if (windowedOptionsPropRef)
+        windowedOptionsPropRef.current = windowedOptions
       if (optionsRef) optionsRef.current = []
       return () => {
         if (optionsRef) optionsRef.current = []
       }
       // Without isVisible in the dependency array,
       // updated options won't go into the optionsRef array
-    }, [optionsRef, isVisible])
+    }, [optionsRef, isVisible, windowedOptions, windowedOptionsPropRef])
 
     const handleKeyDown = useKeyDown()
     const handleBlur = useBlur()

--- a/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
@@ -26,14 +26,19 @@
 
 // Much of the following is pulled from https://github.com/reach/reach-ui
 // because their work is fantastic (but is not in TypeScript)
-import { useContext } from 'react'
-import { ComboboxContext } from '../ComboboxContext'
+import { Context, useContext } from 'react'
+import {
+  ComboboxContextProps,
+  ComboboxMultiContextProps,
+} from '../ComboboxContext'
 import { ComboboxActionType, ComboboxState } from './state'
 
-export function useBlur() {
-  const { state, transition, listRef, inputElement } = useContext(
-    ComboboxContext
-  )
+export function useBlur<
+  TContext extends
+    | ComboboxContextProps
+    | ComboboxMultiContextProps = ComboboxContextProps
+>(context: Context<TContext>) {
+  const { state, transition, listRef, inputElement } = useContext(context)
 
   return function handleBlur() {
     requestAnimationFrame(() => {

--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
@@ -92,7 +92,7 @@ export function useInputEvents<
 
   const handleKeyDown = useKeyDown()
 
-  const handleBlur = useBlur()
+  const handleBlur = useBlur(context)
 
   function handleFocus(e: FocusEvent<HTMLInputElement>) {
     if (readOnly) {

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -34,7 +34,7 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 
-import { useControlWarn } from '../../../utils'
+import { useControlWarn, useWrapEvent } from '../../../utils'
 import {
   InputChipsBase,
   InputChipsCommonProps,
@@ -110,12 +110,17 @@ export const InputChipsInternal = forwardRef(
     {
       values,
       onChange,
-      onKeyDown,
       inputValue: controlledInputValue,
       onInputChange,
       validate,
       onValidationFail,
       onDuplicate,
+
+      // event handlers needing to be wrapped
+      onBlur,
+      onKeyDown,
+      onPaste,
+
       ...props
     }: InputChipsProps,
     ref: Ref<HTMLInputElement>
@@ -174,8 +179,7 @@ export const InputChipsInternal = forwardRef(
     }
 
     function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
-      onKeyDown && onKeyDown(e)
-      if (!e.defaultPrevented && e.key === 'Enter') {
+      if (e.key === 'Enter') {
         // Don't submit a form if there is one
         e.preventDefault()
         // Update values when the user hits return
@@ -203,6 +207,12 @@ export const InputChipsInternal = forwardRef(
       }
     }
 
+    const wrappedEvents = {
+      onBlur: useWrapEvent(handleBlur, onBlur),
+      onKeyDown: useWrapEvent(handleKeyDown, onKeyDown),
+      onPaste: useWrapEvent(handlePaste, onPaste),
+    }
+
     return (
       <InputChipsBase
         ref={ref}
@@ -210,9 +220,7 @@ export const InputChipsInternal = forwardRef(
         onChange={onChange}
         inputValue={inputValue}
         onInputChange={handleInputChange}
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
+        {...wrappedEvents}
         {...props}
       />
     )

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
@@ -287,5 +287,26 @@ describe('closeOnSelect', () => {
 
       fireEvent.click(document)
     })
+
+    test('creates value on blur', () => {
+      const onChangeMock = jest.fn()
+      renderWithTheme(
+        <SelectMulti
+          options={basicOptions}
+          placeholder="Search"
+          onChange={onChangeMock}
+          freeInput
+        />
+      )
+
+      const input = screen.getByPlaceholderText('Search')
+      fireEvent.change(input, { target: { value: 'baz' } })
+      fireEvent.blur(input)
+
+      expect(onChangeMock).toHaveBeenCalledWith(['baz'])
+      expect(input).toHaveValue('')
+
+      fireEvent.click(document)
+    })
   })
 })

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
@@ -25,7 +25,12 @@
  */
 
 import { renderWithTheme } from '@looker/components-test-utils'
-import { cleanup, fireEvent, screen } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import React from 'react'
 
 import { SelectMulti } from './SelectMulti'
@@ -288,7 +293,7 @@ describe('closeOnSelect', () => {
       fireEvent.click(document)
     })
 
-    test('creates value on blur', () => {
+    test('creates value and closes list on blur', async () => {
       const onChangeMock = jest.fn()
       renderWithTheme(
         <SelectMulti
@@ -301,12 +306,13 @@ describe('closeOnSelect', () => {
 
       const input = screen.getByPlaceholderText('Search')
       fireEvent.change(input, { target: { value: 'baz' } })
+      expect(screen.getByRole('listbox')).toBeVisible()
       fireEvent.blur(input)
 
       expect(onChangeMock).toHaveBeenCalledWith(['baz'])
       expect(input).toHaveValue('')
 
-      fireEvent.click(document)
+      await waitForElementToBeRemoved(() => screen.getByRole('listbox'))
     })
   })
 })

--- a/storybook/src/Forms/Select.stories.tsx
+++ b/storybook/src/Forms/Select.stories.tsx
@@ -200,8 +200,8 @@ export function SelectContent() {
     setSearchTerm(term)
   }
   const newOptions = useMemo(() => {
-    if (searchTerm === '') return optionsWithGroups
-    return optionsWithGroups.reduce(optionReducer(searchTerm), [])
+    if (searchTerm === '') return options1k
+    return options1k.reduce(optionReducer(searchTerm), [])
   }, [searchTerm])
   return (
     <Box p="large">


### PR DESCRIPTION
### :sparkles: Changes

- The keyboard nav was still broke when filtering down from > 100 options to < 100 options due to windowed options weirdness
- `SelectMulti` onBlur was doubly broken:
  - with `freeInput` it wasn't creating a chip onBlur because the blur handler from `ComboboxMultiInput` > `useInputEvents` > `useBlur` was clobbering that of `InputChips`
  - but that blur handler was broken itself, looking only for `ComboboxContext` and not `ComboboxMultiContext`

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issues:
![2020-06-30 12 19 49](https://user-images.githubusercontent.com/53451193/86293842-46814c00-bba8-11ea-8922-d7c6666b20b5.gif)
![2020-06-30 12 15 07](https://user-images.githubusercontent.com/53451193/86293852-4aad6980-bba8-11ea-9d60-8963fa3ca36a.gif)
#### Fixes:
![blur-fix](https://user-images.githubusercontent.com/53451193/86294005-8b0ce780-bba8-11ea-9e02-b8020db78696.gif)
![filter-fix](https://user-images.githubusercontent.com/53451193/86294006-8c3e1480-bba8-11ea-922c-0b52a0ad96e9.gif)
