### PR TITLE
TabList now supports distribute prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Tooltip` now renders in a `Portal`
+- `TabList` now supports distribute prop
 
 ### Fixed
 

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -25,18 +25,21 @@
  */
 
 import React, { Children, cloneElement, FC } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import { Tab } from '.'
 
 export interface TabListProps {
   children: JSX.Element[]
   selectedIndex?: number
   onSelectTab?: (index: any) => void
+  className?: string
+  distribute?: boolean
 }
-
-export const TabList: FC<TabListProps> = ({
+const TabListLayout: FC<TabListProps> = ({
   children,
   selectedIndex,
   onSelectTab,
+  className,
 }) => {
   const clonedChildren = Children.map(
     children,
@@ -48,10 +51,17 @@ export const TabList: FC<TabListProps> = ({
       })
     }
   )
-
-  return <TabListContainer>{clonedChildren}</TabListContainer>
+  return <div className={className}>{clonedChildren}</div>
 }
-
-const TabListContainer = styled.div`
+const distributeTabsCSS = css`
+  column-gap: ${(props) => props.theme.space.medium};
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(3rem, auto));
+  ${Tab} {
+    padding: 0 1rem; /* Not dumb here */
+  }
+`
+export const TabList = styled(TabListLayout)`
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};
+  ${({ distribute }) => distribute && distributeTabsCSS}
 `

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -35,6 +35,7 @@ export interface TabListProps {
   className?: string
   distribute?: boolean
 }
+
 const TabListLayout: FC<TabListProps> = ({
   children,
   selectedIndex,
@@ -53,16 +54,25 @@ const TabListLayout: FC<TabListProps> = ({
   )
   return <div className={className}>{clonedChildren}</div>
 }
+
 const distributeTabsCSS = css`
   column-gap: ${(props) => props.theme.space.medium};
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(3rem, auto));
+  grid-gap: ${(props) => props.theme.space.none};
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(${(props) => props.theme.space.xlarge}, auto)
+  );
+
   ${Tab} {
     font-size: ${(props) => props.theme.fontSizes.xsmall};
-    margin-left: 0;
-    padding: 0 1rem 0.5rem;
+    margin-left: ${(props) => props.theme.space.none};
+    padding: ${(props) => props.theme.space.none}
+      ${(props) => props.theme.space.medium}
+      ${(props) => props.theme.space.xsmall};
   }
 `
+
 export const TabList = styled(TabListLayout)`
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};
   ${({ distribute }) => distribute && distributeTabsCSS}

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -58,7 +58,9 @@ const distributeTabsCSS = css`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(3rem, auto));
   ${Tab} {
-    padding: 0 1rem; /* Not dumb here */
+    font-size: ${(props) => props.theme.fontSizes.xsmall};
+    margin-left: 0;
+    padding: 0 1rem 0.5rem;
   }
 `
 export const TabList = styled(TabListLayout)`

--- a/storybook/src/Tabs.stories.tsx
+++ b/storybook/src/Tabs.stories.tsx
@@ -46,18 +46,17 @@ export default {
   title: 'Tabs',
 }
 
-
 export const Basic: FC = () => (
   <Tabs>
     <TabList>
-      <Tab>Light Blue</Tab>
-      <Tab>Coral</Tab>
+      <Tab>Alice Blue</Tab>
+      <Tab>Aqua</Tab>
     </TabList>
     <TabPanels>
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'lightblue',
+            backgroundColor: '#F0F8FF',
             height: '350px',
           }}
         />
@@ -65,7 +64,7 @@ export const Basic: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'coral',
+            backgroundColor: '#00FFFF',
             height: '200px',
           }}
         />
@@ -93,7 +92,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'RebeccaPurple',
+            backgroundColor: '#663399',
             height: '350px',
           }}
         />
@@ -101,7 +100,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'coral',
+            backgroundColor: '#FF7F50',
             height: '350px',
           }}
         />
@@ -109,7 +108,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'ForestGreen',
+            backgroundColor: '#228B22',
             height: '350px',
           }}
         />
@@ -117,7 +116,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'CornflowerBlue',
+            backgroundColor: '#6495ED',
             height: '350px',
           }}
         />
@@ -125,7 +124,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'lightblue',
+            backgroundColor: '#ADD8E6',
             height: '350px',
           }}
         />
@@ -133,7 +132,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'DarkOrange',
+            backgroundColor: '#FF8C00',
             height: '350px',
           }}
         />
