### PR TITLE
Proposal: Make IntentPressed (:active) state more discernable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+#### Change
+
+- `theme` "pressed" colors are more discernable from other stateful colors
+
 ## [0.9.6] - 2020-07-15
 
 - Storybook is now deployed to `https://components.looker.com/storybook`

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -56,8 +56,8 @@ exports[`Button Focus: renders outline when tabbing into focus, but not when cli
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -76,7 +76,7 @@ exports[`Button Focus: renders outline when tabbing into focus, but not when cli
 
 exports[`Button Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 dAphVM ButtonBase-sc-1bpio6j-1 Button-sc-18euc9m-0 hEPxhK"
+  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 dAphVM ButtonBase-sc-1bpio6j-1 Button-sc-18euc9m-0 btmkRb"
 >
   focus
 </button>
@@ -139,8 +139,8 @@ exports[`Button can be full width 1`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -213,8 +213,8 @@ exports[`Button disable 1`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -290,8 +290,8 @@ exports[`Button validates all sizes 1`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -364,8 +364,8 @@ exports[`Button validates all sizes 2`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -438,8 +438,8 @@ exports[`Button validates all sizes 3`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -512,8 +512,8 @@ exports[`Button validates all sizes 4`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -634,8 +634,8 @@ exports[`Button with icon validates all sizes 1`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -800,8 +800,8 @@ exports[`Button with icon validates all sizes 2`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -966,8 +966,8 @@ exports[`Button with icon validates all sizes 3`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -1132,8 +1132,8 @@ exports[`Button with icon validates all sizes 4`] = `
 
 .c1:active,
 .c1.active {
-  background: #8462e5;
-  border-color: #8462e5;
+  background: #5424db;
+  border-color: #5424db;
 }
 
 .c1[disabled]:hover,
@@ -1222,8 +1222,8 @@ exports[`Button works with color critical 1`] = `
 
 .c1:active,
 .c1.active {
-  background: #df2f47;
-  border-color: #df2f47;
+  background: #ad1a2e;
+  border-color: #ad1a2e;
 }
 
 .c1[disabled]:hover,

--- a/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not w
 .c1.hover {
   background: #FFFFFF;
   border-color: #6C43E0;
-  color: #8462e5;
+  color: #5424db;
 }
 
 .c1:active,
@@ -79,7 +79,7 @@ exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not w
 
 exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 dAphVM ButtonBase-sc-1bpio6j-1 ButtonOutline-ncggc7-0 btHUnS"
+  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 dAphVM ButtonBase-sc-1bpio6j-1 ButtonOutline-ncggc7-0 cEqfFo"
 >
   focus
 </button>
@@ -137,7 +137,7 @@ exports[`ButtonOutline has the correct style 1`] = `
 .c1.hover {
   background: #FFFFFF;
   border-color: #6C43E0;
-  color: #8462e5;
+  color: #5424db;
 }
 
 .c1:active,

--- a/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/IconButton.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`IconButton accepts color 1`] = `
 
 .c2:active,
 .c2.active {
-  color: #df2f47;
+  color: #ad1a2e;
 }
 
 .c2 svg {
@@ -220,7 +220,7 @@ exports[`IconButton accepts events 1`] = `
 
 .c2:active,
 .c2.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c2 svg {
@@ -352,7 +352,7 @@ exports[`IconButton accepts events 2`] = `
 
 .c2:active,
 .c2.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c2 svg {
@@ -484,7 +484,7 @@ exports[`IconButton allows for ARIA attributes 1`] = `
 
 .c2:active,
 .c2.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c2 svg {
@@ -616,7 +616,7 @@ exports[`IconButton default 1`] = `
 
 .c2:active,
 .c2.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c2 svg {
@@ -748,7 +748,7 @@ exports[`IconButton outline 1`] = `
 
 .c2:active,
 .c2.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c2:hover,
@@ -1160,7 +1160,7 @@ exports[`IconButton resized 1`] = `
 
 .c2:active,
 .c2.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c2 svg {

--- a/packages/components/src/Dialog/Layout/__snapshots__/DialogHeader.test.tsx.snap
+++ b/packages/components/src/Dialog/Layout/__snapshots__/DialogHeader.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`DialogHeader Snapshot 1`] = `
 
 .c5:active,
 .c5.active {
-  color: #828993;
+  color: #5f656e;
 }
 
 .c5 svg {

--- a/packages/design-tokens/src/utils/color/stateful.ts
+++ b/packages/design-tokens/src/utils/color/stateful.ts
@@ -24,7 +24,7 @@
 
  */
 
-import { lighten } from 'polished'
+import { darken, lighten } from 'polished'
 import {
   StatefulColors,
   StatefulColorChoices,
@@ -35,7 +35,7 @@ import { mixScaledColors } from './blend'
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 
 export const generateInteractive = (color: string) => lighten(0.04, color)
-export const generatePressed = (color: string) => lighten(0.07, color)
+export const generatePressed = (color: string) => darken(0.07, color)
 
 const generateStatefulColor = (
   background: string,

--- a/storybook/src/Buttons/IconButton.stories.tsx
+++ b/storybook/src/Buttons/IconButton.stories.tsx
@@ -39,12 +39,41 @@ export const Basic = () => {
         <IconButton icon="Favorite" size="medium" label="Favorite" />
         <IconButton icon="Favorite" size="large" label="Favorite" />
       </Space>
-
-      <Heading>Sizes</Heading>
+      <Heading>States</Heading>
       <Space>
         <IconButton icon="Favorite" label="Favorite" />
         <IconButton icon="Favorite" label="Favorite" className="hover" />
         <IconButton icon="Favorite" label="Favorite" className="active" />
+      </Space>
+      <Space>
+        <IconButton color="key" icon="Favorite" label="Favorite" />
+        <IconButton
+          color="key"
+          icon="Favorite"
+          label="Favorite"
+          className="hover"
+        />
+        <IconButton
+          color="key"
+          icon="Favorite"
+          label="Favorite"
+          className="active"
+        />
+      </Space>{' '}
+      <Space>
+        <IconButton color="critical" icon="Favorite" label="Favorite" />
+        <IconButton
+          color="critical"
+          icon="Favorite"
+          label="Favorite"
+          className="hover"
+        />
+        <IconButton
+          color="critical"
+          icon="Favorite"
+          label="Favorite"
+          className="active"
+        />
       </Space>
     </>
   )


### PR DESCRIPTION
### :sparkles: Changes

Currently it's hard to discern the different between the :active ("pressed") intent state and the others. This PR proposes a minor change to make it more discernable

#### Before
![image](https://user-images.githubusercontent.com/34253496/87601266-9d5b4b00-c6a9-11ea-919e-8c35600eba63.png)

![image](https://user-images.githubusercontent.com/34253496/87601409-e6130400-c6a9-11ea-8ccd-c1012e440c92.png)


#### After
![image](https://user-images.githubusercontent.com/34253496/87601221-81f04000-c6a9-11ea-8aaa-0b5b36807741.png)

![image](https://user-images.githubusercontent.com/34253496/87601413-ea3f2180-c6a9-11ea-99b3-8a1b3fe91ded.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC