### PR TITLE
theme.colors.text1-5 restructured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Change
 
-- `theme` "pressed" colors are more discernable from other stateful colors
+- `theme.colors.*Pressed` colors are more discernable from other stateful colors
+- `theme.colors.textX` restructured
+  - `text1-5` now go from lightest to darkest to match `ui1-5`
+  - Reduced number of steps:
+    - `text0` is now `text5` (consolidated the former `text0` & `text1`)
+    - `text6` is now `text1` (consolidated the former `text6` & `text5`)
 
 ## [0.9.6] - 2020-07-15
 

--- a/packages/components/src/ActionList/ActionListHeader/ActionListHeader.tsx
+++ b/packages/components/src/ActionList/ActionListHeader/ActionListHeader.tsx
@@ -52,7 +52,7 @@ const ActionListHeaderInternal: FC<CompatibleHTMLProps<HTMLDivElement>> = ({
 
 export const ActionListHeader = styled(ActionListHeaderInternal)`
   border-bottom: solid 1px ${({ theme }) => theme.colors.ui2};
-  color: ${(props) => props.theme.colors.text0};
+  color: ${(props) => props.theme.colors.text5};
   display: flex;
   font-size: ${(props) => props.theme.fontSizes.xsmall};
   font-weight: ${(props) => props.theme.fontWeights.semiBold};

--- a/packages/components/src/ActionList/ActionListItemColumn.tsx
+++ b/packages/components/src/ActionList/ActionListItemColumn.tsx
@@ -62,7 +62,7 @@ const ActionListItemColumnLayout: FC<ActionListItemColumnProps> = ({
 export const ActionListItemColumn = styled(ActionListItemColumnLayout)<
   ActionListItemColumnProps
 >`
-  color: ${({ theme }) => theme.colors.text2};
+  color: ${({ theme }) => theme.colors.text4};
   display: ${({ indicator }) => indicator && 'flex'};
   font-size: ${({ theme }) => theme.fontSizes.xsmall};
   overflow: hidden;

--- a/packages/components/src/ActionList/utils/actionListFormatting.ts
+++ b/packages/components/src/ActionList/utils/actionListFormatting.ts
@@ -46,7 +46,7 @@ export const primaryKeyColumnCSS = (columnIndices: number[]) =>
       (columnIndex) =>
         css`
           ${ActionListItemColumn}:nth-child(${columnIndex + 1}) {
-            color: ${({ theme }) => theme.colors.text0};
+            color: ${({ theme }) => theme.colors.text5};
             font-size: ${(props) => props.theme.fontSizes.small};
           }
         `

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -113,7 +113,7 @@ export const ButtonItem = styled(ButtonLayout)`
   }
 
   &[disabled] {
-    color: ${(props) => props.theme.colors.text5};
+    color: ${(props) => props.theme.colors.text1};
     cursor: default;
   }
 

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -154,7 +154,7 @@ export const Calendar = styled<FC<CalendarProps>>(InternalCalendar)`
     align-items: center;
     border: 1px solid transparent;
     color: ${({ theme: { colors }, disabled }) =>
-      disabled ? colors.text4 : colors.text2};
+      disabled ? colors.text2 : colors.text4};
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
     display: grid;
     justify-items: center;
@@ -163,7 +163,7 @@ export const Calendar = styled<FC<CalendarProps>>(InternalCalendar)`
     transition: background-color 110ms linear;
 
     &.DayPicker-Day--outside {
-      color: ${({ theme: { colors } }) => colors.text6};
+      color: ${({ theme: { colors } }) => colors.text1};
     }
 
     &--today {

--- a/packages/components/src/Dialog/Surface.tsx
+++ b/packages/components/src/Dialog/Surface.tsx
@@ -148,7 +148,7 @@ Surface.defaultProps = {
   backgroundColor: 'background',
   borderRadius: 'medium',
   boxShadow: 3,
-  color: 'text1',
+  color: 'text5',
   maxHeight: '90vh',
   maxWidth: ['90vw', '90vw', '600px'],
 }

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -58,7 +58,7 @@ const appearanceVariant = variant({
       bg: 'ui2',
     },
     onDark: {
-      bg: 'text4',
+      bg: 'text2',
     },
   },
 })

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -115,7 +115,7 @@ const FieldLayout: FunctionComponent<FieldPropsInternal> = ({
   const { fieldsHideLabel } = useContext(FieldsetContext)
 
   const fieldDescription = description && (
-    <Paragraph mt="xsmall" fontSize="xsmall" color="text4">
+    <Paragraph mt="xsmall" fontSize="xsmall" color="text2">
       {description}
     </Paragraph>
   )

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -81,7 +81,7 @@ export const FieldInline = styled(FieldInlineLayout)`
 
   ${Label} {
     align-items: center;
-    color: ${({ theme, disabled }) => disabled && theme.colors.text5};
+    color: ${({ theme, disabled }) => disabled && theme.colors.text1};
     display: flex;
     font-size: ${({ theme }) => theme.fontSizes.small};
     font-weight: normal;

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -233,7 +233,7 @@ exports[`Fieldset 1`] = `
   >
     <legend
       className="c2"
-      color="text2"
+      color="text4"
       fontSize="medium"
       fontWeight="semiBold"
     >

--- a/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
+++ b/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
@@ -81,7 +81,7 @@ export const AdvancedInputControls: FC<AdvancedInputControlsProps> = ({
           key="list-caret"
           name={isVisibleOptions ? 'CaretUp' : 'CaretDown'}
           size={18}
-          color={disabled ? 'text6' : 'text4'}
+          color={disabled ? 'text1' : 'text2'}
           mr="xsmall"
         />
       ),

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -140,7 +140,7 @@ export const Checkbox = styled(CheckboxLayout)`
   input:disabled + ${FauxCheckbox} {
     background: ${({ theme }) => theme.colors.ui1};
     border-color: ${({ theme }) => theme.colors.ui2};
-    color: ${({ theme }) => theme.colors.text5};
+    color: ${({ theme }) => theme.colors.text1};
   }
 
   input:disabled:not(:checked) + ${FauxCheckbox} {

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxOption.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxOption.tsx
@@ -218,7 +218,7 @@ export const ComboboxOption = styled(ComboboxOptionInternal)`
   ${comboboxOptionStyle}
 `
 export const comboboxOptionDefaultProps: Partial<ComboboxOptionProps> = {
-  color: 'text2',
+  color: 'text4',
   display: 'flex',
   fontSize: 'small',
   px: 'xsmall',

--- a/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
+++ b/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
@@ -90,7 +90,7 @@ InlineTextAreaLayout.displayName = 'InlineTextAreaLayout'
 const Input = styled.textarea<InlineTextAreaProps>`
   background: transparent;
   border: none;
-  caret-color: ${({ theme }) => theme.colors.text0};
+  caret-color: ${({ theme }) => theme.colors.text5};
   color: transparent;
   font: inherit;
   height: 100%;
@@ -111,7 +111,7 @@ interface VisibleTextProps {
 
 const VisibleText = styled.div<VisibleTextProps>`
   color: ${({ displayValue, theme }) =>
-    displayValue ? 'inherit' : theme.colors.text5};
+    displayValue ? 'inherit' : theme.colors.text1};
 `
 
 export const InlineTextArea = styled(InlineTextAreaLayout)`

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearchControls.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearchControls.tsx
@@ -83,7 +83,7 @@ export const InputSearchControlsInternal = forwardRef(
       >
         {summary && (
           <Text
-            color="text5"
+            color="text1"
             fontSize="small"
             style={{ whiteSpace: 'nowrap' }}
             pr="xsmall"

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -237,7 +237,7 @@ export const inputTextFocus = css`
 `
 export const inputTextDisabled = css`
   background: ${(props) => props.theme.colors.ui1};
-  color: ${(props) => props.theme.colors.text5};
+  color: ${(props) => props.theme.colors.text1};
   &:hover {
     border-color: ${(props) => props.theme.colors.ui2};
   }
@@ -248,7 +248,7 @@ export const inputHeight = '36px'
 export const InputTextContent = styled.div<SpaceProps>`
   ${space}
   align-items: center;
-  color: ${(props) => props.theme.colors.text5};
+  color: ${(props) => props.theme.colors.text1};
   display: flex;
   height: 100%;
   pointer-events: none;
@@ -275,7 +275,7 @@ export const inputCSS = css`
   background: ${({ theme: { colors } }) => colors.field};
   border: 1px solid ${({ theme: { colors } }) => colors.ui2};
   border-radius: ${({ theme: { radii } }) => radii.medium};
-  color: ${({ theme: { colors } }) => colors.text2};
+  color: ${({ theme: { colors } }) => colors.text4};
   font-size: ${({ theme: { fontSizes } }) => fontSizes.small};
 `
 

--- a/packages/components/src/Form/Inputs/Radio/Radio.tsx
+++ b/packages/components/src/Form/Inputs/Radio/Radio.tsx
@@ -86,7 +86,7 @@ export const Radio = styled(RadioLayout)`
   }
 
   input:disabled + ${FauxRadio} {
-    color: ${({ theme }) => theme.colors.text5};
+    color: ${({ theme }) => theme.colors.text1};
   }
 
   input:disabled:not(:checked) + ${FauxRadio} {

--- a/packages/components/src/Form/Inputs/innerInputStyle.ts
+++ b/packages/components/src/Form/Inputs/innerInputStyle.ts
@@ -29,7 +29,7 @@ import { css } from 'styled-components'
 export const innerInputStyle = css`
   background: transparent;
   border: none;
-  caret-color: ${({ theme }) => theme.colors.text0};
+  caret-color: ${({ theme }) => theme.colors.text5};
   color: inherit;
   height: 100%;
   outline: none;
@@ -43,6 +43,6 @@ export const innerInputStyle = css`
   }
 
   ::placeholder {
-    color: ${(props) => props.theme.colors.text5};
+    color: ${(props) => props.theme.colors.text1};
   }
 `

--- a/packages/components/src/Form/Label/Label.tsx
+++ b/packages/components/src/Form/Label/Label.tsx
@@ -37,7 +37,7 @@ export interface LabelProps
 
 export const Label = styled.label<LabelProps>`
 ${reset}
-  color: ${({ theme: { colors } }) => colors.text2};
+  color: ${({ theme: { colors } }) => colors.text4};
   font-size: ${({ theme: { fontSizes } }) => fontSizes.xsmall};
   font-weight: ${({ theme: { fontWeights } }) => fontWeights.semiBold};
 `

--- a/packages/components/src/Form/Legend/Legend.tsx
+++ b/packages/components/src/Form/Legend/Legend.tsx
@@ -48,7 +48,7 @@ export const Legend = styled.legend<LegendProps>`
 `
 
 Legend.defaultProps = {
-  color: 'text2',
+  color: 'text4',
   fontSize: 'medium',
   fontWeight: 'semiBold',
   padding: 'none',

--- a/packages/components/src/Form/Legend/__snapshots__/Legend.test.tsx.snap
+++ b/packages/components/src/Form/Legend/__snapshots__/Legend.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`A Legend 1`] = `
 
 <legend
   className="c0"
-  color="text2"
+  color="text4"
   fontSize="medium"
   fontWeight="semiBold"
 >

--- a/packages/components/src/InputDateRange/InputDateRange.tsx
+++ b/packages/components/src/InputDateRange/InputDateRange.tsx
@@ -416,7 +416,7 @@ InputDateRange.displayName = 'InputDateRange'
 
 const HyphenWrapper = styled.div<{ hasInputValues: boolean }>`
   color: ${({ theme, hasInputValues }) =>
-    hasInputValues ? theme.colors.text3 : theme.colors.text6};
+    hasInputValues ? theme.colors.text3 : theme.colors.text1};
 `
 
 const InputDateRangeWrapper = styled.div`

--- a/packages/components/src/Menu/MenuGroupLabel.tsx
+++ b/packages/components/src/Menu/MenuGroupLabel.tsx
@@ -62,6 +62,6 @@ const MenuGroupLabelWrapper = styled.div<MenuGroupLabelWrapperProps>`
   top: -1px;
 
   ${Heading} {
-    color: ${({ theme }) => theme.colors.text2};
+    color: ${({ theme }) => theme.colors.text4};
   }
 `

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -108,7 +108,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
       name={icon}
       mr="xsmall"
       size={24 / (compact ? 1.25 : 1)}
-      color="text6"
+      color="text1"
     />
   ) : (
     renderIconPlaceholder && (
@@ -144,7 +144,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
 export const MenuItem = styled(MenuItemInternal)``
 
 const Detail = styled.div`
-  color: ${({ theme: { colors } }) => colors.text6};
+  color: ${({ theme: { colors } }) => colors.text1};
   margin-left: auto;
   margin-right: ${({ theme: { space } }) => space.medium};
   padding-left: ${({ theme: { space } }) => space.large};

--- a/packages/components/src/Menu/MenuItemLayout.tsx
+++ b/packages/components/src/Menu/MenuItemLayout.tsx
@@ -58,7 +58,7 @@ export const MenuItemLayoutGrid = styled.div``
 
 export const MenuItemLayout = styled(MenuItemWrapper)`
   align-items: center;
-  color: ${({ theme: { colors } }) => colors.text1};
+  color: ${({ theme: { colors } }) => colors.text5};
   display: flex;
   flex-wrap: wrap;
   font-size: ${({ theme: { fontSizes } }) => fontSizes.small};
@@ -126,7 +126,7 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
   `}
 
   ${Icon} {
-    color: ${({ theme: { colors } }) => colors.text6};
+    color: ${({ theme: { colors } }) => colors.text1};
     transition: color
       ${({ theme: { easings, transitions } }) =>
         `${transitions.durationQuick} ${easings.ease}`};
@@ -135,10 +135,10 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
   :hover,
   &[aria-current='true'] {
     background: ${({ theme: { colors } }) => colors.ui1};
-    color: ${({ theme: { colors } }) => colors.text0};
+    color: ${({ theme: { colors } }) => colors.text5};
 
     ${Icon} {
-      color: ${({ theme: { colors } }) => colors.text5};
+      color: ${({ theme: { colors } }) => colors.text1};
     }
   }
 
@@ -147,7 +147,7 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
   }
 
   &[disabled] {
-    color: ${({ theme: { colors } }) => colors.text5};
+    color: ${({ theme: { colors } }) => colors.text1};
 
     button,
     a {
@@ -156,10 +156,10 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
 
     &:hover {
       background: ${({ theme: { colors } }) => colors.background};
-      color: ${({ theme: { colors } }) => colors.text5};
+      color: ${({ theme: { colors } }) => colors.text1};
 
       ${Icon} {
-        color: ${({ theme: { colors } }) => colors.text6};
+        color: ${({ theme: { colors } }) => colors.text1};
       }
     }
   }

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`MenuGroup - JSX label 1`] = `
 }
 
 .c5 .c7 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -132,7 +132,7 @@ exports[`MenuGroup - JSX label 1`] = `
 }
 
 .c5[disabled]:hover .c7 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 <li
@@ -313,7 +313,7 @@ exports[`MenuGroup - label 1`] = `
 }
 
 .c5 .c7 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -348,7 +348,7 @@ exports[`MenuGroup - label 1`] = `
 }
 
 .c5[disabled]:hover .c7 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 <li
@@ -504,7 +504,7 @@ exports[`MenuGroup 1`] = `
 }
 
 .c2 .c4 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -539,7 +539,7 @@ exports[`MenuGroup 1`] = `
 }
 
 .c2[disabled]:hover .c4 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 <li

--- a/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuItem.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`MenuItem - current 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -36,7 +36,7 @@ exports[`MenuItem - current 1`] = `
 }
 
 .c4 .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -47,7 +47,7 @@ exports[`MenuItem - current 1`] = `
 }
 
 .c4[disabled]:hover .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 .c0 {
@@ -117,7 +117,7 @@ exports[`MenuItem - current 1`] = `
 }
 
 .c0 .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -152,7 +152,7 @@ exports[`MenuItem - current 1`] = `
 }
 
 .c0[disabled]:hover .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 <li
@@ -258,7 +258,7 @@ exports[`MenuItem - detail 1`] = `
 }
 
 .c0 .c4 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -293,7 +293,7 @@ exports[`MenuItem - detail 1`] = `
 }
 
 .c0[disabled]:hover .c4 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 .c3 button .c1,
@@ -308,7 +308,7 @@ exports[`MenuItem - detail 1`] = `
 }
 
 .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
   margin-left: auto;
   margin-right: 1rem;
   padding-left: 1.25rem;
@@ -346,7 +346,7 @@ exports[`MenuItem - icon 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -373,7 +373,7 @@ exports[`MenuItem - icon 1`] = `
 }
 
 .c4 .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -384,7 +384,7 @@ exports[`MenuItem - icon 1`] = `
 }
 
 .c4[disabled]:hover .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 .c0 {
@@ -454,7 +454,7 @@ exports[`MenuItem - icon 1`] = `
 }
 
 .c0 .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -489,7 +489,7 @@ exports[`MenuItem - icon 1`] = `
 }
 
 .c0[disabled]:hover .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 <li
@@ -594,7 +594,7 @@ exports[`MenuItem 1`] = `
 }
 
 .c0 .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
   -webkit-transition: color 150ms cubic-bezier(0.86,0,0.07,1);
   transition: color 150ms cubic-bezier(0.86,0,0.07,1);
 }
@@ -629,7 +629,7 @@ exports[`MenuItem 1`] = `
 }
 
 .c0[disabled]:hover .c2 {
-  color: #C1C6CC;
+  color: #939BA5;
 }
 
 <li

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -516,7 +516,7 @@ export function usePopover({
           borderColor="ui2"
           borderRadius="medium"
           boxShadow={3}
-          color="text1"
+          color="text5"
         >
           <Box
             maxHeight={`calc(${verticalSpace - 10}px - 1rem)`}

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -50,7 +50,7 @@ export interface SpinnerProps
 }
 
 const SpinnerFactory: FC<SpinnerProps> = (props) => {
-  const { color = 'text0', markers = 13, markerRadius, speed = 1000 } = props
+  const { color = 'text5', markers = 13, markerRadius, speed = 1000 } = props
   return (
     <Style {...omit(props, 'color', 'markers', 'markersRadius', 'speed')}>
       {range(markers).map((i) => (

--- a/packages/components/src/Tabs/Tab.tsx
+++ b/packages/components/src/Tabs/Tab.tsx
@@ -62,7 +62,7 @@ const TabStyle = styled.button<TabProps>`
     props.selected ? props.theme.colors.key : 'transparent'};
   border-radius: 0;
   color: ${(props) =>
-    props.selected ? props.theme.colors.text1 : props.theme.colors.text4};
+    props.selected ? props.theme.colors.text5 : props.theme.colors.text2};
   cursor: pointer;
 
   & + & {
@@ -71,7 +71,7 @@ const TabStyle = styled.button<TabProps>`
 
   &:active {
     border-bottom-color: ${(props) =>
-      props.selected ? props.theme.colors.key : props.theme.colors.text4};
+      props.selected ? props.theme.colors.key : props.theme.colors.text2};
   }
 
   &:active,
@@ -94,7 +94,7 @@ const TabStyle = styled.button<TabProps>`
 
   &:disabled {
     border-bottom-color: transparent;
-    color: ${({ theme }) => theme.colors.text6};
+    color: ${({ theme }) => theme.colors.text1};
     cursor: default;
   }
 `

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`focus behavior Tab Focus: does not render focus ring after click 1`] = 
 
 .c1:disabled {
   border-bottom-color: transparent;
-  color: #C1C6CC;
+  color: #939BA5;
   cursor: default;
 }
 
@@ -106,7 +106,7 @@ exports[`focus behavior Tab Focus: renders focus ring for keyboard navigation 1`
 
 .c1:disabled {
   border-bottom-color: transparent;
-  color: #C1C6CC;
+  color: #939BA5;
   cursor: default;
 }
 

--- a/packages/components/src/Text/text_variant.ts
+++ b/packages/components/src/Text/text_variant.ts
@@ -46,7 +46,7 @@ export const textVariant = variant({
       color: 'critical',
     },
     default: {
-      color: 'text1',
+      color: 'text5',
     },
     inverted: {
       color: 'inverseOn',
@@ -55,10 +55,10 @@ export const textVariant = variant({
       color: 'positive',
     },
     secondary: {
-      color: 'text4',
+      color: 'text2',
     },
     subdued: {
-      color: 'text5',
+      color: 'text1',
     },
   },
 })

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -206,7 +206,7 @@ interface TreeStyleProps {
 }
 
 export const TreeStyle = styled.div<TreeStyleProps>`
-  color: ${({ theme }) => theme.colors.text2};
+  color: ${({ theme }) => theme.colors.text4};
 
   & > ${Accordion} {
     & > ${AccordionContent} {

--- a/packages/design-tokens/src/prismTheme.ts
+++ b/packages/design-tokens/src/prismTheme.ts
@@ -36,12 +36,12 @@ import {
   yellow300,
 } from './tokens/color/palette'
 
-const { inverse, text5, text6 } = theme.colors
+const { inverse, text1 } = theme.colors
 
 export const prismTheme: PrismTheme = {
   plain: {
     backgroundColor: inverse,
-    color: text6,
+    color: text1,
     fontFamily: theme.fonts.code,
     fontSize: theme.fontSizes.small,
   },
@@ -54,7 +54,7 @@ export const prismTheme: PrismTheme = {
     },
     {
       style: {
-        color: text5,
+        color: text1,
       },
       types: ['comment'],
     },

--- a/packages/design-tokens/src/system/color/blends.ts
+++ b/packages/design-tokens/src/system/color/blends.ts
@@ -61,8 +61,7 @@ export interface UIColors {
 
 export interface TextColors {
   /**
-   * TODO - Should be defined
-   * Used for: TBD
+   * Lowest contrast text in UI, disabled states, placeholder text, for non-essential text only
    * @default charcoal400
    */
   text1: string

--- a/packages/design-tokens/src/system/color/blends.ts
+++ b/packages/design-tokens/src/system/color/blends.ts
@@ -61,21 +61,15 @@ export interface UIColors {
 
 export interface TextColors {
   /**
-   * Extra-dark Text
-   * Used for: Inputs
-   * @default charcoal900
-   */
-  text0: string
-  /**
-   * Primary Text
-   * Used for: Headers, Labels, Dashboard tile titles
-   * @default charcoal800
+   * TODO - Should be defined
+   * Used for: TBD
+   * @default charcoal400
    */
   text1: string
   /**
-   * Secondary Text
-   * Used for: Headers, Labels, Dashboard tile titles
-   * @default charcoal700
+   * Reduced emphasis text
+   * Used for: Help text, meta information
+   * @default charcoal500
    */
   text2: string
   /**
@@ -85,21 +79,15 @@ export interface TextColors {
    */
   text3: string
   /**
-   * Reduced emphasis text
-   * Used for: Help text, meta information
-   * @default charcoal500
+   * Secondary Text
+   * Used for: Headers, Labels, Dashboard tile titles
+   * @default charcoal700
    */
   text4: string
   /**
-   * TODO - Should be defined
-   * Used for: TBD
-   * @default charcoal400
+   * Primary Text
+   * Used for: Headers, Labels, Dashboard tile titles
+   * @default charcoal800
    */
   text5: string
-  /**
-   * DEPRECATE - Should be defined
-   * Used for: TBD
-   * @default charcoal300
-   */
-  text6: string
 }

--- a/packages/design-tokens/src/tokens/color/fallbacks.ts
+++ b/packages/design-tokens/src/tokens/color/fallbacks.ts
@@ -61,13 +61,11 @@ export const fallbackBlends: BlendColors = {
   ui3: charcoal300,
   ui4: charcoal400,
   ui5: charcoal800,
-  text0: charcoal900,
-  text1: charcoal800,
-  text2: charcoal700,
+  text1: charcoal400,
+  text2: charcoal500,
   text3: charcoal600,
-  text4: charcoal500,
-  text5: charcoal400,
-  text6: charcoal300,
+  text4: charcoal700,
+  text5: charcoal800,
 }
 
 export const fallbackStateful: StatefulColors = {

--- a/packages/design-tokens/src/tokens/color/fallbacks.ts
+++ b/packages/design-tokens/src/tokens/color/fallbacks.ts
@@ -40,7 +40,6 @@ import {
   charcoal600,
   charcoal700,
   charcoal800,
-  charcoal900,
   purple000,
   purple100,
   purple300,

--- a/packages/design-tokens/src/utils/color/blend.ts
+++ b/packages/design-tokens/src/utils/color/blend.ts
@@ -113,12 +113,10 @@ export const generateBlendColors = (colors: SpecifiableColors): BlendColors => {
     ui4: tintOrShadeUiColor(uiBlends[3], background),
     ui5: tintOrShadeUiColor(uiBlends[4], background),
 
-    text0: mixColors(textBlends[5], text, background),
-    text1: mixColors(textBlends[5], text, background),
-    text2: mixColors(textBlends[4], text, background),
-    text3: mixColors(textBlends[3], text, background),
-    text4: mixColors(textBlends[2], text, background),
-    text5: mixColors(textBlends[1], text, background),
-    text6: mixColors(textBlends[0], text, background),
+    text1: mixColors(textBlends[0], text, background),
+    text2: mixColors(textBlends[1], text, background),
+    text3: mixColors(textBlends[2], text, background),
+    text4: mixColors(textBlends[3], text, background),
+    text5: mixColors(textBlends[4], text, background),
   }
 }

--- a/storybook/src/Accordion.stories.tsx
+++ b/storybook/src/Accordion.stories.tsx
@@ -107,7 +107,7 @@ export const Controlled = () => {
       <AccordionDisclosure>
         <Space between>
           Some Information
-          <Icon color="text4" name="CircleQuestionOutline" size={20} />
+          <Icon color="text2" name="CircleQuestionOutline" size={20} />
         </Space>
       </AccordionDisclosure>
       <AccordionContent>

--- a/storybook/src/Buttons/Button.stories.tsx
+++ b/storybook/src/Buttons/Button.stories.tsx
@@ -45,7 +45,7 @@ const ButtonComponents = {
 }
 
 export const All = () => (
-  <SpaceVertical gap="xlarge">
+  <SpaceVertical>
     <Key />
     <Neutral />
     <Critical />

--- a/www/src/Layout/Navigation/Header.tsx
+++ b/www/src/Layout/Navigation/Header.tsx
@@ -41,7 +41,7 @@ export const HeaderJsx: FC<HeaderProps> = ({ className }) => (
       <Icon
         name="LookerLogo"
         alt="Looker"
-        color="text1"
+        color="text5"
         style={{ height: '26px', width: '60px' }}
       />
       <DividerVertical ml="medium" mr="small" />
@@ -61,8 +61,8 @@ export const HeaderJsx: FC<HeaderProps> = ({ className }) => (
 
 const Header = styled(HeaderJsx)`
   align-items: center;
-  display: flex;
   border-bottom: 1px solid ${({ theme }) => theme.colors.keyAccent};
+  display: flex;
   height: ${({ height }) => height};
   padding: 0 ${({ theme: { space } }) => `${space.large} ${space.xxsmall}`};
 `

--- a/www/src/Layout/Navigation/Navigation.tsx
+++ b/www/src/Layout/Navigation/Navigation.tsx
@@ -79,7 +79,7 @@ const StyledSidebar = styled(Sidebar)<SidebarProps>`
       padding: ${(props) => `${props.theme.space.xxsmall} 0`};
 
       h2 {
-        color: ${(props) => props.theme.colors.text4};
+        color: ${(props) => props.theme.colors.text2};
         font-size: ${(props) => props.theme.fontSizes.xsmall};
         text-transform: uppercase;
       }

--- a/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/www/src/MDX/Pre/CodeSandbox.tsx
@@ -209,7 +209,7 @@ export const ToggleCodeButton: FC<ToggleButtonProps> = ({
 
 const ActionButton = styled(IconButton)<ActionProps>`
   color: ${({ theme, editorIsVisible }) =>
-    editorIsVisible ? theme.colors.text6 : theme.colors.text4};
+    editorIsVisible ? theme.colors.text1 : theme.colors.text2};
 `
 
 const ActionLayout = styled.div<ActionProps>`

--- a/www/src/Shared/ComponentResources/Resource.tsx
+++ b/www/src/Shared/ComponentResources/Resource.tsx
@@ -39,7 +39,7 @@ const Style = styled(ListItem).attrs({
   py: 'xsmall',
 })`
   align-items: center;
-  color: ${(props) => props.theme.colors.text4};
+  color: ${(props) => props.theme.colors.text2};
   display: flex;
 
   svg {

--- a/www/src/Shared/Props/Props.tsx
+++ b/www/src/Shared/Props/Props.tsx
@@ -51,7 +51,7 @@ const PropsCode = styled(Code).attrs({ fontSize: 'small' })`
 const Layout = styled(Flex).attrs({ mb: 'large', mt: 'small', py: 'small' })`
   border-top: 1px solid ${(props) => props.theme.colors.ui2};
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};
-  color: ${(props) => props.theme.colors.text4};
+  color: ${(props) => props.theme.colors.text2};
   font-size: ${(props) => props.theme.fontSizes.small};
 `
 

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -149,7 +149,7 @@ Use the `selected` prop to display a light grey background on a given `TreeItem`
 <Tree label="Cheeses" defaultOpen>
   <TreeItem
     icon="LogoRings"
-    detail={<Text variant="text4">is great</Text>}
+    detail={<Text variant="text2">is great</Text>}
     onClick={() => alert('Clicked Swiss')}
     selected
   >

--- a/www/src/documentation/system/demos/BorderRender.tsx
+++ b/www/src/documentation/system/demos/BorderRender.tsx
@@ -60,7 +60,7 @@ const borderData: BorderType[] = [
     textColor: 'text3',
   },
   {
-    color: 'text4',
+    color: 'text2',
     examples: ['inverse'],
     label: 'Border on Dark',
     textColor: 'inverseOn',


### PR DESCRIPTION
### :sparkles: Changes

  - `text1-5` now go from lightest to darkest to match `ui1-5`
  - Reduced number of steps:
    - `text0` is now `text5` (consolidated the former `text0` & `text1`)
    - `text6` is now `text1` (consolidated the former `text6` & `text5`)


![image](https://user-images.githubusercontent.com/34253496/87608888-e6b19780-c6b5-11ea-80cf-d89cedda6e85.png)


### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
