### PR TITLE
Tabs no longer show scrollbar when overflowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detail is part of `MenuItem`'s clickable area
 - update Error Icon for Fields validation message
 - `Avatar*` corrected styling conflicts when underlying component is switched to button (via `role="button"`)
-
+- `Tabs` no longer show scrollbar when overflowing
 
 ### Changed
 
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor out react-hotkeys and improve keyboard ux for multiple stacked focus traps (effects `MenuList`, `Surface`, and `OverlaySurface`)
 - Updates to how we apply colors to `ButtonOutline` and `ButtonTransparent` to be more inline with design spec
 - `neutral` intent color is now defaults to `charcoal500`
-
 
 ### Added
 

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -83,8 +83,14 @@ const distributeCSS = css`
 
 export const TabList = styled(TabListLayout)`
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
   overflow-x: auto;
+  scrollbar-width: none; /* Firefox */
   white-space: nowrap;
+
+  &::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 
   ${({ distribute }) => (distribute ? distributeCSS : defaultLayoutCSS)}
 `


### PR DESCRIPTION
### :sparkles: Changes

- Tabs no longer show scrollbar when overflowing

#### Before

![image](https://user-images.githubusercontent.com/34253496/89342367-88922780-d657-11ea-9ed2-4d965317efa8.png)

NOTE: To emulate this behavior for easy testing switch "System Preferences > General" "Show Scroll bars" to "Always"

![image](https://user-images.githubusercontent.com/34253496/89342108-29ccae00-d657-11ea-9b11-b0a867eeb923.png)

#### After
![image](https://user-images.githubusercontent.com/34253496/89342035-0f92d000-d657-11ea-9658-b6629384dace.png)




### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
