### PR TITLE
IE11 Fixes (Accordion, Tree, DialogHeader, Space)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Accordion` & `Tree` presentation fixes for IE11
 - `DialogHeader` presentation fix for IE11
 - `Space` presentation fix for IE11 (also affects consumers)
+- `Tree` correct React warning about nested buttons by changing `TreeItem` back to `div` with `role="button`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ActionListControlBar` component
 - `useActionListSelectManager` hook
+- Added `xxxxxlarge` to sizes to support updated type ramp.
 
 ### Fixed
 
@@ -20,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update Error Icon for Fields validation message
 - `Avatar*` corrected styling conflicts when underlying component is switched to button (via `role="button"`)
 - `Tabs` no longer show scrollbar when overflowing
+- `Accordion` & `Tree` presentation fixes for IE11
+- `DialogHeader` presentation fix for IE11
+- `Space` presentation fix for IE11 (also affects consumers)
 
 ### Changed
 
@@ -30,10 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove arrow from `Tooltip`, `Popover` and `Menu` by default
 - Updates to how we apply colors to `ButtonOutline` and `ButtonTransparent` to be more inline with design spec
 - `neutral` intent color is now defaults to `charcoal500`
-
-### Added
-
-- Added `xxxxxlarge` to sizes to support updated type ramp.
 
 ## [0.9.9] - 2020-08-02
 

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -43,10 +43,10 @@ import { AccordionDisclosureGrid } from './AccordionDisclosureGrid'
 
 export interface AccordionDisclosureProps
   extends TypographyProps,
-    CompatibleHTMLProps<HTMLButtonElement> {
+    CompatibleHTMLProps<HTMLElement> {
   className?: string
   focusVisible?: boolean
-  ref?: Ref<HTMLButtonElement>
+  ref?: Ref<HTMLDivElement>
 }
 
 export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRef(
@@ -69,13 +69,13 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
       toggleOpen(!isOpen)
     }
 
-    const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
       if (event.keyCode === 13) {
         handleToggle()
       }
     }
 
-    const handleKeyUp = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
       if (event.keyCode === 9 && event.currentTarget === event.target)
         setFocusVisible(true)
     }
@@ -91,6 +91,7 @@ export const AccordionDisclosureLayout: FC<AccordionDisclosureProps> = forwardRe
 
     return (
       <AccordionDisclosureStyle
+        role="button"
         aria-controls={accordionContentId}
         aria-expanded={isOpen}
         className={className}
@@ -117,7 +118,7 @@ interface AccordionDisclosureStyleProps {
   focusVisible: boolean
 }
 
-export const AccordionDisclosureStyle = styled.button<
+export const AccordionDisclosureStyle = styled.div<
   AccordionDisclosureStyleProps
 >`
   align-items: center;

--- a/packages/components/src/Accordion/AccordionDisclosureGrid.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosureGrid.tsx
@@ -50,30 +50,40 @@ const AccordionDisclosureGridLayout: FC<AccordionDisclosureGridProps> = ({
   className,
   isOpen,
   indicatorIcons,
+  indicatorPosition,
   indicatorSize,
-}) => (
-  <div className={className}>
+}) => {
+  const indicator = (
     <Indicator>
       <Icon
         name={isOpen ? indicatorIcons.open : indicatorIcons.close}
         size={indicatorSize}
       />
     </Indicator>
-    <Label>{children}</Label>
-  </div>
-)
+  )
 
+  return (
+    <div className={className}>
+      {indicatorPosition === 'left' && indicator}
+      <Label>{children}</Label>
+      {indicatorPosition !== 'left' && indicator}
+    </div>
+  )
+}
 export const AccordionDisclosureGrid = styled(AccordionDisclosureGridLayout)`
   align-items: center;
-  display: grid;
-  grid-gap: ${({ indicatorGap, theme }) => theme.space[indicatorGap]};
-  grid-template-areas: ${({ indicatorPosition }) =>
-    indicatorPosition === 'left'
-      ? '"indicator children"'
-      : '"children indicator"'};
-  grid-template-columns: ${({ indicatorPosition, indicatorSize, theme }) =>
-    indicatorPosition === 'left'
-      ? theme.space[indicatorSize] + ' 1fr'
-      : '1fr ' + theme.space[indicatorSize]};
+  display: flex;
   width: 100%;
+
+  & > ${Label} {
+    flex: 1;
+  }
+
+  & > ${Indicator} {
+    ${({ indicatorGap, indicatorPosition, theme: { space } }) =>
+      indicatorPosition === 'left'
+        ? `margin-right: ${space[indicatorGap]};`
+        : `margin-left: ${space[indicatorGap]};`}
+    width: ${({ indicatorSize, theme: { space } }) => space[indicatorSize]};
+  }
 `

--- a/packages/components/src/Dialog/Layout/DialogHeader.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader.tsx
@@ -108,15 +108,14 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
 }
 
 const Detail = styled.div`
-  grid-area: close;
+  margin-left: auto;
 `
 
 export const DialogHeader = styled(DialogHeaderLayout)`
   ${reset}
   ${space}
   align-items: center;
-  display: grid;
-  grid-template-columns: [text] 1fr [close] auto;
+  display: flex;
 `
 
 DialogHeader.defaultProps = {

--- a/packages/components/src/Dialog/Layout/__snapshots__/DialogFooter.test.tsx.snap
+++ b/packages/components/src/Dialog/Layout/__snapshots__/DialogFooter.test.tsx.snap
@@ -55,6 +55,16 @@ exports[`DialogFooter with Button 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.c1 > * {
+    margin-right: 1rem;
+  }
+
+  .c1.c1 > *:first-child {
+    margin-right: 0rem;
+  }
+}
+
 <footer
   className="c0 "
   width="100%"
