### PR TITLE
Remove arrow from tooltip, menu, and popover by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ActionListManager` - renamed `noResultsText` to `noResultsDisplay` and now supports a `ReactNode` (supply a JSX for custom formatting)
 - Refactor out react-hotkeys and improve keyboard ux for multiple stacked focus traps (effects `MenuList`, `Surface`, and `OverlaySurface`)
+- Remove arrow from `Tooltip`, `Popover` and `Menu` by default
 
 ## [0.9.7] - 2020-07-27
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -383,7 +383,7 @@ function usePopoverToggle(
 }
 
 export function usePopover({
-  arrow = true,
+  arrow = false,
   canClose,
   content,
   groupedPopoversRef,

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -49,12 +49,6 @@ import { TooltipContent } from './TooltipContent'
 
 export interface UseTooltipProps {
   /**
-   * Display and arrow that points to the trigger element on popovers
-   * @default true
-   */
-  arrow?: boolean
-
-  /**
    * Specify a callback to be called before trying to close the Tooltip. This allows for
    * use-cases where the user might lose work (think common "Save before closing warning" type flow)
    * Specify a callback to be called each time this Tooltip is closed
@@ -125,7 +119,6 @@ export interface TooltipProps extends UseTooltipProps {
 }
 
 export function useTooltip({
-  arrow = true,
   canClose,
   content,
   isOpen: initializeOpen = false,
@@ -174,7 +167,6 @@ export function useTooltip({
   const usePopperProps: UsePopperProps = useMemo(
     () => ({
       anchor: element,
-      arrow,
       options: {
         modifiers: [
           {
@@ -188,7 +180,7 @@ export function useTooltip({
         placement: propsPlacement,
       },
     }),
-    [arrow, element, propsPlacement]
+    [element, propsPlacement]
   )
   const {
     arrowProps,
@@ -206,7 +198,7 @@ export function useTooltip({
     isOpen && content && !disabled ? (
       <Portal>
         <OverlaySurface
-          arrow={arrow}
+          arrow={false}
           arrowProps={arrowProps}
           eventHandlers={{ onMouseOut: handleMouseOut }}
           placement={placement}

--- a/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,64 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
-.c2 {
-  position: absolute;
-}
-
-.c2::before {
-  background-color: #262D33;
-  color: #FFFFFF;
-  border-radius: 0.25rem;
-  border-left: none;
-  border-radius: 0;
-  border-top: none;
-  content: '';
-  display: block;
-  height: 0.5rem;
-  margin: auto;
-  width: 0.5rem;
-}
-
-.c2[data-placement*='top'] {
-  bottom: 0.25rem;
-}
-
-.c2[data-placement*='top']::before {
-  -webkit-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  transform: rotate(45deg);
-}
-
-.c2[data-placement*='right'] {
-  left: 0.25rem;
-}
-
-.c2[data-placement*='right']::before {
-  -webkit-transform: rotate(135deg);
-  -ms-transform: rotate(135deg);
-  transform: rotate(135deg);
-}
-
-.c2[data-placement*='bottom'] {
-  top: 0.25rem;
-}
-
-.c2[data-placement*='bottom']::before {
-  -webkit-transform: rotate(225deg);
-  -ms-transform: rotate(225deg);
-  transform: rotate(225deg);
-}
-
-.c2[data-placement*='left'] {
-  right: 0.25rem;
-}
-
-.c2[data-placement*='left']::before {
-  -webkit-transform: rotate(315deg);
-  -ms-transform: rotate(315deg);
-  transform: rotate(315deg);
-}
-
 .c0 {
   border-radius: 0.25rem;
   box-shadow: 0 3px 18px rgba(0,0,0,0.12),0 1px 4px rgba(0,0,0,0.04);
@@ -88,18 +30,18 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
   word-break: break-word;
 }
 
-.c1 .c3 {
+.c1 .c2 {
   color: #E8E5FF;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1 .c3:focus,
-.c1 .c3:hover {
+.c1 .c2:focus,
+.c1 .c2:hover {
   color: #F3F2FF;
 }
 
-.c1 .c3:active {
+.c1 .c2:active {
   color: #FFFFFF;
 }
 
@@ -116,11 +58,5 @@ exports[`Tooltip trigger: open on mouseover, close on mouseout 1`] = `
   >
     Hello world
   </p>
-  <div
-    class="c2"
-    color="inverseOn"
-    data-placement="bottom"
-    style="position: absolute;"
-  />
 </div>
 `;

--- a/www/src/documentation/components/overlays/popover.mdx
+++ b/www/src/documentation/components/overlays/popover.mdx
@@ -39,7 +39,7 @@ Popovers are assembled of two pieces: an overlay and a surface. Unlike [Dialogs]
 
 Placement can be adjusted with the `placement` prop. Valid positions are `top`, `left`, `right` and `bottom`, each can be augmented with -`start` or `-end` which places the edge of the popover at the start or end of the target.
 
-If you want to hide the popover arrow you can set the prop `arrow` prop to false.
+If you want to show the popover arrow you can set the prop `arrow` prop to true.
 
 ```jsx
 ;() => {
@@ -71,7 +71,7 @@ If you want to hide the popover arrow you can set the prop `arrow` prop to false
         <Popover content={popoverContent} placement="right-end">
           <Button>Right End</Button>
         </Popover>
-        <Popover content={popoverContent} placement="top-start" arrow={false}>
+        <Popover content={popoverContent} placement="top-start" arrow={true}>
           <Button>Top Start</Button>
         </Popover>
       </Space>


### PR DESCRIPTION
### :sparkles: Changes

This PR removes the arrow from tooltip, menu and popover by default. 

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
