### PR TITLE
Fix Select/SelectMulti toggling from the caret icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select`/`SelectMulti` toggling the list from the caret
 - `Select` and `SelectMulti` keyboard navigation issues when filtering options
 - `SelectMulti` with `freeInput` tokenizing the input value when an option is clicked
 - `Tabs` now can be controlled

--- a/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
@@ -68,7 +68,7 @@ export function useBlur<
     }
     // we on want to close only if focus rests outside the select
     const popoverCurrent = listRef ? listRef.current : null
-    if (e.relatedTarget !== inputElement && popoverCurrent) {
+    if (popoverCurrent) {
       const focusInList =
         popoverCurrent && popoverCurrent.contains(e.relatedTarget as Node)
 
@@ -76,7 +76,7 @@ export function useBlur<
         if (focusInList && state !== ComboboxState.INTERACTING) {
           // focus landed inside the select, keep it open
           transition && transition(ComboboxActionType.INTERACT)
-        } else if (!focusInList) {
+        } else if (!focusInList && document.activeElement !== inputElement) {
           // focus landed outside the select, close it
           closeList()
         }

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -141,7 +141,9 @@ export const InputChipsInternal = forwardRef(
       if (!isControlled) {
         setUncontrolledValue(val)
       }
-      onInputChange && onInputChange(val)
+      if (val !== inputValue) {
+        onInputChange && onInputChange(val)
+      }
     }
 
     function updateValues(newInputValue?: string) {
@@ -150,12 +152,7 @@ export const InputChipsInternal = forwardRef(
         invalidValues,
         unusedValues,
         validValues,
-      } = getUpdatedValues(
-        // TypeScript can't tell that inputValue won't be undefined
-        newInputValue || inputValue,
-        values,
-        validate
-      )
+      } = getUpdatedValues(newInputValue || inputValue, values, validate)
 
       // Save valid values and keep invalid ones in the input
       const updatedInputValue = unusedValues.join(', ')
@@ -170,7 +167,6 @@ export const InputChipsInternal = forwardRef(
       if (duplicateValues.length > 0) {
         onDuplicate && onDuplicate(duplicateValues)
       }
-
       setInputValue(updatedInputValue)
     }
 

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -167,6 +167,7 @@ export const InputChipsInternal = forwardRef(
       if (duplicateValues.length > 0) {
         onDuplicate && onDuplicate(duplicateValues)
       }
+
       setInputValue(updatedInputValue)
     }
 


### PR DESCRIPTION
### :sparkles: Changes

- **Issue 1:** In this PR https://github.com/looker-open-source/components/pull/1241 I broke toggling when clicking on a `Select` caret icon after you've opened and closed it once:
  ![select-toggle](https://user-images.githubusercontent.com/53451193/88438639-0899d100-cdbe-11ea-8d97-6d9fc8095a5e.gif)
- **Issue 2:** On `SelectMulti` + `freeInput` clicking on the caret icon to close the list was always broken due to an unnecessary `onInputChange` call (which triggers the combobox's `SUGGESTING` state):
  ![freeinput](https://user-images.githubusercontent.com/53451193/88438552-d6886f00-cdbd-11ea-9123-fd27a6400075.gif)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