@@ -116,6 +126,16 @@ exports[`DialogFooter with DialogContext 1`] = `
 }
 
 @supports not (-moz-appearance:none) {
+  .c1.c1 > * {
+    margin-right: 1rem;
+  }
+
+  .c1.c1 > *:first-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
   .c1.c1 > * {
     margin-right: 1rem;
   }

--- a/packages/components/src/Dialog/Layout/__snapshots__/DialogHeader.test.tsx.snap
+++ b/packages/components/src/Dialog/Layout/__snapshots__/DialogHeader.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`DialogHeader Snapshot 1`] = `
 }
 
 .c2 {
-  grid-area: close;
+  margin-left: auto;
 }
 
 .c0 {
@@ -118,8 +118,10 @@ exports[`DialogHeader Snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  display: grid;
-  grid-template-columns: [text] 1fr [close] auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <header

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -97,20 +97,29 @@ export const spaceCSS = css`
  *
  */
 
+const fauxGap = ({ gap = defaultGap, reverse }: SpaceHelperProps) => css`
+  && > * {
+    margin-right: ${({ theme: { space } }) => space[gap]};
+  }
+
+  ${({ theme: { space } }) =>
+    reverse
+      ? `&& > *:first-child { margin-right: ${space.none}; }`
+      : `&& > *:last-child { margin-right: ${space.none}; }`}
+`
+
 const flexGap = ({ gap = defaultGap, reverse }: SpaceHelperProps) => css`
   @supports (-moz-appearance: none) {
     gap: ${({ theme: { space } }) => space[gap]};
   }
 
   @supports not (-moz-appearance: none) {
-    && > * {
-      margin-right: ${({ theme: { space } }) => space[gap]};
-    }
+    ${fauxGap({ gap, reverse })}
+  }
 
-    ${({ theme: { space } }) =>
-      reverse
-        ? `&& > *:first-child { margin-right: ${space.none}; }`
-        : `&& > *:last-child { margin-right: ${space.none}; }`}
+  /* Target IE11 */
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    ${fauxGap({ gap, reverse })}
   }
 `
 

--- a/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
+++ b/packages/components/src/Layout/Space/__snapshots__/Space.test.tsx.snap
@@ -149,6 +149,16 @@ exports[`Space default 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0.c0 > * {
+    margin-right: 1rem;
+  }
+
+  .c0.c0 > *:last-child {
+    margin-right: 0rem;
+  }
+}
+
 <div
   className="c0"
   width="100%"
@@ -239,6 +249,16 @@ exports[`Space reversed 1`] = `
   }
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0.c0 > * {
+    margin-right: 1rem;
+  }
+
+  .c0.c0 > *:first-child {
+    margin-right: 0rem;
+  }
+}
+
 <div
   className="c0"
   width="100%"
@@ -281,6 +301,16 @@ exports[`Space with specified gap 1`] = `
 }
 
 @supports not (-moz-appearance:none) {
+  .c0.c0 > * {
+    margin-right: 2rem;
+  }
+
+  .c0.c0 > *:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
   .c0.c0 > * {
     margin-right: 2rem;
   }

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -101,7 +101,7 @@ const TreeLayout: FC<TreeProps> = ({
   visuallyAsBranch,
   ...restProps
 }) => {
-  const disclosureRef = useRef<HTMLButtonElement>(null)
+  const disclosureRef = useRef<HTMLDivElement>(null)
   const [isHovered] = useHovered(disclosureRef)
 
   const treeContext = useContext(TreeContext)


### PR DESCRIPTION

### :sparkles: Changes

- `Accordion` & `Tree` presentation fixes for IE11
- `DialogHeader` presentation fix for IE11
- `Space` presentation fix for IE11 (also affects consumers)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
