### PR TITLE
Set Tree disclosure's default color to text4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Tree` default color is text4 (was previously a different color due to browser button defaults)
 - `MenuItem` disabled prop is not clickable and its not a link.
 - detail is part of `MenuItem`'s clickable area
 - update Error Icon for Fields validation message

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -125,6 +125,7 @@ export const AccordionDisclosureStyle = styled.button<
   border: 1px solid transparent;
   border-color: ${({ focusVisible, theme }) =>
     focusVisible && theme.colors.keyFocus};
+  color: currentColor;
   cursor: pointer;
   display: flex;
   outline: none;

--- a/storybook/src/Tree/FieldPicker.stories.tsx
+++ b/storybook/src/Tree/FieldPicker.stories.tsx
@@ -165,5 +165,5 @@ export const FieldPicker = () => (
 
 export default {
   component: FieldPicker,
-  title: 'Tree/FieldPicker',
+  title: 'Tree',
 }


### PR DESCRIPTION
### :sparkles: Changes

- Changed default color of `Tree` disclosure from black (dependent on browser default for button) to text4
  - Design specs from Explore requested that the default `Tree` color be text4

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![Screen Shot 2020-08-04 at 3 45 25 PM](https://user-images.githubusercontent.com/16812885/89353098-8f766580-d66a-11ea-8e93-f40ef600e47a.png)

