### PR TITLE
Fix focus-trap selecting text in non-filterable Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select` getting text highlighted in a focus trap when not filterable
 - `Tree` default color is text4 (was previously a different color due to browser button defaults)
 - `MenuItem` disabled prop is not clickable and its not a link.
 - detail is part of `MenuItem`'s clickable area

--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
@@ -95,8 +95,11 @@ export function useInputEvents<
   const handleBlur = useBlur(context)
 
   function handleFocus(e: FocusEvent<HTMLInputElement>) {
-    if (readOnly) {
-      e.currentTarget.selectionEnd = e.currentTarget.selectionStart
+    const input = e.currentTarget
+    if (readOnly && input) {
+      window.requestAnimationFrame(() => {
+        input.selectionEnd = input.selectionStart = 0
+      })
     } else if (selectOnClick) {
       selectOnClickRef.current = true
     }


### PR DESCRIPTION
### :sparkles: Changes

- Workaround for this issue in `focus-trap` https://github.com/davidtheclark/focus-trap/issues/114 – when `Select` (without `isFilterable`) is the first focus-able element in a focus-trapped component (`Dialog` or `Popover`), the text is getting inappropriately highlighted.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![7396f80b-5162-4848-b4d0-c8b01444fa60](https://user-images.githubusercontent.com/53451193/89606791-c8a70500-d825-11ea-88c8-bd3c28de4f19.gif)