### PR TITLE
Fix Select popover-related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select`/`SelectMulti` list closing when trying to scroll by dragging the scrollbar
+- `SelectMulti` list height now adjusts as needed when chips are added
 - `Tree` default color is text4 (was previously a different color due to browser button defaults)
 - `MenuItem` disabled prop is not clickable and its not a link.
 - detail is part of `MenuItem`'s clickable area

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
@@ -27,7 +27,6 @@
 import omit from 'lodash/omit'
 import {
   createContext,
-  RefObject,
   Ref,
   MutableRefObject,
   Dispatch,
@@ -56,7 +55,7 @@ export interface ComboboxContextProps<
   inputCallbackRef?: Ref<HTMLInputElement>
   inputElement?: HTMLInputElement | null
   wrapperElement?: HTMLDivElement | null
-  listRef?: RefObject<HTMLUListElement>
+  listRef?: MutableRefObject<HTMLElement | null>
   onChange?: TChange
   optionsRef?: MutableRefObject<ComboboxOptionObject[]>
   state?: ComboboxState

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -47,7 +47,6 @@ import React, {
 import styled, { css } from 'styled-components'
 import once from 'lodash/once'
 import throttle from 'lodash/throttle'
-import { useForkedRef } from '../../../utils'
 import { usePopover } from '../../../Popover'
 import { ComboboxOptionIndicatorProps } from './ComboboxOptionIndicator'
 import { ComboboxContext, ComboboxMultiContext } from './ComboboxContext'
@@ -117,7 +116,7 @@ const ComboboxListInternal = forwardRef(
       isMulti,
       ...props
     }: ComboboxListInternalProps,
-    forwardedRef: Ref<HTMLUListElement>
+    ref: Ref<HTMLUListElement>
   ) => {
     const context = useContext(ComboboxContext)
     const contextMulti = useContext(ComboboxMultiContext)
@@ -160,7 +159,6 @@ const ComboboxListInternal = forwardRef(
     const handleBlur = isMulti
       ? useBlur(ComboboxMultiContext)
       : useBlur(ComboboxContext)
-    const ref = useForkedRef(listRef, forwardedRef)
 
     // Avoid calling getBoundingClientWidth if width/minWidth are set in props
     const width = props.width || getElementWidth(wrapperElement) || 'auto'
@@ -199,6 +197,11 @@ const ComboboxListInternal = forwardRef(
       triggerElement: wrapperElement,
       triggerToggle: false,
     })
+    if (popperInstanceRef.current && listRef) {
+      // Using the outermost popover element ensures the check in useBlur
+      // will not fail to detect a scroll-bar click-drag
+      listRef.current = popperInstanceRef.current.state.elements.popper
+    }
 
     // For isMulti, we update the popover position when values are added/removed
     // since it may affect the height of the field

--- a/packages/components/src/Form/Inputs/Combobox/utils/useComboboxRefs.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useComboboxRefs.ts
@@ -39,7 +39,7 @@ export function useComboboxRefs(forwardedRef: Ref<HTMLDivElement>) {
   // I'm pretty excited about it.
   const optionsRef = useRef<ComboboxOptionObject[]>([])
 
-  const listRef = useRef<HTMLUListElement>(null)
+  const listRef = useRef<HTMLElement | null>(null)
 
   // When <ComboboxInput autoComplete={false} /> we don't want cycle back to
   // the user's value while navigating (because it's always the user's value),

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -37,6 +37,7 @@ import React, {
   isValidElement,
   cloneElement,
 } from 'react'
+import { CSSProperties } from 'styled-components'
 import { Box } from '../Layout'
 import { Portal } from '../Portal'
 import { DialogContext } from '../Dialog'
@@ -178,7 +179,9 @@ function useVerticalSpace(
   element: HTMLElement | null,
   pin: boolean,
   placement: Placement,
-  isOpen: boolean
+  isOpen: boolean,
+  // Included to trigger an update if Popper's positioning moves
+  popperStyle: CSSProperties
 ) {
   const [spaceTop, setSpaceTop] = useState(0)
   const [spaceBottom, setSpaceBottom] = useState(0)
@@ -217,7 +220,14 @@ function useVerticalSpace(
     return () => {
       window.removeEventListener('resize', getVerticalSpace)
     }
-  }, [element, pin, placementIsBottom, placementIsTop, isOpen])
+  }, [
+    element,
+    pin,
+    placementIsBottom,
+    placementIsTop,
+    isOpen,
+    popperStyle.transform,
+  ])
 
   // Set height to the larger, popper will take care of flipping as needed
   const max = Math.max(spaceTop, spaceBottom)
@@ -433,7 +443,6 @@ export function usePopover({
     element
   )
 
-  const verticalSpace = useVerticalSpace(element, pin, propsPlacement, isOpen)
   const openWithoutElem = useOpenWithoutElement(isOpen, element)
 
   useEffect(() => {
@@ -502,6 +511,14 @@ export function usePopover({
     style,
     targetRef,
   } = usePopper(usePopperProps)
+
+  const verticalSpace = useVerticalSpace(
+    element,
+    pin,
+    propsPlacement,
+    isOpen,
+    style
+  )
 
   const ref = useForkedRef(targetRef, focusRef)
 


### PR DESCRIPTION
### :sparkles: Changes

#### `Select` scrollbar issue
When focus leaves the input, the handler in `useBlur` tries to determine if focus landed somewhere in the list. To do that it was using a ref on the `ul` but when you click on the scrollbar to drag it, focus lands on `OverlaySurface.Outer`. Since `ComboboxList` already has access to `popperInstanceRef`, I updated `listRef` to take the `elements.popper` value from there.

#### `SelectMulti` list height issue
`Popover` has an internal `useVerticalHeight` hook that keeps long popovers from going off the page (which would be bad, because of the scroll lock). It updates on window resize, but wasn't updating with the popover's position changed (via `popoverInstanceRef.update()`). I'm piggy-backing on the effects of that update – a changed value for `style.transform` from `usePopper` – to trigger an update in `useVerticalHeight`.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC