### PR TITLE
Gatsby Sidebar SEO

### DIFF
--- a/packages/components/src/Sidebar/SidebarGroup.tsx
+++ b/packages/components/src/Sidebar/SidebarGroup.tsx
@@ -59,7 +59,9 @@ const InternalSidebarGroup: FC<SidebarGroupProps> = ({
           <Icon size={20} name={isOpen ? 'CaretUp' : 'CaretDown'} />
         </button>
       </SidebarGroupHeading>
-      {isOpen && <Box px="medium">{children}</Box>}
+      <Box px="medium" height={isOpen ? 'auto' : '0'} overflow="hidden">
+        {children}
+      </Box>
     </section>
   )
 }


### PR DESCRIPTION
### :sparkles: Changes

- This PR updates the method we use to toggle sidebar links. Rather than removing links from the dom entirely, I simply shrink the container to `height: 0` so that the hidden links will still be in the dom. This will hopefully alert Google search to the existence of other pages, allowing google site-search as a stopgap solution until proper search functionality is implemented. Per @whscullin's [request](https://looker.slack.com/archives/C9NHFLY0G/p1593627269194000?thread_ts=1593624285.191300&cid=C9NHFLY0G)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC


