### PR TITLE
InputChipsBase: fix click/mousedown/focus issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SelectMulti` and `InputChips` issues clicking on icons and chips
 - `InputChips` and `SelectMulti` overflow when a fixed height is used
 - `InputChips` and `SelectMulti` long values breaking out of the input
 - `InputSearch`, `Select`, `InputChips` and `SelectMulti` x button not clickable with `autoResize` and a max-width reached

--- a/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
+++ b/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
@@ -29,16 +29,17 @@ import flatMap from 'lodash/flatMap'
 import tail from 'lodash/tail'
 import compact from 'lodash/compact'
 import { Icon } from '../../Icon'
-import { InputSearchControls } from './InputSearch/InputSearchControls'
+import {
+  InputSearchControls,
+  InputSearchControlsProps,
+} from './InputSearch/InputSearchControls'
 
-interface AdvancedInputControlsProps {
+export interface AdvancedInputControlsProps
+  extends Omit<InputSearchControlsProps, 'height' | 'showClear'> {
   validationType?: 'error'
   renderSearchControls?: boolean
   isVisibleOptions?: boolean
   hasOptions?: boolean
-  disabled?: boolean
-  onClear: () => void
-  summary?: string
 }
 
 // inserts a divider line between each control element (item1 | item2 | item3)
@@ -50,11 +51,10 @@ const intersperseDivider = (children: ReactElement[]) =>
 export const AdvancedInputControls: FC<AdvancedInputControlsProps> = ({
   validationType,
   renderSearchControls,
-  onClear,
   disabled,
   isVisibleOptions,
-  summary,
   hasOptions = true,
+  ...rest
 }) => {
   const children = intersperseDivider(
     compact([
@@ -70,10 +70,9 @@ export const AdvancedInputControls: FC<AdvancedInputControlsProps> = ({
       renderSearchControls && (
         <InputSearchControls
           key="search-controls"
-          onClear={onClear}
           showClear={true}
           disabled={disabled}
-          summary={summary}
+          {...rest}
         />
       ),
       hasOptions && (

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.test.tsx
@@ -148,6 +148,18 @@ tag2`
     expect(onChangeMock).toHaveBeenCalledWith([])
   })
 
+  test('all values are removed by clicking clear field', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(
+      <InputChips onChange={onChangeMock} values={['tag1', 'tag2']} />
+    )
+    const clear = screen.getByText('Clear Field')
+
+    fireEvent.click(clear)
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+    expect(onChangeMock).toHaveBeenCalledWith([])
+  })
+
   test('values are removed by clicking remove on the chip', () => {
     const onChangeMock = jest.fn()
     renderWithTheme(<InputChips onChange={onChangeMock} values={['tag1']} />)
@@ -261,5 +273,58 @@ tag2`
 
       expect(onChangeMock).not.toHaveBeenCalled()
     })
+  })
+
+  test('mousedown on a chip does not focus the inner input', () => {
+    const rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: any) => cb())
+
+    renderWithTheme(
+      <InputChips
+        onChange={() => null}
+        values={['foo', 'bar']}
+        placeholder="type here"
+      />
+    )
+
+    const chip = screen.getByText('bar')
+    const deleteButton = screen.getAllByText('Delete')[0]
+    const input = screen.getByPlaceholderText('type here')
+
+    fireEvent.mouseDown(chip)
+    expect(document.activeElement).not.toEqual(input)
+
+    // Focus should move _after_ delete button is clicked
+    fireEvent.click(deleteButton)
+    expect(document.activeElement).toEqual(input)
+
+    rafSpy.mockRestore()
+  })
+
+  test('mousedown on clear button does not focus the inner input', () => {
+    const rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: any) => cb())
+
+    renderWithTheme(
+      <InputChips
+        onChange={() => null}
+        values={['foo', 'bar']}
+        placeholder="type here"
+      />
+    )
+
+    const clear = screen.getByText('Clear Field')
+    const input = screen.getByPlaceholderText('type here')
+
+    fireEvent.mouseDown(clear)
+    expect(document.activeElement).not.toEqual(input)
+
+    // Focus should move _after_ clear button is clicked
+    fireEvent.click(clear)
+    expect(document.activeElement).toEqual(input)
+
+    rafSpy.mockRestore()
   })
 })

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearchControls.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearchControls.tsx
@@ -24,6 +24,7 @@
 
  */
 
+import { CompatibleHTMLProps } from '@looker/design-tokens'
 import omit from 'lodash/omit'
 import React, { forwardRef, MouseEvent, Ref } from 'react'
 import styled from 'styled-components'
@@ -31,7 +32,8 @@ import { Box, Space } from '../../../Layout'
 import { IconButton } from '../../../Button'
 import { Text } from '../../../Text'
 
-export interface InputSearchControlsProps {
+export interface InputSearchControlsProps
+  extends CompatibleHTMLProps<HTMLDivElement> {
   summary?: string
   showClear: boolean
   onClear: (e: MouseEvent<HTMLButtonElement>) => void


### PR DESCRIPTION
### :sparkles: Changes

- `InputChipsBase` (used in `InputChips` and `SelectMulti`) renders an `InputText`, which moves focus to the inner input just after mousedown
- This behavior disrupts clicking on other elements in the component, like a `Chip` (the whole thing, if a user wants to select a specific chip to delete, or copy its text, as well as the x icon), and the clear field x icon button.
- Some of the disruption can only be seen if the inner input is below the fold (see screen capture below) whereas trying to select a specific chip or copy its text just never works.
- The fix is to add `stopPropagation` on the `Chip` and clear field button, but then move focus to the inner input after the action is complete (where appropriate)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots

![d63df948-ffd3-4ba9-b4c1-d7c96dc946e1 (1)](https://user-images.githubusercontent.com/53451193/89683783-0b142480-d8ae-11ea-8513-dd0ed5f948e3.gif)