### PR TITLE
MenuGroup: Fix iconPlaceholder bug for MenuGroups with only 1 MenuItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `iconSizes` style function includes `xxsmall` case
 
 ### Changed
+
 - `MenuGroup` labels improvements when using `compact`
 - `Menu` now has a new focus style for `MenuItems` as well as updateing sizing
 - `Accordion`
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Select`/`SelectMulti` keyboard navigation when filtering and going from > 100 to < 100 options
 - `SelectMulti` with `freeInput` not saving input value on tab key
 - `SelectMulti` list not closing on blur
+- `MenuGroup` now includes icon placeholder spacing if higher `MenuItemContext` has `renderIconPlaceholder === true`
 
 ### Removed
 

--- a/packages/components/src/Menu/MenuGroup.test.tsx
+++ b/packages/components/src/Menu/MenuGroup.test.tsx
@@ -26,11 +26,12 @@
 
 import 'jest-styled-components'
 import React from 'react'
-import { assertSnapshot } from '@looker/components-test-utils'
+import { assertSnapshot, renderWithTheme } from '@looker/components-test-utils'
 
 import { Box } from '../Layout'
 import { MenuGroup } from './MenuGroup'
 import { MenuItem } from './MenuItem'
+import { MenuList } from './MenuList'
 
 test('MenuGroup', () => {
   assertSnapshot(
@@ -58,4 +59,41 @@ test('MenuGroup - JSX label', () => {
       <MenuItem>where?</MenuItem>
     </MenuGroup>
   )
+})
+
+test('MenuGroup - indents MenuItem with no icon when a sibling within the same group has an icon', () => {
+  const { getByTestId } = renderWithTheme(
+    <MenuGroup>
+      <MenuItem icon="Calendar">Gouda</MenuItem>
+      <MenuItem id="cheddar">Cheddar</MenuItem>
+    </MenuGroup>
+  )
+
+  getByTestId('menu-item-cheddar-icon-placeholder')
+})
+
+test('MenuGroup - indents MenuItem with no icon when a sibling outside of the group has an icon', () => {
+  const { getByTestId } = renderWithTheme(
+    <MenuList>
+      <MenuItem icon="Calendar">Gouda</MenuItem>
+      <MenuGroup>
+        <MenuItem id="cheddar">Cheddar</MenuItem>
+      </MenuGroup>
+    </MenuList>
+  )
+
+  getByTestId('menu-item-cheddar-icon-placeholder')
+})
+
+test('MenuGroup - does not indent MenuItems with no icon if all siblings do not have icons', () => {
+  const { queryByTestId } = renderWithTheme(
+    <MenuGroup>
+      <MenuItem>Gouda</MenuItem>
+      <MenuItem id="cheddar">Cheddar</MenuItem>
+    </MenuGroup>
+  )
+
+  expect(
+    queryByTestId('menu-item-cheddar-icon-placeholder')
+  ).not.toBeInTheDocument()
 })

--- a/packages/components/src/Menu/MenuGroup.tsx
+++ b/packages/components/src/Menu/MenuGroup.tsx
@@ -45,11 +45,15 @@ const MenuGroupLayout: FC<MenuGroupProps> = ({
   label,
 }) => {
   const [renderIconPlaceholder, setRenderIconPlaceholder] = useState(false)
-  const { compact: contextCompact } = useContext(MenuItemContext)
+  const {
+    compact: contextCompact,
+    renderIconPlaceholder: contextRenderIconPlaceholder,
+  } = useContext(MenuItemContext)
 
   const context = {
     compact: compact === undefined ? contextCompact : compact,
-    renderIconPlaceholder,
+    renderIconPlaceholder:
+      contextRenderIconPlaceholder || renderIconPlaceholder,
     setRenderIconPlaceholder,
   }
 

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -28,6 +28,7 @@ import { CompatibleHTMLProps } from '@looker/design-tokens'
 import { IconNames } from '@looker/icons'
 import styled from 'styled-components'
 import React, { FC, ReactNode, useContext, useState, useEffect } from 'react'
+import { useID } from '../utils/useID'
 import { Icon } from '../Icon'
 import { MenuContext, MenuItemContext } from './MenuContext'
 import { MenuItemLayout, MenuItemLayoutGrid } from './MenuItemLayout'
@@ -100,6 +101,8 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
     icon && setRenderIconPlaceholder(true)
   }, [icon, setRenderIconPlaceholder])
 
+  const renderedIconID = useID(props.id)
+
   const renderedIcon = icon ? (
     <Icon
       name={icon}
@@ -108,7 +111,9 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
       color="text6"
     />
   ) : (
-    renderIconPlaceholder && <div />
+    renderIconPlaceholder && (
+      <div data-testid={`menu-item-${renderedIconID}-icon-placeholder`} />
+    )
   )
 
   const Component = itemRole === 'link' ? 'a' : 'button'

--- a/packages/components/src/Menu/MenuList.test.tsx
+++ b/packages/components/src/Menu/MenuList.test.tsx
@@ -26,7 +26,11 @@
 
 import 'jest-styled-components'
 import * as React from 'react'
-import { mountWithTheme, shallowWithTheme } from '@looker/components-test-utils'
+import {
+  mountWithTheme,
+  shallowWithTheme,
+  renderWithTheme,
+} from '@looker/components-test-utils'
 import { MenuGroup } from './MenuGroup'
 import { MenuItem } from './MenuItem'
 import { MenuList } from './MenuList'
@@ -90,4 +94,15 @@ test('Menu - compact', () => {
   )
 
   expect(menu).toMatchSnapshot()
+})
+
+test('Menu - allocates space for MenuItem when a sibling has an icon', () => {
+  const { getByTestId } = renderWithTheme(
+    <MenuList>
+      <MenuItem icon="Calendar">Gouda</MenuItem>
+      <MenuItem id="cheddar">Cheddar</MenuItem>
+    </MenuList>
+  )
+
+  getByTestId('menu-item-cheddar-icon-placeholder')
 })

--- a/storybook/src/Overlays/Menu.stories.tsx
+++ b/storybook/src/Overlays/Menu.stories.tsx
@@ -39,6 +39,7 @@ import {
   Paragraph,
   IconButton,
   MenuContext,
+  Divider,
 } from '@looker/components'
 
 export const All = () => (
@@ -111,11 +112,23 @@ export const IconSpace = () => (
       </MenuList>
     </Menu>
 
+    <Divider />
+
     <MenuList compact>
-      <MenuGroup label="Cheeses">
+      <MenuGroup label="MenuGroup with 3 Items">
         <MenuItem icon="LogoRings">Looker</MenuItem>
-        <MenuItem>Pizza!</MenuItem>
         <MenuItem icon="Validate">Validate</MenuItem>
+        <MenuItem>Pizza!</MenuItem>
+      </MenuGroup>
+    </MenuList>
+
+    <Divider />
+
+    <MenuList compact>
+      <MenuItem icon="LogoRings">Looker</MenuItem>
+      <MenuItem icon="Validate">Validate</MenuItem>
+      <MenuGroup label="MenuGroup with 1 Item">
+        <MenuItem>Pizza!</MenuItem>
       </MenuGroup>
     </MenuList>
   </div>


### PR DESCRIPTION
### :sparkles: Changes

- `MenuGroup` now checks parent `MenuItemContext`s for `renderIconPlaceholder`
  - Doing this means that if a `MenuGroup` is the child of a `MenuList` or another `MenuGroup`, it will enable `renderIconPlaceholder` for its children assuming its parent context is set to true

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![Screen Shot 2020-07-10 at 5 48 49 PM](https://user-images.githubusercontent.com/16812885/87212853-a1682100-c2d5-11ea-942a-63bc81214ad7.png)