@@ -141,7 +140,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'DeepPink',
+            backgroundColor: '#FF1493',
             height: '350px',
           }}
         />
@@ -149,7 +148,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'Gold',
+            backgroundColor: '#FFD700',
             height: '350px',
           }}
         />
@@ -157,7 +156,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'Gainsboro',
+            backgroundColor: '#DCDCDC',
             height: '350px',
           }}
         />
@@ -165,7 +164,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'YellowGreen',
+            backgroundColor: '#9ACD32',
             height: '350px',
           }}
         />
@@ -173,7 +172,7 @@ export const DistributeTabs: FC = () => (
       <TabPanel>
         <div
           style={{
-            backgroundColor: 'DarkMagenta',
+            backgroundColor: '#8B008B',
             height: '350px',
           }}
         />

--- a/storybook/src/Tabs.stories.tsx
+++ b/storybook/src/Tabs.stories.tsx
@@ -25,7 +25,27 @@
  */
 
 import React, { FC } from 'react'
-import { Tab, Tabs, TabList, TabPanel, TabPanels } from '@looker/components'
+import {
+  SpaceVertical,
+  Tab,
+  Tabs,
+  TabList,
+  TabPanel,
+  TabPanels,
+} from '@looker/components'
+
+export const All = () => (
+  <SpaceVertical>
+    <Basic />
+    <DistributeTabs />
+  </SpaceVertical>
+)
+
+export default {
+  component: All,
+  title: 'Tabs',
+}
+
 
 export const Basic: FC = () => (
   <Tabs>
@@ -54,7 +74,110 @@ export const Basic: FC = () => (
   </Tabs>
 )
 
-export default {
-  component: Basic,
-  title: 'Tabs',
-}
+export const DistributeTabs: FC = () => (
+  <Tabs>
+    <TabList distribute>
+      <Tab>Rebecca Purple</Tab>
+      <Tab>Coral</Tab>
+      <Tab>Forest Green</Tab>
+      <Tab>Cornflower Blue</Tab>
+      <Tab>Light Blue</Tab>
+      <Tab>Dark Orange</Tab>
+      <Tab>Deep Pink</Tab>
+      <Tab>Gold</Tab>
+      <Tab>Gainsboro</Tab>
+      <Tab>Yellow Green</Tab>
+      <Tab>Dark Magenta</Tab>
+    </TabList>
+    <TabPanels>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'RebeccaPurple',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'coral',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'ForestGreen',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'CornflowerBlue',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'lightblue',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'DarkOrange',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'DeepPink',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'Gold',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'Gainsboro',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'YellowGreen',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+      <TabPanel>
+        <div
+          style={{
+            backgroundColor: 'DarkMagenta',
+            height: '350px',
+          }}
+        />
+      </TabPanel>
+    </TabPanels>
+  </Tabs>
+)

--- a/www/src/documentation/components/content/tabs.mdx
+++ b/www/src/documentation/components/content/tabs.mdx
@@ -68,6 +68,55 @@ To create a disabled Tab add the disabled prop. You must still create a TabPanel
 </Tabs>
 ```
 
+## Distribute Attribute
+
+Using the distribute porp on `TabList` will equally distributed each `Tab` in the container.
+
+```jsx
+<Tabs>
+  <TabList distribute>
+    <Tab>Rebecca Purple</Tab>
+    <Tab>Coral</Tab>
+    <Tab>Forest Green</Tab>
+    <Tab>Cornflower Blue</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <div
+        style={{
+          backgroundColor: 'RebeccaPurple',
+          height: '350px',
+        }}
+      />
+    </TabPanel>
+    <TabPanel>
+      <div
+        style={{
+          backgroundColor: 'coral',
+          height: '350px',
+        }}
+      />
+    </TabPanel>
+    <TabPanel>
+      <div
+        style={{
+          backgroundColor: 'ForestGreen',
+          height: '350px',
+        }}
+      />
+    </TabPanel>
+    <TabPanel>
+      <div
+        style={{
+          backgroundColor: 'CornflowerBlue',
+          height: '350px',
+        }}
+      />
+    </TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
 ## Tab using Hooks
 
 ```jsx


### PR DESCRIPTION
### :sparkles: Changes

- TabList now supports distribute prop

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="750" alt="Screen Shot 2020-07-06 at 1 43 19 PM" src="https://user-images.githubusercontent.com/23616264/86639984-b9b30580-bf8e-11ea-8a93-59a43e0f0433.png">
