### PR TITLE
Accordion: Accessibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-#### Change
+#### Changed
 
 - `theme` "pressed" colors are more discernable from other stateful colors
+- `Accordion` added accessibility improvements
 
 ## [0.9.6] - 2020-07-15
 

--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -29,6 +29,7 @@ import styled from 'styled-components'
 import { SpacingSizes } from '@looker/design-tokens'
 import { IconNames, IconSize } from '../Icon'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
+import { useID } from '../utils'
 import { AccordionContext, accordionContextDefaults } from './AccordionContext'
 import { AccordionContent } from './AccordionContent'
 import { AccordionDisclosure } from './AccordionDisclosure'
@@ -114,19 +115,24 @@ export interface AccordionProps
     SimpleLayoutProps {
   children: ReactNode
   className?: string
+  /**
+   * A unique ID primarily used to supply aria-controls and aria-labelledby to child AccordionDisclosure and child AccordionContent
+   * Note: This will be auto-generated if left undefined
+   */
+  id?: string
 }
 
 const AccordionLayout: FC<AccordionProps> = ({
   children,
   className,
-  defaultOpen,
+  id,
   indicatorGap,
   indicatorSize,
   indicatorIcons,
   indicatorPosition,
   ...props
 }) => {
-  const [isOpen, setIsOpen] = useState(!!defaultOpen)
+  const [isOpen, setIsOpen] = useState(!!props.defaultOpen)
 
   if (
     (props.isOpen && props.toggleOpen === undefined) ||
@@ -137,8 +143,12 @@ const AccordionLayout: FC<AccordionProps> = ({
       'Please provide both an isOpen prop and a toggleOpen prop if you wish to control a Accordion state. If you would like an uncontrolled Accordion, avoid passing in either prop into your Accordion element.'
     )
 
+  const accordionId = useID(id)
+
   const context = {
     ...accordionContextDefaults,
+    accordionContentId: `${accordionId}-content`,
+    accordionDisclosureId: `${accordionId}-disclosure`,
     indicatorGap: indicatorGap || accordionContextDefaults.indicatorGap,
     indicatorIcons: indicatorIcons || accordionContextDefaults.indicatorIcons,
     indicatorPosition:
@@ -152,7 +162,9 @@ const AccordionLayout: FC<AccordionProps> = ({
 
   return (
     <AccordionContext.Provider value={context}>
-      <div className={className}>{children}</div>
+      <div className={className} id={accordionId}>
+        {children}
+      </div>
     </AccordionContext.Provider>
   )
 }

--- a/packages/components/src/Accordion/AccordionContent.tsx
+++ b/packages/components/src/Accordion/AccordionContent.tsx
@@ -37,9 +37,17 @@ const AccordionContentLayout: FC<AccordionContentProps> = ({
   children,
   className,
 }) => {
-  const { isOpen } = useContext(AccordionContext)
+  const { accordionDisclosureId, isOpen } = useContext(AccordionContext)
 
-  return isOpen ? <div className={className}>{children}</div> : null
+  return isOpen ? (
+    <div
+      aria-labelledby={accordionDisclosureId}
+      className={className}
+      role="region"
+    >
+      {children}
+    </div>
+  ) : null
 }
 
 export const AccordionContent = styled(AccordionContentLayout)``

--- a/packages/components/src/Accordion/AccordionContent.tsx
+++ b/packages/components/src/Accordion/AccordionContent.tsx
@@ -37,12 +37,15 @@ const AccordionContentLayout: FC<AccordionContentProps> = ({
   children,
   className,
 }) => {
-  const { accordionDisclosureId, isOpen } = useContext(AccordionContext)
+  const { accordionContentId, accordionDisclosureId, isOpen } = useContext(
+    AccordionContext
+  )
 
   return isOpen ? (
     <div
       aria-labelledby={accordionDisclosureId}
       className={className}
+      id={accordionContentId}
       role="region"
     >
       {children}

--- a/packages/components/src/Accordion/AccordionContext.tsx
+++ b/packages/components/src/Accordion/AccordionContext.tsx
@@ -31,6 +31,8 @@ import { IconSize } from '../Icon'
 import { IndicatorIcons } from './Accordion'
 
 export interface AccordionContextProps {
+  accordionContentId: string
+  accordionDisclosureId: string
   indicatorGap: SpacingSizes
   indicatorIcons: IndicatorIcons
   indicatorSize: IconSize
@@ -42,6 +44,8 @@ export interface AccordionContextProps {
 }
 
 export const accordionContextDefaults: AccordionContextProps = {
+  accordionContentId: '',
+  accordionDisclosureId: '',
   indicatorGap: 'xsmall',
   indicatorIcons: {
     close: 'CaretDown',

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -40,7 +40,7 @@ import { AccordionDisclosureGrid } from './AccordionDisclosureGrid'
 export interface AccordionDisclosureProps extends TypographyProps {
   className?: string
   focusVisible?: boolean
-  ref?: Ref<HTMLDivElement>
+  ref?: Ref<HTMLButtonElement>
 }
 
 export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRef(
@@ -56,13 +56,13 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
       toggleOpen(!isOpen)
     }
 
-    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
       if (event.keyCode === 13) {
         handleToggle()
       }
     }
 
-    const handleKeyUp = (event: KeyboardEvent<HTMLDivElement>) => {
+    const handleKeyUp = (event: KeyboardEvent<HTMLButtonElement>) => {
       if (event.keyCode === 9 && event.currentTarget === event.target)
         setFocusVisible(true)
     }
@@ -97,8 +97,15 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
 
 AccordionDisclosureLayout.displayName = 'AccordionDisclosureLayout'
 
-export const AccordionDisclosureStyle = styled.div<{ focusVisible: boolean }>`
+interface AccordionDisclosureStyleProps {
+  focusVisible: boolean
+}
+
+export const AccordionDisclosureStyle = styled.button<
+  AccordionDisclosureStyleProps
+>`
   align-items: center;
+  background-color: transparent;
   border: 1px solid transparent;
   border-color: ${({ focusVisible, theme }) =>
     focusVisible && theme.colors.keyFocus};
@@ -106,6 +113,7 @@ export const AccordionDisclosureStyle = styled.div<{ focusVisible: boolean }>`
   display: flex;
   outline: none;
   padding: ${({ theme: { space } }) => `${space.xsmall} ${space.none}`};
+  text-align: left;
   width: 100%;
 `
 

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -54,6 +54,7 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
     const [isFocusVisible, setFocusVisible] = useState(false)
     const {
       accordionContentId,
+      accordionDisclosureId,
       isOpen,
       toggleOpen,
       onClose,
@@ -94,6 +95,7 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
         aria-expanded={isOpen}
         className={className}
         focusVisible={isFocusVisible}
+        id={accordionDisclosureId}
         onBlur={handleBlur}
         onClick={handleClick}
         onKeyDown={handleKeyDown}

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -33,11 +33,17 @@ import React, {
   useState,
 } from 'react'
 import styled from 'styled-components'
-import { TypographyProps, typography } from '@looker/design-tokens'
+import {
+  TypographyProps,
+  typography,
+  CompatibleHTMLProps,
+} from '@looker/design-tokens'
 import { AccordionContext } from './AccordionContext'
 import { AccordionDisclosureGrid } from './AccordionDisclosureGrid'
 
-export interface AccordionDisclosureProps extends TypographyProps {
+export interface AccordionDisclosureProps
+  extends TypographyProps,
+    CompatibleHTMLProps<HTMLButtonElement> {
   className?: string
   focusVisible?: boolean
   ref?: Ref<HTMLButtonElement>
@@ -46,9 +52,15 @@ export interface AccordionDisclosureProps extends TypographyProps {
 export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRef(
   ({ children, className }, ref) => {
     const [isFocusVisible, setFocusVisible] = useState(false)
-    const { isOpen, toggleOpen, onClose, onOpen, ...props } = useContext(
-      AccordionContext
-    )
+    const {
+      accordionContentId,
+      isOpen,
+      toggleOpen,
+      onClose,
+      onOpen,
+      ...props
+    } = useContext(AccordionContext)
+
     const handleOpen = () => onOpen && onOpen()
     const handleClose = () => onClose && onClose()
     const handleToggle = () => {
@@ -78,6 +90,8 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
 
     return (
       <AccordionDisclosureStyle
+        aria-controls={accordionContentId}
+        aria-expanded={isOpen}
         className={className}
         focusVisible={isFocusVisible}
         onBlur={handleBlur}

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -101,7 +101,7 @@ const TreeLayout: FC<TreeProps> = ({
   visuallyAsBranch,
   ...restProps
 }) => {
-  const disclosureRef = useRef<HTMLDivElement>(null)
+  const disclosureRef = useRef<HTMLButtonElement>(null)
   const [isHovered] = useHovered(disclosureRef)
 
   const treeContext = useContext(TreeContext)

--- a/storybook/src/Accordion.stories.tsx
+++ b/storybook/src/Accordion.stories.tsx
@@ -59,7 +59,7 @@ export default {
 const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
 
 export const Basic = () => (
-  <Accordion px="large">
+  <Accordion id="basic-accordion" px="large">
     <AccordionDisclosure> See more...</AccordionDisclosure>
     <AccordionContent>{lorem}</AccordionContent>
   </Accordion>

--- a/www/src/documentation/components/content/accordion.mdx
+++ b/www/src/documentation/components/content/accordion.mdx
@@ -10,6 +10,8 @@ import { Props } from '../../../Shared'
 
 The `<Accordion>` component in particular acts as a wrapper and context provider for its companion components, `<AccordionDisclosure>` and `<AccordionContent>`.
 
+Use the `id` prop to set the ID of the parent `Accordion` div. In addition, IDs will be auto-generated for any child `AccordionDisclosure` and `AccordionContent` elements based on `Accordion`'s ID.
+
 Use the `onClose` and `onOpen` props if you would like to trigger callbacks on `<Accordion>` open or close.
 
 If you want your `<Accordion>` open by default, use the `defaultOpen` prop.


### PR DESCRIPTION
### :sparkles: Changes

- `Accordion` added "id" prop
  -  Used to generate "accordionDisclosureId" and "accordionContentId" values which are passed down to the disclosure and content elements via `AccordionContext`
- `AccordionDisclosure`
  - Converted from div to button element
  - Utilizes `aria-expanded` and `aria-controls` attributes
- `AccordionContent`
  - Utilizes `aria-labelledby` and `role` attributes

**Note:** If this approach seems 👍  I'll update documentation to elaborate on use of `id` prop on `Accordion`.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC
