### PR TITLE
Action List: Checkbox accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-### Change
+### Changed
 
 - `theme.colors.*Pressed` colors are more discernable from other stateful colors
 - `theme.colors.textX` restructured
@@ -15,8 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reduced number of steps:
     - `text0` is now `text5` (consolidated the former `text0` & `text1`)
     - `text6` is now `text1` (consolidated the former `text6` & `text5`)
+- `ActionList`
+  - Checkboxes use `aria-describedby` attribute for accessibility purposes
 
 ### Fixed
+
 - Fix a few typos in the `Field` documentation
 
 ## [0.9.6] - 2020-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reduced number of steps:
     - `text0` is now `text5` (consolidated the former `text0` & `text1`)
     - `text6` is now `text1` (consolidated the former `text6` & `text5`)
-- `ActionList`
-  - Checkboxes use `aria-describedby` attribute for accessibility purposes
+- `ActionListCheckbox` now use `aria-describedby` attribute for accessibility purposes
+  - Receives id from parent `ActionListRow`, who receives it from parent `ActionListItem` or `ActionListHeader`
 
 ### Fixed
 
 - Fix a few typos in the `Field` documentation
+- `ActionList` fixed bug where passing object (with single attribute "all") into `canSelect` results in select all checkbox regardless of "all" setting
 
 ## [0.9.6] - 2020-07-15
 

