### PR TITLE
Deploy to a subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/looker-open-source/components.svg?branch=master)](https://travis-ci.com/looker-open-source/components)
 
-This repository hosts the Looker UI Components library and the platform needed to generate our style guide. If you're looking for documentation for using Looker UI Components within your own application, you can view the documentation online at [http://components.looker.com](http://components.looker.com)
+This repository hosts the Looker UI Components library and the platform needed to generate our style guide. If you're looking for documentation for using Looker UI Components within your own application, you can view the documentation online on our web site.
 
 ## Bugs & Feature Requests
 
@@ -46,7 +46,7 @@ We recommend using [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm#in
 - **yarn develop** shortcut for booting up www, playground, and server packages for local development
 - **yarn storybook** starts Storybook, a tool for developing components in isolation
 - **yarn playground** starts a bare-bones React app used for developing components
-- **yarn gatsby** starts the Gatsby server (powers [components.looker.com](https://components.looker.com))
+- **yarn gatsby** starts the Gatsby server (powers our documentation site)
 - **yarn server** starts a local proxy server to facilitate local fetch requests to a Looker instance
 - **yarn build** runs build across all packages. This calls several subtasks
   - **yarn prebuild** run clean, then use lerna to do any pre-build tasks needed for packages

--- a/config/deploy.sh
+++ b/config/deploy.sh
@@ -10,5 +10,5 @@ yarn workspace storybook build
 yarn workspace www build
 mv www/public/* public
 
-echo \"components.looker.com\" > public/CNAME
+#echo \"components.looker.com\" > public/CNAME
 yarn gh-pages -d public -r https://$GITHUB_TOKEN@github.com/looker-open-source/components.git

--- a/config/deploy.sh
+++ b/config/deploy.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-mkdir -p public
+# clean-up previous build
+rm -rf public
+mkdir public
 
 yarn workspace storybook build
+
+# Build Gatsby, then move contents to public folder for publishing
 yarn workspace www build
 mv www/public/* public
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "storybook",
     "www"
   ],
-  "homepage": "http://components.looker.com",
+  "homepage": "http://github.com/looker-open-source/components",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/looker-open-source/components.git"

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This package provides a series of components that implement Looker's Design System. See http://components.looker.com for additional detail on Looker Components.
+This package provides a series of components that implement Looker's Design System.
 
 ## Installation
 

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -25,6 +25,7 @@
  */
 
 module.exports = {
+  pathPrefix: `/components`,
   siteMetadata: {
     title: 'Looker UI Components',
   },

--- a/www/package.json
+++ b/www/package.json
@@ -32,7 +32,7 @@
     "styled-components": "^4.4.1"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "start": "gatsby develop"
   }
 }

--- a/www/src/Layout/Navigation/Page.tsx
+++ b/www/src/Layout/Navigation/Page.tsx
@@ -25,6 +25,7 @@
  */
 
 import { Badge, SidebarItem } from '@looker/components'
+import { withPrefix } from 'gatsby'
 import React, { FC, useContext } from 'react'
 import { LocationContext } from './LocationContext'
 import { NavigationPage } from './types'
@@ -34,7 +35,7 @@ interface PageProps {
   path: string[]
 }
 
-export const pathToUri = (path: string[]) => `/${path.join('/')}`
+export const pathToUri = (path: string[]) => withPrefix(`/${path.join('/')}`)
 
 const Page: FC<PageProps> = ({ page, path }) => {
   const currentPath = useContext(LocationContext)

--- a/www/src/documentation/components/content/calendar.mdx
+++ b/www/src/documentation/components/content/calendar.mdx
@@ -9,8 +9,7 @@ import { CalendarPropTable } from './demos'
 
 <MessageBar>
   If you need an interactive date picker, please use{' '}
-  <a href="/components/forms/input-date">InputDate</a> or InputDateRange
-  instead.
+  <a href="../forms/input-date">InputDate</a> or InputDateRange instead.
 </MessageBar>
 
 `Calendar` is a stateless component which renders a standard calendar month. It accepts a limited amount of props, and is the foundation of our more useful [`InputDate`](/components/forms/input-date) and `InputDateRange` components.

--- a/www/src/documentation/components/content/list.mdx
+++ b/www/src/documentation/components/content/list.mdx
@@ -11,13 +11,13 @@ By default a `<List />` component will render as an unordered list, `<ul>` tag, 
 ```jsx
 <List>
   <ListItem>
-    <Link href="/#!/Card">Card</Link>
+    <Link href="./card">Card</Link>
   </ListItem>
   <ListItem>
-    <Link href="/#!/Link">Link</Link>
+    <Link href="../actions/link">Link</Link>
   </ListItem>
   <ListItem>
-    <Link href="/#!/Heading">Heading</Link>
+    <Link href="../typography/heading">Heading</Link>
   </ListItem>
 </List>
 ```

--- a/www/src/documentation/components/dialogs/index.mdx
+++ b/www/src/documentation/components/dialogs/index.mdx
@@ -10,8 +10,8 @@ Dialogs break out of the standard application flow and UI to present new informa
 
 <MessageBar intent="warn">
   Dialog provides a general purpose (empty & unstyled) overlay.{' '}
-  <a href="/components/dialogs/confirm">Confirm</a> will likely be more useful
-  if your intent is to render a standard user confirmation dialog.
+  <a href="./confirm">Confirm</a> will likely be more useful if your intent is
+  to render a standard user confirmation dialog.
 </MessageBar>
 
 ## Standard Use

--- a/www/src/documentation/components/forms/fieldset.mdx
+++ b/www/src/documentation/components/forms/fieldset.mdx
@@ -88,7 +88,7 @@ Viable `Accordion` props include:
 - onOpen
 - onClose
 
-For more details on the props listed above, visit the [Accordion documentation](https://components.looker.com/components/content/accordion).
+For more details on the props listed above, visit the [Accordion documentation](../content/accordion).
 
 ```jsx
 <Fieldset

--- a/www/src/documentation/utilities/globalstyle.mdx
+++ b/www/src/documentation/utilities/globalstyle.mdx
@@ -18,7 +18,7 @@ The GlobalStyle component will assign the theme's "brand" font family ('Open San
 
 <MessageBar>
   Note that the `GlobalStyle` component will not load any fonts specified. Refer
-  to the <a href="/getting-started">Getting Started</a> documentation for font
+  to the <a href="../getting-started">Getting Started</a> documentation for font
   import recommendations.
 </MessageBar>
 


### PR DESCRIPTION
This change reconfigures Gatsby so that it expects to be deployed to a subfolder (specifically https://looker-open-source.github.io/components). 

- Corrects several root relative links that will break when this change is made.
- Corrects sidebar navigation links to use Gatsby helper to detect and use prefix if applicable

### Testing

Reproducing the deployment environment locally is a little annoying but it is feasible.

```
yarn deploy
# ignore prompts to login to github (build will fail this last step but the built artifacts will be written
mkdir faux-server
mv public faux-server
cd faux-server
python -m SimpleHTTPServer
# visit https://your-instance:8000/components
```

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
