### PR TITLE
update MenuItem to not support click and its not a link if disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `MenuItem` disabled prop is not clickable and its not a link.
 - detail is part of `MenuItem`'s clickable area
 - update Error Icon for Fields validation message
 - `Avatar*` corrected styling conflicts when underlying component is switched to button (via `role="button"`)

--- a/packages/components/src/Menu/MenuItem.test.tsx
+++ b/packages/components/src/Menu/MenuItem.test.tsx
@@ -63,12 +63,15 @@ describe('MenuItem', () => {
   })
 
   test('MenuItem - disabled to be a button', () => {
+    const callbackFn = jest.fn()
+
     renderWithTheme(
       <MenuItem
         disabled={true}
-        itemRole="link"
-        target="_blank"
         href="https://google.com"
+        itemRole="link"
+        onClick={callbackFn}
+        target="_blank"
       >
         Item
       </MenuItem>

--- a/packages/components/src/Menu/MenuItem.test.tsx
+++ b/packages/components/src/Menu/MenuItem.test.tsx
@@ -73,8 +73,8 @@ describe('MenuItem', () => {
         Item
       </MenuItem>
     )
-    // screen.debug()
-    expect(screen.getByText('Item').closest('button')).toBeInTheDocument()
+    const item = screen.getByText('Item')
+    expect(item.closest('button')).toBeInTheDocument()
   })
 
   test('MenuItem - disabled is not clickable', () => {

--- a/packages/components/src/Menu/MenuItem.test.tsx
+++ b/packages/components/src/Menu/MenuItem.test.tsx
@@ -27,7 +27,7 @@
 import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
-import { screen } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 
 import { MenuItem } from './MenuItem'
 
@@ -60,5 +60,35 @@ describe('MenuItem', () => {
       </MenuItem>
     )
     expect(screen.getByTitle('SVG Title Here')).toBeInTheDocument()
+  })
+
+  test('MenuItem - disabled to be a button', () => {
+    renderWithTheme(
+      <MenuItem
+        disabled={true}
+        itemRole="link"
+        target="_blank"
+        href="https://google.com"
+      >
+        Item
+      </MenuItem>
+    )
+    // screen.debug()
+    expect(screen.getByText('Item').closest('button')).toBeInTheDocument()
+  })
+
+  test('MenuItem - disabled is not clickable', () => {
+    const callbackFn = jest.fn()
+
+    renderWithTheme(
+      <MenuItem disabled onClick={callbackFn}>
+        Item
+      </MenuItem>
+    )
+
+    const item = screen.getByText('Item')
+    fireEvent.click(item)
+
+    expect(callbackFn).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -28,6 +28,7 @@ import { CompatibleHTMLProps } from '@looker/design-tokens'
 import { IconNames } from '@looker/icons'
 import styled from 'styled-components'
 import React, { FC, ReactNode, useContext, useState, useEffect } from 'react'
+import { noop } from 'lodash'
 import { useID } from '../utils/useID'
 import { Icon } from '../Icon'
 import { MenuContext, MenuItemContext } from './MenuContext'
@@ -136,7 +137,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
       focusVisible={isFocusVisible}
       hasIcon={Boolean(renderedIcon)}
       onBlur={handleOnBlur}
-      onClick={handleOnClick}
+      onClick={disabled ? noop : handleOnClick}
       onKeyUp={handleOnKeyUp}
       className={className}
     >

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -121,6 +121,13 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
 
   const Component = !disabled && itemRole === 'link' ? 'a' : 'button'
 
+  if (disabled && itemRole === 'link') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'itemRole="link" and disabled cannot be combined - use itemRole="button" if you need to offer a disabled MenuItem'
+    )
+  }
+
   return (
     <MenuItemLayout
       aria-current={current && 'true'}

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -28,7 +28,6 @@ import { CompatibleHTMLProps } from '@looker/design-tokens'
 import { IconNames } from '@looker/icons'
 import styled from 'styled-components'
 import React, { FC, ReactNode, useContext, useState, useEffect } from 'react'
-import { noop } from 'lodash'
 import { useID } from '../utils/useID'
 import { Icon } from '../Icon'
 import { MenuContext, MenuItemContext } from './MenuContext'
@@ -137,7 +136,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
       focusVisible={isFocusVisible}
       hasIcon={Boolean(renderedIcon)}
       onBlur={handleOnBlur}
-      onClick={disabled ? noop : handleOnClick}
+      onClick={disabled ? undefined : handleOnClick}
       onKeyUp={handleOnKeyUp}
       className={className}
     >

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -119,7 +119,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
       )
     )
 
-  const Component = itemRole === 'link' ? 'a' : 'button'
+  const Component = !disabled && itemRole === 'link' ? 'a' : 'button'
 
   return (
     <MenuItemLayout

--- a/www/src/documentation/components/overlays/menu.mdx
+++ b/www/src/documentation/components/overlays/menu.mdx
@@ -149,7 +149,7 @@ For accessibility reasons, if you want your `MenuItem` to link somewhere then yo
 
 An icon can optionally be assigned to each item via the `icon` property.
 
-**Note:** The `Menu` will close by default when `MenuItem` is clicked, after the `onClick` handler, if there is one. Any component, such as a `Dialog`, that is meant to be conditionally shown on click, should not be nested inside `MenuList` since it will be removed.
+**Note:** `itemRole="link"` and `disabled` cannot be combined (use `itemRole="button" if you need to offer a disabled`MenuItem`)
 
 ```jsx
 <Menu>

--- a/www/src/documentation/components/overlays/menu.mdx
+++ b/www/src/documentation/components/overlays/menu.mdx
@@ -145,6 +145,7 @@ A `MenuList` accepts a `compact` prop that will make the spacing between the `Me
 `MenuItem` is an `HTMLButtonElement` that supports all of the `BoxProps` properties. Use this for triggering actions from with in a `MenuList`. For example, opening a dialog.
 
 For accessibility reasons, if you want your `MenuItem` to link somewhere then you can use the `itemRole` prop to identify it as a link.
+**Note:** If using the props `itemRole` don't use the prop `disabled` As it is bad-form and defeat the purpose.
 
 An icon can optionally be assigned to each item via the `icon` property.
 


### PR DESCRIPTION
### :sparkles: Changes

- update MenuItem to not support click and its not a link if disabled

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

![d6c66827-f261-468c-b86b-372fe9408728](https://user-images.githubusercontent.com/23616264/88985346-dd632600-d284-11ea-97d7-a1816b29bbaa.gif)
