### PR TITLE
zIndexFloor defaults to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `theme.zIndexFloor` now defaults to `1` instead of `undefined` (this helps with compatibility due to Firefox's stacking order eccentricities)
 - `Tooltip` now renders in a `Portal`
 
 ### Fixed

--- a/packages/design-tokens/src/theme.ts
+++ b/packages/design-tokens/src/theme.ts
@@ -82,7 +82,7 @@ export interface Theme {
   shadows: Shadows
   space: SpaceRamp
   transitions: Transitions
-  zIndexFloor?: number
+  zIndexFloor: number
 }
 
 export const theme: Theme = {
@@ -98,4 +98,5 @@ export const theme: Theme = {
   sizes,
   space,
   transitions,
+  zIndexFloor: 1,
 }


### PR DESCRIPTION
### :sparkles: Changes

- CORE product needs a zIndexFloor due to Firefox issue with `order` - this could be an issue with other use cases as well so setting a `1` seems like a logical, light-weight fix.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
