### PR TITLE
Fix InputChips/InputText layout issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InputChips` and `SelectMulti` overflow when a fixed height is used
+- `InputChips` and `SelectMulti` long values breaking out of the input
 - `Select`/`SelectMulti` list closing when trying to scroll by dragging the scrollbar
 - `SelectMulti` list height now adjusts as needed when chips are added
 - `Select` getting text highlighted in a focus trap when not filterable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `InputChips` and `SelectMulti` overflow when a fixed height is used
 - `InputChips` and `SelectMulti` long values breaking out of the input
+- `InputSearch`, `Select`, `InputChips` and `SelectMulti` x button not clickable with `autoResize` and a max-width reached
 - `Select`/`SelectMulti` list closing when trying to scroll by dragging the scrollbar
 - `SelectMulti` list height now adjusts as needed when chips are added
 - `Select` getting text highlighted in a focus trap when not filterable

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -25,6 +25,7 @@
  */
 
 import React, { FunctionComponent, ReactNode, useContext } from 'react'
+import { width } from '@looker/design-tokens'
 import styled, { css } from 'styled-components'
 import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
 import omit from 'lodash/omit'
@@ -160,7 +161,10 @@ FieldDetail.defaultProps = {
   fontSize: 'xsmall',
 }
 
-const InputArea = styled.div``
+const InputArea = styled.div`
+  /* Workaround for Chip's truncate styling breaking flexbox layout in FieldChips */
+  min-width: 0;
+`
 const MessageArea = styled.div``
 
 const fieldLabelCSS = (inline?: boolean) =>
@@ -188,8 +192,8 @@ export const Field = styled(FieldLayout)<FieldPropsInternal>`
   grid-template-columns: ${({ inline }) => (inline ? '150px 1fr' : undefined)};
   height: fit-content;
   justify-content: space-between;
-  width: ${({ autoResize, width }) =>
-    width || autoResize ? 'fit-content' : '100%'};
+  width: ${({ autoResize }) => (autoResize ? 'fit-content' : '100%')};
+  ${width}
 
   ${InputArea} {
     align-items: center;

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`A FieldText with default label 1`] = `
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -26,17 +26,17 @@ exports[`A FieldText with default label 1`] = `
   font-size: 0.875rem;
 }
 
