### PR TITLE
Tree: Style Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `undefinedCoalesce` util function
 - `Link` now supports explicit `underline` & `keyColor` properties
 - `FactCheck` icon
+- `TreeItem` and `Tree`
+  - Altered style defaults
+- `iconSizes` style function includes `xxsmall` case
 
 ### Changed
 

--- a/packages/components/src/Button/icon.ts
+++ b/packages/components/src/Button/icon.ts
@@ -70,6 +70,7 @@ export const iconMargins = (props: ButtonProps) => {
 export const iconSizes = (props: ButtonProps) => {
   let iconSize = 18
   switch (props.size) {
+    case 'xxsmall':
     case 'xsmall':
       iconSize = 12
       break

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -25,7 +25,7 @@
  */
 
 import styled, { css } from 'styled-components'
-import { FontWeights, Theme, uiTransparencyBlend } from '@looker/design-tokens'
+import { Theme, uiTransparencyBlend } from '@looker/design-tokens'
 import React, { FC, ReactNode, useContext, useRef } from 'react'
 import {
   Accordion,
@@ -65,11 +65,6 @@ export interface TreeProps extends AccordionProps {
    */
   detailAccessory?: boolean
   /**
-   * The font weight of the Tree's text
-   * @default 'semiBold'
-   */
-  fontWeight?: FontWeights
-  /**
    * Icon element that appears between the Tree indicator and the Tree label
    */
   icon?: IconNames
@@ -78,6 +73,11 @@ export interface TreeProps extends AccordionProps {
    * Note: This is a required prop
    */
   label: ReactNode
+  /**
+   * If true, the internal AccordionDisclosure will have fontWeight = 'Normal'
+   * @default false
+   */
+  visuallyAsBranch?: boolean
 }
 
 const indicatorProps: AccordionIndicatorProps = {
@@ -95,9 +95,9 @@ const TreeLayout: FC<TreeProps> = ({
   detail,
   detailHoverDisclosure: propsDetailHoverDisclosure,
   detailAccessory: propsDetailAccessory,
-  fontWeight,
   icon,
   label,
+  visuallyAsBranch,
   ...restProps
 }) => {
   const disclosureRef = useRef<HTMLDivElement>(null)
@@ -129,7 +129,10 @@ const TreeLayout: FC<TreeProps> = ({
 
   const innerAccordion = (
     <Accordion {...indicatorProps} {...restProps}>
-      <AccordionDisclosure ref={disclosureRef} fontWeight={fontWeight}>
+      <AccordionDisclosure
+        ref={disclosureRef}
+        fontWeight={visuallyAsBranch ? 'normal' : 'semiBold'}
+      >
         {treeItem}
       </AccordionDisclosure>
       <AccordionContent>{children}</AccordionContent>

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -121,7 +121,6 @@ const TreeLayout: FC<TreeProps> = ({
       detail={detail}
       detailAccessory={hasDetailAccessory}
       detailHoverDisclosure={hasDetailHoverDisclosure}
-      gapSize="xsmall"
       icon={icon}
     >
       {label}

--- a/packages/components/src/Tree/TreeGroup.tsx
+++ b/packages/components/src/Tree/TreeGroup.tsx
@@ -54,6 +54,7 @@ export const TreeGroup = styled(TreeGroupLayout)`
 export const TreeGroupLabel = styled.div`
   /* Border is here to get proper alignment with Tree and TreeItem text */
   border: 1px transparent solid;
+  color: ${({ theme }) => theme.colors.text2};
   font-size: ${({ theme }) => theme.fontSizes.xxsmall};
   font-weight: ${({ theme }) => theme.fontWeights.semiBold};
   padding: ${({ theme: { space } }) => `${space.xsmall} ${space.xxsmall}`};

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -187,7 +187,9 @@ const TreeItemLayout: FC<TreeItemProps> = ({
         {...restProps}
       >
         <TreeItemLabel gap={gapSize} hovered={isHovered} selected={selected}>
-          {props.icon && <Icon name={props.icon} size={defaultIconSize} />}
+          {props.icon && (
+            <PrimaryIcon name={props.icon} size={defaultIconSize} />
+          )}
           <FlexItem flex="1">{children}</FlexItem>
           {!detailAccessory && detail}
         </TreeItemLabel>
@@ -197,7 +199,9 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   )
 }
 
-export const TreeItem = styled(TreeItemLayout)``
+const PrimaryIcon = styled(Icon)`
+  opacity: 0.5;
+`
 
 interface TreeItemSpace {
   focusVisible: boolean
@@ -234,4 +238,8 @@ const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`
   height: 100%;
   padding-right: ${({ detailAccessory, theme }) =>
     detailAccessory && theme.space.xxsmall};
+`
+
+export const TreeItem = styled(TreeItemLayout)`
+  color: ${({ theme }) => theme.colors.text2};
 `

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -92,7 +92,7 @@ export interface TreeItemProps extends CompatibleHTMLProps<HTMLDivElement> {
 const TreeItemLayout: FC<TreeItemProps> = ({
   children,
   className,
-  gapSize = 'xxsmall',
+  gapSize = 'xsmall',
   selected,
   ...props
 }) => {

--- a/storybook/src/Tree/FieldPicker.stories.tsx
+++ b/storybook/src/Tree/FieldPicker.stories.tsx
@@ -114,6 +114,7 @@ const PickerItem = () => {
               </MenuDisclosure>
             </>
           }
+          detailHoverDisclosure={!overlay}
           onClick={() => alert('Clicked on cost!')}
           selected={!!overlay}
           icon="FieldNumber"
@@ -128,6 +129,7 @@ const PickerItem = () => {
 export const FieldPicker = () => (
   <Tree
     defaultOpen
+    detailAccessory
     detail={
       <ButtonTransparent
         size="xxsmall"

--- a/storybook/src/Tree/FieldPicker.stories.tsx
+++ b/storybook/src/Tree/FieldPicker.stories.tsx
@@ -69,10 +69,6 @@ const PickerItem = () => {
       onKeyDown={(event) => {
         event.stopPropagation()
       }}
-      style={{
-        background: '#fff',
-        height: '18px',
-      }}
     />
   )
 
@@ -118,7 +114,6 @@ const PickerItem = () => {
               </MenuDisclosure>
             </>
           }
-          detailHoverDisclosure={!overlay}
           onClick={() => alert('Clicked on cost!')}
           selected={!!overlay}
           icon="FieldNumber"
@@ -133,7 +128,6 @@ const PickerItem = () => {
 export const FieldPicker = () => (
   <Tree
     defaultOpen
-    detailAccessory
     detail={
       <ButtonTransparent
         size="xxsmall"

--- a/storybook/src/Tree/Tree.stories.tsx
+++ b/storybook/src/Tree/Tree.stories.tsx
@@ -51,31 +51,31 @@ export default {
 
 export const FileSelector = () => (
   <Tree label="thelook" icon="ExploreOutline" defaultOpen>
-    <Tree label="Orders" icon="VisibilityOutline" defaultOpen>
-      <Tree label="Orders" icon="Table" defaultOpen>
+    <Tree visuallyAsBranch label="Orders" icon="VisibilityOutline" defaultOpen>
+      <Tree visuallyAsBranch label="Orders" icon="Table" defaultOpen>
         <TreeItem icon="IdeDimension">ID</TreeItem>
         <TreeItem icon="IdeDimension">Status</TreeItem>
         <TreeItem icon="IdeDimensionGroup">Created</TreeItem>
       </Tree>
-      <Tree label="Products" icon="Table" defaultOpen>
+      <Tree visuallyAsBranch label="Products" icon="Table" defaultOpen>
         <TreeItem icon="IdeDimension">Brand</TreeItem>
         <TreeItem icon="IdeDimension">ID</TreeItem>
         <TreeItem icon="IdeDimension">Department</TreeItem>
         <TreeItem icon="IdeDimension">Sku</TreeItem>
       </Tree>
-      <Tree label="Users" icon="Table" defaultOpen>
+      <Tree visuallyAsBranch label="Users" icon="Table" defaultOpen>
         <TreeItem icon="IdeDimension">ID</TreeItem>
         <TreeItem icon="IdeDimension">Name</TreeItem>
         <TreeItem icon="IdeDimensionGroup">Created</TreeItem>
       </Tree>
     </Tree>
-    <Tree label="Users" icon="VisibilityOutline" defaultOpen>
-      <Tree label="Orders" icon="Table" defaultOpen>
+    <Tree visuallyAsBranch label="Users" icon="VisibilityOutline" defaultOpen>
+      <Tree visuallyAsBranch label="Orders" icon="Table" defaultOpen>
         <TreeItem icon="IdeDimension">ID</TreeItem>
         <TreeItem icon="IdeDimension">Status</TreeItem>
         <TreeItem icon="IdeDimensionGroup">Created</TreeItem>
       </Tree>
-      <Tree label="Users" icon="Table" defaultOpen>
+      <Tree visuallyAsBranch label="Users" icon="Table" defaultOpen>
         <TreeItem icon="IdeDimension">ID</TreeItem>
         <TreeItem icon="IdeDimension">Name</TreeItem>
         <TreeItem icon="IdeDimensionGroup">Created</TreeItem>

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -39,21 +39,21 @@ Use `detail` to display an element in the negative space of the `Tree` label.
 </Tree>
 ```
 
-If you'd like a `Tree`'s entire disclosure to trigger opening and closing on click, avoid the `detail` prop and instead pass a composition into the `label` prop, like so:
+Use the `visuallyAsBranch` prop if you'd like your `Tree`'s disclosure text to have a "normal" font weight.
+
+This is especially useful when you want a nested `Tree` to match its sibling `TreeItem`s
 
 ```jsx
-<Tree
-  label={
-    <Space between>
-      <Text fontSize="xsmall">Orders</Text>
-      <Text fontSize="xsmall" color="ui4">
-        thelook
-      </Text>
-    </Space>
-  }
-  icon="Table"
->
-  <TreeItem icon="FieldNumber">Cost</TreeItem>
+<Tree label="Orders" icon="Table" defaultOpen>
+  <Tree visuallyAsBranch label="Created" defaultOpen>
+    <TreeItem>Created Date</TreeItem>
+    <TreeItem>Created Month</TreeItem>
+    <TreeItem>Created Year</TreeItem>
+    <TreeItem>Created Quarter</TreeItem>
+  </Tree>
+  <TreeItem>Cost</TreeItem>
+  <TreeItem>Location</TreeItem>
+  <TreeItem>ID</TreeItem>
 </Tree>
 ```
 


### PR DESCRIPTION
### :sparkles: Changes

- **Note:** All changes were made in response to design feedback from New Explore Experience
- `iconSizes`
  - Added `xxsmall` case: `ButtonBase` supports `xxsmall`, but `ButtonIcon` previously did not have a specific case for `xxsmall`. Doing this means that each potential size value of `Button` has a corresponding `ButtonIcon` size
- `Tree`
  - Removed `fontWeight` prop
  - Added `visuallyAsBranch` prop to control inner disclosure font weight
- `TreeItem`
  - Defaulted text color to `text2`
  - Added `PrimaryIcon` helper component that styles primary icon with `opacity: 0.5`

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
Proper sizing on `xxsmall` "+ Add"
![Screen Shot 2020-07-09 at 5 39 14 PM](https://user-images.githubusercontent.com/16812885/87103886-1f132a80-c20b-11ea-94b6-ed653c3299e9.png)
 button in detail:

`visuallyAsBranch` changes font weight of `Tree` disclosure text to "normal":
![Screen Shot 2020-07-09 at 5 40 07 PM](https://user-images.githubusercontent.com/16812885/87103923-423dda00-c20b-11ea-93c4-e330b75c2344.png)

`TreeItem` and `TreeGroup` have default text color of `theme.colors.text2` (also `opacity: 0.5` on primary icons):
![Screen Shot 2020-07-09 at 5 40 54 PM](https://user-images.githubusercontent.com/16812885/87103952-5aadf480-c20b-11ea-9346-3a8299f903b4.png)


