### PR TITLE
Fix SelectMulti freeInput + honor click outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- `Popover` now supports `cancelClickOutside` (`true` by default) to determine whether the "dismissal" click event is allowed to propagate
+
 ### Changed
 
+- `Select` and `SelectMulti` with `isFilterable` or `freeInput` no longer cancel the first click outside when the list is open
 - update `Tab` to scroll left to right when overflow
 - `theme` "pressed" colors are more discernable from other stateful colors
 - `Accordion` added accessibility improvements
@@ -23,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SelectMulti` with `freeInput` tokenizing the input value when an option is clicked
 - `Tabs` now can be controlled
 - Fix a few typos in the `Field` documentation
 - `ActionList` fixed bug where passing object (with single attribute "all") into `canSelect` results in select all checkbox regardless of "all" setting

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
@@ -77,11 +77,14 @@ export interface ComboboxContextProps<
   setListClientRect?: Dispatch<SetStateAction<DOMRect | undefined>>
 }
 
-export type ComboboxMultiContextProps = ComboboxContextProps<
-  ComboboxMultiData,
-  ComboboxMultiCallback,
-  ComboboxTransition<ComboboxMultiActionPayload>
->
+export interface ComboboxMultiContextProps
+  extends ComboboxContextProps<
+    ComboboxMultiData,
+    ComboboxMultiCallback,
+    ComboboxTransition<ComboboxMultiActionPayload>
+  > {
+  freeInputPropRef?: MutableRefObject<boolean>
+}
 
 export const defaultData: ComboboxData = {
   // the value the user has typed, we derived this also when the developer is

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -53,7 +53,6 @@ import { ComboboxOptionIndicatorProps } from './ComboboxOptionIndicator'
 import { ComboboxContext, ComboboxMultiContext } from './ComboboxContext'
 import { useBlur } from './utils/useBlur'
 import { useKeyDown } from './utils/useKeyDown'
-import { ComboboxActionType } from './utils/state'
 
 export interface ComboboxListProps
   extends Pick<ComboboxOptionIndicatorProps, 'indicator'>,
@@ -128,7 +127,6 @@ const ComboboxListInternal = forwardRef(
       closeOnSelectPropRef,
       windowedOptionsPropRef,
       indicatorPropRef,
-      transition,
       wrapperElement,
       isVisible,
       optionsRef,
@@ -184,12 +182,10 @@ const ComboboxListInternal = forwardRef(
     )
 
     const setOpen = (isOpen: boolean) => {
-      // Delay the BLUR transition so freeInput can have a chance to tokenize the input value
-      requestAnimationFrame(() => {
-        if (!isOpen) {
-          transition && transition(ComboboxActionType.BLUR)
-        }
-      })
+      if (!isOpen) {
+        // Without passing an event, this just handles state change required when closing the list
+        handleBlur()
+      }
     }
 
     const { popover, contentContainer, popperInstanceRef } = usePopover({

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -86,6 +86,11 @@ export interface ComboboxListProps
    * @default false
    */
   windowedOptions?: boolean
+  /**
+   * Whether to honor the first click outside the popover
+   * @default false
+   */
+  cancelClickOutside?: boolean
 }
 
 interface ComboboxListInternalProps extends ComboboxListProps {
@@ -106,6 +111,9 @@ const ComboboxListInternal = forwardRef(
       closeOnSelect = true,
       // disables the optionsRef behavior, to be handled externally (support keyboard nav in long lists)
       windowedOptions = false,
+      // passed to usePopover – when false, allows first outside click to be honored
+      // generally should be false except for when closely mimicking native browser select
+      cancelClickOutside = false,
       indicator,
       isMulti,
       ...props
@@ -183,6 +191,7 @@ const ComboboxListInternal = forwardRef(
 
     const { popover, contentContainer, popperInstanceRef } = usePopover({
       arrow: false,
+      cancelClickOutside,
       content,
       focusTrap: false,
       isOpen: isVisible,

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -184,9 +184,12 @@ const ComboboxListInternal = forwardRef(
     )
 
     const setOpen = (isOpen: boolean) => {
-      if (!isOpen) {
-        transition && transition(ComboboxActionType.BLUR)
-      }
+      // Delay the BLUR transition so freeInput can have a chance to tokenize the input value
+      requestAnimationFrame(() => {
+        if (!isOpen) {
+          transition && transition(ComboboxActionType.BLUR)
+        }
+      })
     }
 
     const { popover, contentContainer, popperInstanceRef } = usePopover({

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMulti.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMulti.tsx
@@ -45,7 +45,7 @@ import {
   ComboboxCommonProps,
   ComboboxWrapper,
 } from './Combobox'
-import { useComboboxRefs } from './utils/useComboboxRefs'
+import { useComboboxMultiRefs } from './utils/useComboboxRefs'
 import { useComboboxToggle } from './utils/useComboboxToggle'
 import { useScrollState } from './utils/useScrollState'
 
@@ -118,7 +118,7 @@ export const ComboboxMultiInternal = forwardRef(
 
     const isVisible = useComboboxToggle(state, options, onOpen, onClose)
 
-    const { ref, ...commonRefs } = useComboboxRefs(forwardedRef)
+    const { ref, ...commonRefs } = useComboboxMultiRefs(forwardedRef)
 
     const scrollState = useScrollState()
 

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
@@ -48,7 +48,7 @@ import {
   getOptionsFromValues,
 } from './utils/state'
 import { useInputEvents } from './utils/useInputEvents'
-import { useInputPropRefs } from './utils/useInputPropRefs'
+import { useInputMultiPropRefs } from './utils/useInputPropRefs'
 
 export interface ComboboxMultiInputProps
   extends Omit<InputChipsCommonProps, 'autoComplete'>,
@@ -92,7 +92,7 @@ export const ComboboxMultiInputInternal = forwardRef(
       isVisible,
     } = useContext(ComboboxMultiContext)
 
-    useInputPropRefs(props, ComboboxMultiContext)
+    useInputMultiPropRefs(props)
 
     function handleClear() {
       transition && transition(ComboboxActionType.CLEAR)

--- a/packages/components/src/Form/Inputs/Combobox/utils/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/state.ts
@@ -337,7 +337,10 @@ const reducerMulti: Reducer<
     case ComboboxActionType.ESCAPE:
       return {
         ...nextState,
-        inputValue: '',
+        inputValue:
+          action.inputValue !== undefined
+            ? action.inputValue
+            : nextState.inputValue,
         navigationOption: undefined,
       }
     case ComboboxActionType.SELECT_WITH_CLICK:

--- a/packages/components/src/Form/Inputs/Combobox/utils/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/state.ts
@@ -337,6 +337,7 @@ const reducerMulti: Reducer<
     case ComboboxActionType.ESCAPE:
       return {
         ...nextState,
+        inputValue: '',
         navigationOption: undefined,
       }
     case ComboboxActionType.SELECT_WITH_CLICK:

--- a/packages/components/src/Form/Inputs/Combobox/utils/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/state.ts
@@ -337,7 +337,6 @@ const reducerMulti: Reducer<
     case ComboboxActionType.ESCAPE:
       return {
         ...nextState,
-        inputValue: '',
         navigationOption: undefined,
       }
     case ComboboxActionType.SELECT_WITH_CLICK:

--- a/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
@@ -26,7 +26,7 @@
 
 // Much of the following is pulled from https://github.com/reach/reach-ui
 // because their work is fantastic (but is not in TypeScript)
-import { Context, useContext } from 'react'
+import { Context, FocusEvent, useContext } from 'react'
 import {
   ComboboxContextProps,
   ComboboxMultiContextProps,
@@ -40,21 +40,22 @@ export function useBlur<
 >(context: Context<TContext>) {
   const { state, transition, listRef, inputElement } = useContext(context)
 
-  return function handleBlur() {
-    requestAnimationFrame(() => {
-      // we on want to close only if focus rests outside the select
-      const popoverCurrent = listRef ? listRef.current : null
-      if (document.activeElement !== inputElement && popoverCurrent) {
-        if (popoverCurrent && popoverCurrent.contains(document.activeElement)) {
-          // focus landed inside the select, keep it open
+  return function handleBlur(e: FocusEvent) {
+    // we on want to close only if focus rests outside the select
+    const popoverCurrent = listRef ? listRef.current : null
+    if (e.relatedTarget !== inputElement && popoverCurrent) {
+      if (popoverCurrent && popoverCurrent.contains(e.relatedTarget as Node)) {
+        // focus landed inside the select, keep it open
+        requestAnimationFrame(() => {
           if (state !== ComboboxState.INTERACTING) {
             transition && transition(ComboboxActionType.INTERACT)
           }
-        } else {
-          // focus landed outside the select, close it.
-          transition && transition(ComboboxActionType.BLUR)
-        }
+        })
+        e.preventDefault()
+      } else {
+        // focus landed outside the select, close it.
+        transition && transition(ComboboxActionType.BLUR)
       }
-    })
+    }
   }
 }

--- a/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
@@ -45,12 +45,12 @@ export function useBlur<
     inputElement,
     ...contextValue
   } = useContext(context)
+  const contextMulti = contextValue as ComboboxMultiContextProps
 
   function closeList() {
     // for ComboboxInputMulti, input value is cleared when the list closes
     // EXCEPT when freeInput is true and the underlying InputChips blur handler
     // needs to tokenize the value
-    const contextMulti = contextValue as ComboboxMultiContextProps
     const isMultiNoFreeInput =
       contextMulti.freeInputPropRef &&
       contextMulti.freeInputPropRef.current === false
@@ -81,7 +81,12 @@ export function useBlur<
           closeList()
         }
       })
-      focusInList && e.preventDefault()
+      // Stop ComboboxMultiInput + freeInput underlying InputChips blur handler from
+      // tokenizing input value when an option is clicked
+      focusInList &&
+        contextMulti.freeInputPropRef &&
+        contextMulti.freeInputPropRef.current &&
+        e.preventDefault()
     }
   }
 }

--- a/packages/components/src/Form/Inputs/Combobox/utils/useComboboxRefs.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useComboboxRefs.ts
@@ -70,3 +70,9 @@ export function useComboboxRefs(forwardedRef: Ref<HTMLDivElement>) {
     wrapperElement,
   }
 }
+
+export function useComboboxMultiRefs(forwardedRef: Ref<HTMLDivElement>) {
+  const refs = useComboboxRefs(forwardedRef)
+  const freeInputPropRef = useRef(false)
+  return { ...refs, freeInputPropRef }
+}

--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputPropRefs.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputPropRefs.ts
@@ -28,6 +28,7 @@ import { ComboboxInputProps } from '../ComboboxInput'
 import { ComboboxMultiInputProps } from '../ComboboxMultiInput'
 import {
   ComboboxContextProps,
+  ComboboxMultiContext,
   ComboboxMultiContextProps,
 } from '../ComboboxContext'
 
@@ -53,4 +54,18 @@ export function useInputPropRefs<
     if (readOnlyPropRef) readOnlyPropRef.current = readOnly
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [readOnly])
+}
+
+export function useInputMultiPropRefs({
+  freeInput = false,
+  ...props
+}: ComboboxMultiInputProps) {
+  useInputPropRefs(props, ComboboxMultiContext)
+
+  const { freeInputPropRef } = useContext(ComboboxMultiContext)
+
+  useLayoutEffect(() => {
+    if (freeInputPropRef) freeInputPropRef.current = freeInput
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [freeInput])
 }

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -175,6 +175,7 @@ const SelectComponent = forwardRef(
           <ComboboxList
             persistSelection
             windowedOptions={windowedOptions}
+            cancelClickOutside={!isFilterable}
             indicator={indicator}
             width={autoResize ? 'auto' : undefined}
             {...ariaProps}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -137,7 +137,7 @@ const SelectMultiComponent = forwardRef(
           removeOnBackspace={removeOnBackspace}
           validationType={validationType}
           autoComplete={false}
-          readOnly={!isFilterable}
+          readOnly={!isFilterable && !freeInput}
           onInputChange={handleInputChange}
           selectOnClick={isFilterable}
           freeInput={freeInput}
@@ -148,6 +148,7 @@ const SelectMultiComponent = forwardRef(
             persistSelection
             closeOnSelect={closeOnSelect}
             windowedOptions={windowedOptions}
+            cancelClickOutside={!isFilterable && !freeInput}
             indicator={indicator}
             {...ariaProps}
             {...listLayout}

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -198,6 +198,27 @@ describe('Popover', () => {
     expect(doThing).toBeCalledTimes(0)
   })
 
+  test('With cancelClickOutside = false, open popover does not cancel click event', () => {
+    const doThing = jest.fn()
+
+    const { getByText, queryByText } = renderWithTheme(
+      <>
+        <Popover content={SimpleContent} cancelClickOutside={false}>
+          <button>Instant Click</button>
+        </Popover>
+        <a onClick={doThing}>Do thing...</a>
+      </>
+    )
+
+    const trigger = getByText('Instant Click')
+    fireEvent.click(trigger) // open Popover
+
+    const closer = getByText('Do thing...')
+    fireEvent.click(closer)
+    expect(queryByText('simple content')).not.toBeInTheDocument()
+    expect(doThing).toBeCalledTimes(1)
+  })
+
   test('Popover Group - item outside group does NOT receive first click event', () => {
     const { getByText, queryByText } = renderWithTheme(<PopoverGroup />)
     const trigger = getByText('Instant Click')

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -135,6 +135,12 @@ export interface UsePopoverProps {
    * @default true
    */
   focusTrap?: boolean
+
+  /**
+   * Whether to honor the first click outside the popover
+   * @default true
+   */
+  cancelClickOutside?: boolean
 }
 
 type PopoverRenderProp = (popoverProps: {
@@ -253,9 +259,15 @@ function usePopoverToggle(
     canClose,
     groupedPopoversRef,
     triggerToggle,
+    cancelClickOutside = true,
   }: Pick<
     UsePopoverProps,
-    'isOpen' | 'setOpen' | 'canClose' | 'groupedPopoversRef' | 'triggerToggle'
+    | 'isOpen'
+    | 'setOpen'
+    | 'canClose'
+    | 'groupedPopoversRef'
+    | 'triggerToggle'
+    | 'cancelClickOutside'
   >,
   portalElement: HTMLElement | null,
   triggerElement: HTMLElement | null
@@ -312,11 +324,12 @@ function usePopoverToggle(
         return
       }
 
-      // Group-member clicked, allow event to propagate
       if (
-        groupedPopoversRef &&
-        groupedPopoversRef.current &&
-        groupedPopoversRef.current.contains(event.target as Node)
+        !cancelClickOutside ||
+        // Group-member clicked, allow event to propagate
+        (groupedPopoversRef &&
+          groupedPopoversRef.current &&
+          groupedPopoversRef.current.contains(event.target as Node))
       ) {
         return
       }
@@ -355,6 +368,7 @@ function usePopoverToggle(
       document.removeEventListener('mouseup', handleMouseUp, true)
     }
   }, [
+    cancelClickOutside,
     canClose,
     groupedPopoversRef,
     isOpen,
@@ -381,6 +395,7 @@ export function usePopover({
   triggerElement,
   triggerToggle = true,
   focusTrap = true,
+  cancelClickOutside,
 }: UsePopoverProps) {
   const {
     element: scrollElement,
@@ -408,6 +423,7 @@ export function usePopover({
   const [isOpen, setOpen] = usePopoverToggle(
     {
       canClose,
+      cancelClickOutside,
       groupedPopoversRef,
       isOpen: controlledIsOpen,
       setOpen: controlledSetOpen,

--- a/storybook/src/Forms/SelectMulti.stories.tsx
+++ b/storybook/src/Forms/SelectMulti.stories.tsx
@@ -287,6 +287,16 @@ export function SelectMultiDemo() {
         removeOnBackspace={false}
         mb="xlarge"
       />
+      <SelectMulti
+        options={newOptions}
+        placeholder="with freeInput"
+        isFilterable
+        onFilter={handleFilter}
+        alignSelf="flex-start"
+        freeInput
+        removeOnBackspace={false}
+        mb="xlarge"
+      />
 
       <Heading mb="medium" as="h4">
         Validation Errors

--- a/storybook/src/Forms/SelectMulti.stories.tsx
+++ b/storybook/src/Forms/SelectMulti.stories.tsx
@@ -221,7 +221,7 @@ export function SelectMultiDemo() {
         <FieldSelectMulti
           label="Label"
           options={selectOptions}
-          placeholder="Search fruits"
+          placeholder="Select fruits"
           detail="5/50"
         />
         <FieldSelectMulti
@@ -254,7 +254,7 @@ export function SelectMultiDemo() {
       </Heading>
       <SelectMulti
         options={selectGroups}
-        placeholder="Search fruits"
+        placeholder="Select fruits"
         mb="xlarge"
       />
       <Heading mb="medium" as="h4">
@@ -262,7 +262,7 @@ export function SelectMultiDemo() {
       </Heading>
       <SelectMulti
         options={selectOptions}
-        placeholder="Search fruits"
+        placeholder="Select fruits"
         closeOnSelect
         mb="xlarge"
       />
@@ -304,7 +304,7 @@ export function SelectMultiDemo() {
       <SelectMulti
         name="fruitError"
         options={selectOptions}
-        placeholder="Search fruits"
+        placeholder="Select fruits"
         closeOnSelect
         mb="xlarge"
         validationType="error"
@@ -322,7 +322,7 @@ export function SelectMultiDemo() {
             value: 'indicator',
           },
         ]}
-        placeholder="Search fruits"
+        placeholder="Select fruits"
         closeOnSelect
         mb="xlarge"
         indicator={({ isActive, isSelected }) => (

--- a/storybook/src/Overlays/Popovers/Testing.stories.tsx
+++ b/storybook/src/Overlays/Popovers/Testing.stories.tsx
@@ -41,6 +41,7 @@ import {
   Paragraph,
   Popover,
   PopoverContent,
+  Space,
   SpaceVertical,
   usePopover,
   useToggle,
@@ -80,58 +81,68 @@ export const PopoverFocusTrap = () => {
   }
 
   return (
-    <Box mt="large">
+    <SpaceVertical mt="large">
       <Heading>Focus Trap Test</Heading>
-      <Popover
-        content={
-          <PopoverContent p="large" width="360px">
-            <Paragraph>
-              Does tabbing focus only loop through these 3 buttons &amp; Select?
-            </Paragraph>
-            <Paragraph>
-              Does clicking (or mousedown) each trigger an alert?
-            </Paragraph>
-            <Button mr="small" onClick={getButtonAlert('First')}>
-              First
-            </Button>
-            <Button mr="small" onClick={getButtonAlert('Second')}>
-              Second
-            </Button>
-            <Button
-              mt="small"
-              mb="medium"
-              onMouseDown={getButtonAlert('Third')}
-            >
-              Third (mousedown)
-            </Button>
-            <FieldSelect
-              label="Default Value"
-              width={300}
-              options={options}
-              aria-label="Fruits"
-              defaultValue="1"
-            />
-            <Paragraph>
-              Does it scroll here when the Select is closed?
-            </Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-            <Paragraph>Long text</Paragraph>
-          </PopoverContent>
-        }
-      >
-        <Button mt="medium">Open Focus Trap Test Popover</Button>
-      </Popover>
+      <Paragraph>With cancelClickOutside=false</Paragraph>
+      <Space>
+        <Popover
+          cancelClickOutside={false}
+          content={
+            <PopoverContent p="large" width="360px">
+              <Paragraph>
+                Does tabbing focus only loop through these 3 buttons &amp;
+                Select?
+              </Paragraph>
+              <Paragraph>
+                Does clicking (or mousedown) each trigger an alert?
+              </Paragraph>
+              <Button mr="small" onClick={getButtonAlert('First')}>
+                First
+              </Button>
+              <Button mr="small" onClick={getButtonAlert('Second')}>
+                Second
+              </Button>
+              <Button
+                mt="small"
+                mb="medium"
+                onMouseDown={getButtonAlert('Third')}
+              >
+                Third (mousedown)
+              </Button>
+              <FieldSelect
+                label="Default Value"
+                width={300}
+                options={options}
+                aria-label="Fruits"
+                defaultValue="1"
+              />
+              <Paragraph>
+                Does it scroll here when the Select is closed?
+              </Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+              <Paragraph>Long text</Paragraph>
+            </PopoverContent>
+          }
+        >
+          <Button>Open Focus Trap Test Popover</Button>
+        </Popover>
+        <ButtonOutline
+          onClick={() => alert('cancelClickOutside=false is working')}
+        >
+          Click me with the popover open
+        </ButtonOutline>
+      </Space>
       <Paragraph>Does it scroll here when the Popover is closed?</Paragraph>
       <Paragraph>Long text</Paragraph>
       <Paragraph>Long text</Paragraph>
@@ -161,7 +172,7 @@ export const PopoverFocusTrap = () => {
       <Paragraph>Long text</Paragraph>
       <Paragraph>Long text</Paragraph>
       <Paragraph>Long text</Paragraph>
-    </Box>
+    </SpaceVertical>
   )
 }
 


### PR DESCRIPTION
### :sparkles: Changes

- Convention seems to say that a [_select_](https://material-ui.com/components/selects/) (no typing allowed) should stay focused after the click that dismisses the list, while a [_combobox_ / _autocomplete_](https://material-ui.com/components/autocomplete/) (typing allowed) should lose focus in this scenario.
- **Issue 1:** Because we don't currently follow this convention, there's a bug with `SelectMulti` > `freeInput` where you lose the input value on dismiss click, but the expected behavior is that the value should be tokenized (similar to `InputChips`).
- Updating to follow convention and allow the `Select`/`SelectMulti` input to lose focus (and whatever was clicked to receive that event / focus) on the list-dismissal click when typing is allowed (`isFilterable` or `freeInput`) fixes this bug.
- Added `cancelClickOutside` (default `true`) prop to `Popover`/`usePopover` to support this.
- **Issue 2** with `freeInput`, when you type into the input _then_ select from the list, but the value you typed and the option you clicked are added.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue 1:
![issue-1](https://user-images.githubusercontent.com/53451193/88257817-7eddec80-cc73-11ea-8cd8-ecc0fe5a6f58.gif)

#### Issue 2:
![issue-2](https://user-images.githubusercontent.com/53451193/88257831-869d9100-cc73-11ea-9c3a-169dae01355e.gif)
