### PR TITLE
Move the default tooltip placement for menu disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED]
 
 ### Changed
+- `MenuDisclosure` - tooltip placement now defaults to `bottom`
+
+### Changed
 
 - update `Tab` to scroll left to right when overflow
 - `theme` "pressed" colors are more discernable from other stateful colors

--- a/packages/components/src/Menu/MenuDisclosure.tsx
+++ b/packages/components/src/Menu/MenuDisclosure.tsx
@@ -88,7 +88,7 @@ export const MenuDisclosure: FC<MenuDisclosureProps> = ({
     content: tooltip,
     disabled: isOpen,
     id: disclosureId ? `${disclosureId}-tooltip` : undefined,
-    placement: tooltipPlacement || 'top',
+    placement: tooltipPlacement || 'bottom',
     triggerElement,
   })
 


### PR DESCRIPTION
### :sparkles: Changes

This PR sets the default placement for `MenuDisclosure`'s tooltip to the bottom. This brings consistency to how we do it with icon buttons

### Before
![image](https://user-images.githubusercontent.com/170681/88335584-678d1680-cce8-11ea-8c8a-1b7853f2cb7b.png)


### After
![image](https://user-images.githubusercontent.com/170681/88335559-5f34db80-cce8-11ea-8a0e-5471fae49012.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