-.c4 .c6 {
+.c5 .c7 {
   height: 100%;
   max-width: 100%;
   width: 100%;
 }
 
-.c4 .c6 span {
+.c5 .c7 span {
   padding: 0 0.5rem;
 }
 
-.c4 input {
+.c5 input {
   background: transparent;
   border: none;
   caret-color: #262D33;
@@ -52,37 +52,37 @@ exports[`A FieldText with default label 1`] = `
   padding: 0 0.5rem;
 }
 
-.c4 input::-webkit-search-decoration,
-.c4 input::-webkit-search-cancel-button,
-.c4 input::-webkit-search-results-button,
-.c4 input::-webkit-search-results-decoration {
+.c5 input::-webkit-search-decoration,
+.c5 input::-webkit-search-cancel-button,
+.c5 input::-webkit-search-results-button,
+.c5 input::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c4 input::-webkit-input-placeholder {
+.c5 input::-webkit-input-placeholder {
   color: #939BA5;
 }
 
-.c4 input::-moz-placeholder {
+.c5 input::-moz-placeholder {
   color: #939BA5;
 }
 
-.c4 input:-ms-input-placeholder {
+.c5 input:-ms-input-placeholder {
   color: #939BA5;
 }
 
-.c4 input::placeholder {
+.c5 input::placeholder {
   color: #939BA5;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #C1C6CC;
 }
 
-.c4:focus,
-.c4:focus-within {
+.c5:focus,
+.c5:focus-within {
   border-color: #9785F2;
   box-shadow: 0 0 0 2px #E8E5FF;
   outline: none;
@@ -92,6 +92,10 @@ exports[`A FieldText with default label 1`] = `
   color: #343C42;
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.c4 {
+  min-width: 0;
 }
 
 .c0 {
@@ -119,7 +123,7 @@ exports[`A FieldText with default label 1`] = `
   grid-area: input;
 }
 
-.c0 .c5 {
+.c0 .c6 {
   grid-area: messages;
 }
 
@@ -129,13 +133,13 @@ exports[`A FieldText with default label 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c0 .c8 {
+.c0 .c9 {
   grid-area: detail;
   justify-self: end;
   padding-left: 0.75rem;
 }
 
-.c0 .c7 {
+.c0 .c8 {
   margin-top: 0.5rem;
 }
 
@@ -150,10 +154,10 @@ exports[`A FieldText with default label 1`] = `
     👍
   </label>
   <div
-    className="c3 "
+    className="c3 c4"
   >
     <div
-      className="c4 "
+      className="c5 "
       onMouseDown={[Function]}
     >
       <input
@@ -164,14 +168,14 @@ exports[`A FieldText with default label 1`] = `
     </div>
   </div>
   <div
-    className="c5 "
+    className="c6 "
     id="FieldTextID-describedby"
   />
 </div>
 `;
 
 exports[`A FieldText with label inline 1`] = `
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -196,17 +200,17 @@ exports[`A FieldText with label inline 1`] = `
   font-size: 0.875rem;
 }
 
-.c4 .c7 {
+.c5 .c8 {
   height: 100%;
   max-width: 100%;
   width: 100%;
 }
 
-.c4 .c7 span {
+.c5 .c8 span {
   padding: 0 0.5rem;
 }
 
-.c4 input {
+.c5 input {
   background: transparent;
   border: none;
   caret-color: #262D33;
@@ -222,37 +226,37 @@ exports[`A FieldText with label inline 1`] = `
   padding: 0 0.5rem;
 }
 
-.c4 input::-webkit-search-decoration,
-.c4 input::-webkit-search-cancel-button,
-.c4 input::-webkit-search-results-button,
-.c4 input::-webkit-search-results-decoration {
+.c5 input::-webkit-search-decoration,
+.c5 input::-webkit-search-cancel-button,
+.c5 input::-webkit-search-results-button,
+.c5 input::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c4 input::-webkit-input-placeholder {
+.c5 input::-webkit-input-placeholder {
   color: #939BA5;
 }
 
-.c4 input::-moz-placeholder {
+.c5 input::-moz-placeholder {
   color: #939BA5;
 }
 
-.c4 input:-ms-input-placeholder {
+.c5 input:-ms-input-placeholder {
   color: #939BA5;
 }
 
-.c4 input::placeholder {
+.c5 input::placeholder {
   color: #939BA5;
 }
 
-.c4:hover {
+.c5:hover {
   border-color: #C1C6CC;
 }
 
-.c4:focus,
-.c4:focus-within {
+.c5:focus,
+.c5:focus-within {
   border-color: #9785F2;
   box-shadow: 0 0 0 2px #E8E5FF;
   outline: none;
@@ -264,7 +268,11 @@ exports[`A FieldText with label inline 1`] = `
   font-weight: 600;
 }
 
-.c6 .c3 {
+.c4 {
+  min-width: 0;
+}
+
+.c7 .c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -272,11 +280,11 @@ exports[`A FieldText with label inline 1`] = `
   grid-area: input;
 }
 
-.c6 .c5 {
+.c7 .c6 {
   grid-area: messages;
 }
 
-.c6 > .c1 {
+.c7 > .c1 {
   grid-area: label;
   line-height: 1rem;
   padding-bottom: 0.5rem;
@@ -308,7 +316,7 @@ exports[`A FieldText with label inline 1`] = `
   grid-area: input;
 }
 
-.c0 .c5 {
+.c0 .c6 {
   grid-area: messages;
 }
 
@@ -321,7 +329,7 @@ exports[`A FieldText with label inline 1`] = `
   text-align: right;
 }
 
-.c0 .c9 {
+.c0 .c10 {
   grid-area: detail;
   justify-self: end;
   padding-left: 0.75rem;
@@ -330,7 +338,7 @@ exports[`A FieldText with label inline 1`] = `
   align-self: center;
 }
 
-.c0 .c8 {
+.c0 .c9 {
   margin-top: 0.5rem;
 }
 
@@ -345,10 +353,10 @@ exports[`A FieldText with label inline 1`] = `
     👍
   </label>
   <div
-    className="c3 "
+    className="c3 c4"
   >
     <div
-      className="c4 "
+      className="c5 "
       onMouseDown={[Function]}
     >
       <input
@@ -359,7 +367,7 @@ exports[`A FieldText with label inline 1`] = `
     </div>
   </div>
   <div
-    className="c5 "
+    className="c6 "
     id="FieldTextID-describedby"
   />
 </div>

--- a/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`A FieldTextArea with default label 1`] = `
-.c4 {
+.c5 {
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
@@ -9,13 +9,13 @@ exports[`A FieldTextArea with default label 1`] = `
   width: 100%;
 }
 
-.c4 .c6 {
+.c5 .c7 {
   position: absolute;
   right: 0.5rem;
   top: 0.5rem;
 }
 
-.c4 textarea {
+.c5 textarea {
   min-height: 6.25rem;
   background: #FFFFFF;
   border: 1px solid #DEE1E5;
@@ -28,12 +28,12 @@ exports[`A FieldTextArea with default label 1`] = `
   width: 100%;
 }
 
-.c4 textarea:hover {
+.c5 textarea:hover {
   border-color: #C1C6CC;
 }
 
-.c4 textarea:focus,
-.c4 textarea:focus-within {
+.c5 textarea:focus,
+.c5 textarea:focus-within {
   border-color: #9785F2;
   box-shadow: 0 0 0 2px #E8E5FF;
   outline: none;
@@ -43,6 +43,10 @@ exports[`A FieldTextArea with default label 1`] = `
   color: #343C42;
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.c4 {
+  min-width: 0;
 }
 
 .c0 {
@@ -70,7 +74,7 @@ exports[`A FieldTextArea with default label 1`] = `
   grid-area: input;
 }
 
-.c0 .c5 {
+.c0 .c6 {
   grid-area: messages;
 }
 
@@ -80,13 +84,13 @@ exports[`A FieldTextArea with default label 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c0 .c8 {
+.c0 .c9 {
   grid-area: detail;
   justify-self: end;
   padding-left: 0.75rem;
 }
 
-.c0 .c7 {
+.c0 .c8 {
   margin-top: 0.5rem;
 }
 
@@ -101,10 +105,10 @@ exports[`A FieldTextArea with default label 1`] = `
     👍
   </label>
   <div
-    className="c3 "
+    className="c3 c4"
   >
     <div
-      className="c4 "
+      className="c5 "
     >
       <textarea
         aria-describedby="FieldTextAreaID-describedby"
@@ -113,14 +117,14 @@ exports[`A FieldTextArea with default label 1`] = `
     </div>
   </div>
   <div
-    className="c5 "
+    className="c6 "
     id="FieldTextAreaID-describedby"
   />
 </div>
 `;
 
 exports[`A FieldTextArea with label inline 1`] = `
-.c4 {
+.c5 {
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
@@ -128,13 +132,13 @@ exports[`A FieldTextArea with label inline 1`] = `
   width: 100%;
 }
 
-.c4 .c7 {
+.c5 .c8 {
   position: absolute;
   right: 0.5rem;
   top: 0.5rem;
 }
 
-.c4 textarea {
+.c5 textarea {
   min-height: 6.25rem;
   background: #FFFFFF;
   border: 1px solid #DEE1E5;
@@ -147,12 +151,12 @@ exports[`A FieldTextArea with label inline 1`] = `
   width: 100%;
 }
 
-.c4 textarea:hover {
+.c5 textarea:hover {
   border-color: #C1C6CC;
 }
 
-.c4 textarea:focus,
-.c4 textarea:focus-within {
+.c5 textarea:focus,
+.c5 textarea:focus-within {
   border-color: #9785F2;
   box-shadow: 0 0 0 2px #E8E5FF;
   outline: none;
@@ -164,7 +168,11 @@ exports[`A FieldTextArea with label inline 1`] = `
   font-weight: 600;
 }
 
-.c6 .c3 {
+.c4 {
+  min-width: 0;
+}
+
+.c7 .c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -172,11 +180,11 @@ exports[`A FieldTextArea with label inline 1`] = `
   grid-area: input;
 }
 
-.c6 .c5 {
+.c7 .c6 {
   grid-area: messages;
 }
 
-.c6 > .c1 {
+.c7 > .c1 {
   grid-area: label;
   line-height: 1rem;
   padding-bottom: 0.5rem;
@@ -208,7 +216,7 @@ exports[`A FieldTextArea with label inline 1`] = `
   grid-area: input;
 }
 
-.c0 .c5 {
+.c0 .c6 {
   grid-area: messages;
 }
 
@@ -221,7 +229,7 @@ exports[`A FieldTextArea with label inline 1`] = `
   text-align: right;
 }
 
-.c0 .c9 {
+.c0 .c10 {
   grid-area: detail;
   justify-self: end;
   padding-left: 0.75rem;
@@ -230,7 +238,7 @@ exports[`A FieldTextArea with label inline 1`] = `
   align-self: center;
 }
 
-.c0 .c8 {
+.c0 .c9 {
   margin-top: 0.5rem;
 }
 
@@ -245,10 +253,10 @@ exports[`A FieldTextArea with label inline 1`] = `
     👍
   </label>
   <div
-    className="c3 "
+    className="c3 c4"
   >
     <div
-      className="c4 "
+      className="c5 "
     >
       <textarea
         aria-describedby="FieldTextAreaID-describedby"
@@ -257,7 +265,7 @@ exports[`A FieldTextArea with label inline 1`] = `
     </div>
   </div>
   <div
-    className="c5 "
+    className="c6 "
     id="FieldTextAreaID-describedby"
   />
 </div>

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Fieldset 1`] = `
   flex-direction: column;
 }
 
-.c8 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -56,17 +56,17 @@ exports[`Fieldset 1`] = `
   font-size: 0.875rem;
 }
 
-.c8 .c10 {
+.c9 .c11 {
   height: 100%;
   max-width: 100%;
   width: 100%;
 }
 
-.c8 .c10 span {
+.c9 .c11 span {
   padding: 0 0.5rem;
 }
 
-.c8 input {
+.c9 input {
   background: transparent;
   border: none;
   caret-color: #262D33;
@@ -82,37 +82,37 @@ exports[`Fieldset 1`] = `
   padding: 0 0.5rem;
 }
 
-.c8 input::-webkit-search-decoration,
-.c8 input::-webkit-search-cancel-button,
-.c8 input::-webkit-search-results-button,
-.c8 input::-webkit-search-results-decoration {
+.c9 input::-webkit-search-decoration,
+.c9 input::-webkit-search-cancel-button,
+.c9 input::-webkit-search-results-button,
+.c9 input::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c8 input::-webkit-input-placeholder {
+.c9 input::-webkit-input-placeholder {
   color: #939BA5;
 }
 
-.c8 input::-moz-placeholder {
+.c9 input::-moz-placeholder {
   color: #939BA5;
 }
 
-.c8 input:-ms-input-placeholder {
+.c9 input:-ms-input-placeholder {
   color: #939BA5;
 }
 
-.c8 input::placeholder {
+.c9 input::placeholder {
   color: #939BA5;
 }
 
-.c8:hover {
+.c9:hover {
   border-color: #C1C6CC;
 }
 
-.c8:focus,
-.c8:focus-within {
+.c9:focus,
+.c9:focus-within {
   border-color: #9785F2;
   box-shadow: 0 0 0 2px #E8E5FF;
   outline: none;
@@ -129,12 +129,12 @@ exports[`Fieldset 1`] = `
   width: 100%;
 }
 
-.c0 .c11 {
+.c0 .c12 {
   padding-left: calc(1px + 1rem + 0.5rem);
   padding-top: 1rem;
 }
 
-.c0 .c12 {
+.c0 .c13 {
   font-size: 0.875rem;
   font-weight: 600;
   height: 24px;
@@ -145,6 +145,10 @@ exports[`Fieldset 1`] = `
   color: #343C42;
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.c8 {
+  min-width: 0;
 }
 
 .c4 {
@@ -172,7 +176,7 @@ exports[`Fieldset 1`] = `
   grid-area: input;
 }
 
-.c4 .c9 {
+.c4 .c10 {
   grid-area: messages;
 }
 
@@ -182,13 +186,13 @@ exports[`Fieldset 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c4 .c14 {
+.c4 .c15 {
   grid-area: detail;
   justify-self: end;
   padding-left: 0.75rem;
 }
 
-.c4 .c13 {
+.c4 .c14 {
   margin-top: 0.5rem;
 }
 
@@ -255,10 +259,10 @@ exports[`Fieldset 1`] = `
           one
         </label>
         <div
-          className="c7 "
+          className="c7 c8"
         >
           <div
-            className="c8 "
+            className="c9 "
             onMouseDown={[Function]}
           >
             <input
@@ -270,7 +274,7 @@ exports[`Fieldset 1`] = `
           </div>
         </div>
         <div
-          className="c9 "
+          className="c10 "
           id="text-1-describedby"
         />
       </div>
@@ -285,10 +289,10 @@ exports[`Fieldset 1`] = `
           two
         </label>
         <div
-          className="c7 "
+          className="c7 c8"
         >
           <div
-            className="c8 "
+            className="c9 "
             onMouseDown={[Function]}
           >
             <input
@@ -300,7 +304,7 @@ exports[`Fieldset 1`] = `
           </div>
         </div>
         <div
-          className="c9 "
+          className="c10 "
           id="text-2-describedby"
         />
       </div>
@@ -315,10 +319,10 @@ exports[`Fieldset 1`] = `
           three
         </label>
         <div
-          className="c7 "
+          className="c7 c8"
         >
           <div
-            className="c8 "
+            className="c9 "
             onMouseDown={[Function]}
           >
             <input
@@ -330,7 +334,7 @@ exports[`Fieldset 1`] = `
           </div>
         </div>
         <div
-          className="c9 "
+          className="c10 "
           id="text-3-describedby"
         />
       </div>

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -106,6 +106,10 @@ const StyledInput = styled.input`
 const StyledText = styled.span`
   color: transparent;
   line-height: inherit;
+  /* max-width & overflow keep this span from blocking the x button
+  in InputSearch, etc, with autoResize and maxWidth */
+  max-width: 100%;
+  overflow: hidden;
   text-align: inherit;
   white-space: pre;
 `

--- a/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InlineInputText/__snapshots__/InlineInputText.test.tsx.snap
@@ -59,6 +59,8 @@ exports[`InlineInputText renders an input with a placeholder 1`] = `
 .c2 {
   color: transparent;
   line-height: inherit;
+  max-width: 100%;
+  overflow: hidden;
   text-align: inherit;
   white-space: pre;
 }
@@ -172,6 +174,8 @@ exports[`InlineInputText renders an input with no value 1`] = `
 .c2 {
   color: transparent;
   line-height: inherit;
+  max-width: 100%;
+  overflow: hidden;
   text-align: inherit;
   white-space: pre;
 }
@@ -284,6 +288,8 @@ exports[`InlineInputText renders an input with specific predefined value 1`] = `
 .c2 {
   color: transparent;
   line-height: inherit;
+  max-width: 100%;
+  overflow: hidden;
   text-align: inherit;
   white-space: pre;
 }

--- a/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
@@ -179,6 +179,9 @@ export const InputChipsBase = styled(InputChipsBaseInternal)`
     align-content: flex-start;
     display: flex;
     flex-wrap: wrap;
+    /* Workaround for Chip's truncate styling breaking flexbox layout */
+    min-width: 0;
+    overflow-y: auto;
     width: 100%;
   }
 

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Form with one child 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -41,17 +41,17 @@ exports[`Form with one child 1`] = `
   font-size: 0.875rem;
 }
 
-.c5 .c7 {
+.c6 .c8 {
   height: 100%;
   max-width: 100%;
   width: 100%;
 }
 
-.c5 .c7 span {
+.c6 .c8 span {
   padding: 0 0.5rem;
 }
 
-.c5 input {
+.c6 input {
   background: transparent;
   border: none;
   caret-color: #262D33;
@@ -67,37 +67,37 @@ exports[`Form with one child 1`] = `
   padding: 0 0.5rem;
 }
 
-.c5 input::-webkit-search-decoration,
-.c5 input::-webkit-search-cancel-button,
-.c5 input::-webkit-search-results-button,
-.c5 input::-webkit-search-results-decoration {
+.c6 input::-webkit-search-decoration,
+.c6 input::-webkit-search-cancel-button,
+.c6 input::-webkit-search-results-button,
+.c6 input::-webkit-search-results-decoration {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 }
 
-.c5 input::-webkit-input-placeholder {
+.c6 input::-webkit-input-placeholder {
   color: #939BA5;
 }
 
-.c5 input::-moz-placeholder {
+.c6 input::-moz-placeholder {
   color: #939BA5;
 }
 
-.c5 input:-ms-input-placeholder {
+.c6 input:-ms-input-placeholder {
   color: #939BA5;
 }
 
-.c5 input::placeholder {
+.c6 input::placeholder {
   color: #939BA5;
 }
 
-.c5:hover {
+.c6:hover {
   border-color: #C1C6CC;
 }
 
-.c5:focus,
-.c5:focus-within {
+.c6:focus,
+.c6:focus-within {
   border-color: #9785F2;
   box-shadow: 0 0 0 2px #E8E5FF;
   outline: none;
@@ -107,6 +107,10 @@ exports[`Form with one child 1`] = `
   color: #343C42;
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.c5 {
+  min-width: 0;
 }
 
 .c1 {
@@ -134,7 +138,7 @@ exports[`Form with one child 1`] = `
   grid-area: input;
 }
 
-.c1 .c6 {
+.c1 .c7 {
   grid-area: messages;
 }
 
@@ -144,13 +148,13 @@ exports[`Form with one child 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c1 .c9 {
+.c1 .c10 {
   grid-area: detail;
   justify-self: end;
   padding-left: 0.75rem;
 }
 
-.c1 .c8 {
+.c1 .c9 {
   margin-top: 0.5rem;
 }
 
@@ -185,10 +189,10 @@ exports[`Form with one child 1`] = `
       label
     </label>
     <div
-      className="c4 "
+      className="c4 c5"
     >
       <div
-        className="c5 "
+        className="c6 "
         onMouseDown={[Function]}
       >
         <input
@@ -200,7 +204,7 @@ exports[`Form with one child 1`] = `
       </div>
     </div>
     <div
-      className="c6 "
+      className="c7 "
       id="text-field-describedby"
     />
   </div>

--- a/storybook/src/Forms/Chips.stories.tsx
+++ b/storybook/src/Forms/Chips.stories.tsx
@@ -25,15 +25,29 @@
  */
 
 import React, { useState } from 'react'
-import { FieldChips, Grid, InputChips, Paragraph } from '@looker/components'
+import {
+  FieldChips,
+  Grid,
+  InputChips,
+  Paragraph,
+  Space,
+  SpaceVertical,
+} from '@looker/components'
 
 export const All = () => (
-  <Grid>
+  <SpaceVertical align="start">
     <FieldChipOptions />
-    <Basic />
-    <Controlled />
-    <ValidationDuplicate />
-  </Grid>
+    <Space align="start">
+      <Basic />
+      <Controlled />
+      <ValidationDuplicate />
+    </Space>
+    <Space align="start">
+      <Truncate />
+      <Overflow />
+      <AutoResize />
+    </Space>
+  </SpaceVertical>
 )
 
 export default {
@@ -118,7 +132,7 @@ export const ValidationDuplicate = () => {
     setDuplicate(`Duplicate email: ${values.join(', ')}`)
 
   return (
-    <>
+    <SpaceVertical>
       <InputChips
         values={values}
         onChange={handleChange}
@@ -130,6 +144,57 @@ export const ValidationDuplicate = () => {
       <Paragraph>
         {invalid} {duplicate}
       </Paragraph>
-    </>
+    </SpaceVertical>
+  )
+}
+
+export function Truncate() {
+  const [values, setValues] = useState<string[]>([
+    'A very long token that will truncate',
+  ])
+
+  return (
+    <FieldChips
+      label="Truncate"
+      width={250}
+      values={values}
+      onChange={setValues}
+    />
+  )
+}
+export function Overflow() {
+  const [values, setValues] = useState<string[]>([
+    'California',
+    'Wyoming',
+    'Nevada',
+    'Wisconsin',
+    'Mississippi',
+    'Missouri',
+    'New York',
+    'New Jersey',
+  ])
+
+  return (
+    <FieldChips
+      label="Overflow"
+      width={200}
+      maxHeight={145}
+      values={values}
+      onChange={setValues}
+    />
+  )
+}
+
+export function AutoResize() {
+  const [values, setValues] = useState<string[]>([])
+
+  return (
+    <InputChips
+      autoResize
+      maxWidth="50vw"
+      placeholder="Auto Resize"
+      values={values}
+      onChange={setValues}
+    />
   )
 }

--- a/storybook/src/Forms/Search.stories.tsx
+++ b/storybook/src/Forms/Search.stories.tsx
@@ -24,17 +24,18 @@
 
  */
 import React from 'react'
-import { Form, InputSearch } from '@looker/components'
+import { InputSearch, SpaceVertical } from '@looker/components'
 
 export const All = () => (
-  <Form>
+  <SpaceVertical align="start">
     <Basic />
     <Placeholder />
     <Value />
     <Summary />
     <DefaultValue />
     <NoIcon />
-  </Form>
+    <AutoResize />
+  </SpaceVertical>
 )
 
 export default {
@@ -59,4 +60,7 @@ export const DefaultValue = () => (
 )
 export const NoIcon = () => (
   <InputSearch hideSearchIcon placeholder="Type your search" />
+)
+export const AutoResize = () => (
+  <InputSearch autoResize placeholder="Resizes to fit value" maxWidth={250} />
 )


### PR DESCRIPTION
### :sparkles: Changes

- `SelectMulti` & `InputChips`:
  - Enable vertical scrolling if a max-height is set.
  - The `white-space: nowrap` on `Chip` causes it to break out of the flex layout – fixed with `min-width: 0` (see screenshot 1) https://stackoverflow.com/questions/38223879/white-space-nowrap-breaks-flexbox-layout
- `InputSearch`, `Select`, `InputChips` & `SelectMulti`
  - with `autoResize` and a max-width that has been reached, the x `IconButton` becomes unclickable (blocked by the hidden text) – see screenshot 2

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Screenshot 1
![image-2020-07-31-15-12-03-402](https://user-images.githubusercontent.com/53451193/89607458-7b2b9780-d827-11ea-9ef7-d9bf1660052c.png)
#### Screenshot 2
![2020-08-06_13-43-37 (1) (1)](https://user-images.githubusercontent.com/53451193/89608328-b7f88e00-d829-11ea-8cb6-ea2888dbd968.gif)