--- a/packages/components/src/ActionList/ActionList.tsx
+++ b/packages/components/src/ActionList/ActionList.tsx
@@ -151,7 +151,7 @@ export const ActionListLayout: FC<ActionListProps> = ({
   const context = {
     addItemToAllItems,
     allSelected,
-    canSelect: !!canSelect,
+    canSelect,
     columns,
     itemsSelected,
     onClickRowSelect,

--- a/packages/components/src/ActionList/ActionList.tsx
+++ b/packages/components/src/ActionList/ActionList.tsx
@@ -27,6 +27,7 @@
 import styled from 'styled-components'
 import React, { FC, ReactNode, useState } from 'react'
 import { MixedBoolean } from '../Form'
+import { useID } from '../utils/useID'
 import {
   ActionListHeader,
   generateActionListHeaderColumns,
@@ -108,6 +109,11 @@ export interface ActionListProps {
    * @default false
    */
   onClickRowSelect?: boolean
+  /**
+   * ID of the header row. Used for the aria-describedby of the select all checkbox.
+   * Note: If undefined, this will be auto-generated
+   */
+  headerRowId?: string
 }
 
 export const ActionListLayout: FC<ActionListProps> = ({
@@ -121,6 +127,7 @@ export const ActionListLayout: FC<ActionListProps> = ({
   onSelect,
   onSelectAll,
   onSort,
+  headerRowId,
 }) => {
   const [allItems, setAllItems] = useState<string[]>([])
 
@@ -139,6 +146,8 @@ export const ActionListLayout: FC<ActionListProps> = ({
 
   const handleSelectAll = onSelectAll ? () => onSelectAll() : undefined
 
+  const guaranteedId = useID(headerRowId)
+
   const context = {
     addItemToAllItems,
     allSelected,
@@ -153,11 +162,11 @@ export const ActionListLayout: FC<ActionListProps> = ({
 
   const actionListHeader =
     header === true ? (
-      <ActionListHeader>
+      <ActionListHeader id={guaranteedId}>
         {generateActionListHeaderColumns(columns)}
       </ActionListHeader>
     ) : header === false ? null : (
-      <ActionListHeader>{header}</ActionListHeader>
+      <ActionListHeader id={guaranteedId}>{header}</ActionListHeader>
     )
 
   return (

--- a/packages/components/src/ActionList/ActionListCheckbox.tsx
+++ b/packages/components/src/ActionList/ActionListCheckbox.tsx
@@ -58,8 +58,6 @@ const ActionListCheckboxLayout: FC<ActionListCheckboxProps> = ({
     }
   }
 
-  console.log(id)
-
   return (
     <div onClick={handleOnChange} className={className}>
       <Checkbox

--- a/packages/components/src/ActionList/ActionListCheckbox.tsx
+++ b/packages/components/src/ActionList/ActionListCheckbox.tsx
@@ -29,17 +29,19 @@ import styled from 'styled-components'
 import { Checkbox, MixedBoolean } from '../Form'
 
 export interface ActionListCheckboxProps {
+  id?: string
   checked?: MixedBoolean
   disabled?: boolean
   onChange?: () => void
   className?: string
 }
 
-export const checkListProps = ['checked', 'disabled', 'onChange']
+export const checkListProps = ['checked', 'disabled', 'onChange', 'id']
 
 export const actionListCheckboxWidth = '2.75rem'
 
 const ActionListCheckboxLayout: FC<ActionListCheckboxProps> = ({
+  id,
   onChange,
   checked,
   disabled,
@@ -56,9 +58,12 @@ const ActionListCheckboxLayout: FC<ActionListCheckboxProps> = ({
     }
   }
 
+  console.log(id)
+
   return (
     <div onClick={handleOnChange} className={className}>
       <Checkbox
+        aria-describedby={id}
         disabled={disabled}
         checked={checked}
         onChange={handleOnChange}

--- a/packages/components/src/ActionList/ActionListHeader/ActionListHeader.tsx
+++ b/packages/components/src/ActionList/ActionListHeader/ActionListHeader.tsx
@@ -33,6 +33,7 @@ import { ActionListContext } from '../ActionListContext'
 const ActionListHeaderInternal: FC<CompatibleHTMLProps<HTMLDivElement>> = ({
   children,
   className,
+  id,
 }) => {
   const { allSelected, canSelect, onSelectAll } = useContext(ActionListContext)
 
@@ -40,6 +41,7 @@ const ActionListHeaderInternal: FC<CompatibleHTMLProps<HTMLDivElement>> = ({
 
   return (
     <ActionListRow
+      id={id}
       className={className}
       hasCheckbox={hasCheckbox}
       onChange={onSelectAll}

--- a/packages/components/src/ActionList/ActionListItem.tsx
+++ b/packages/components/src/ActionList/ActionListItem.tsx
@@ -110,6 +110,7 @@ const ActionListItemInternal: FC<ActionListItemProps> = ({
 
   return (
     <ActionListRow
+      id={id}
       className={className}
       secondary={itemActions}
       ref={actionListItemRef}

--- a/storybook/src/ActionList/ActionList.tsx
+++ b/storybook/src/ActionList/ActionList.tsx
@@ -74,6 +74,7 @@ export const Basic = () => {
       onSelectAll={onSelectAll}
       itemsSelected={selections}
       columns={columns}
+      headerRowId="all-pdts"
     >
       {items}
     </ActionList>

--- a/www/src/documentation/components/content/action-list.mdx
+++ b/www/src/documentation/components/content/action-list.mdx
@@ -362,7 +362,9 @@ A header checkbox is included next to your `<ActionList/>`'s header when the `ca
 
 Clicking on this header checkbox will trigger the callback passed into the `<ActionList/>`'s `onSelectAll` prop.
 
-**Note:** If you would like to remove the header checkbox, but retain the row checkboxes, pass in `{ all: false }` into your `canSelect` prop.
+If you would like to remove the header checkbox, but retain the row checkboxes, pass in `{ all: false }` into your `canSelect` prop.
+
+For accessibility purposes, the header checkbox is described by the ID of the header row. To set the ID of the header row, use the `headerRowId` prop on `ActionList`.
 
 ```jsx
 ;() => {


### PR DESCRIPTION
### :sparkles: Changes

- `ActionListCheckbox` passes row ID into "aria-describedby" attribute
- `ActionList` new "headerRowId" prop
  - Used to set the id of the header row, which is then used for the "aria-describedby" of the select all checkbox
- Fixed bug where passing object (with single attribute "all") into `canSelect` results in select all checkbox regardless of "all" setting

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC