### PR TITLE
update MenuItem detail to be part of the clickable area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- detail is part of `MenuItem`'s clickable area
 - update Error Icon for Fields validation message
 - `Avatar*` corrected styling conflicts when underlying component is switched to button (via `role="button"`)
 

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -133,13 +133,18 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
       onKeyUp={handleOnKeyUp}
       className={className}
     >
-      <Component href={href} role="menuitem" target={target}>
+      <Component
+        href={href}
+        role="menuitem"
+        style={{ display: 'flex' }}
+        target={target}
+      >
         <MenuItemLayoutGrid>
           {renderedIcon}
           {children}
         </MenuItemLayoutGrid>
+        {detail && <Detail>{detail}</Detail>}
       </Component>
-      {detail && <Detail>{detail}</Detail>}
     </MenuItemLayout>
   )
 }

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -172,6 +172,11 @@ exports[`MenuGroup - JSX label 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c6 "
@@ -188,6 +193,11 @@ exports[`MenuGroup - JSX label 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c6 "
@@ -204,6 +214,11 @@ exports[`MenuGroup - JSX label 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c6 "
@@ -384,6 +399,11 @@ exports[`MenuGroup - label 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c6 "
@@ -400,6 +420,11 @@ exports[`MenuGroup - label 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c6 "
@@ -416,6 +441,11 @@ exports[`MenuGroup - label 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c6 "
@@ -557,6 +587,11 @@ exports[`MenuGroup 1`] = `
     >
       <button
         role="menuitem"
+        style={
+          Object {
+            "display": "flex",
+          }
+        }
       >
         <div
           className="c3 "


### PR DESCRIPTION
### :sparkles: Changes

- detail is now part of MenuItem's clickable area 

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
