### PR TITLE
Update text blends to closer match previous color palette

### DIFF
--- a/packages/design-tokens/src/utils/color/blend.ts
+++ b/packages/design-tokens/src/utils/color/blend.ts
@@ -30,7 +30,7 @@ import { BlendColors, SpecifiableColors } from '../../system/color'
 import { tintOrShadeUiColor } from './tintOrShadeUiColor'
 import { scaleMixAmount } from './scaleMixAmount'
 
-const textBlends = [30, 40, 60, 70, 80, 100]
+const textBlends = [45, 65, 78, 88, 95, 99]
 export const uiBlends = [4, 12, 23, 34, 85]
 type UIColorLevels = 1 | 2 | 3 | 4 | 5 | 6
 


### PR DESCRIPTION
### :sparkles: Changes

This change adjusts our blending levels for the text blends to closer align with our previous palette. Our generated text colors were a bit lighter this PR brings them closer to previous levels. Here are some before and after images, the left is our previous palette colors, the right is our generated colors

#### Before

![image](https://user-images.githubusercontent.com/170681/90044885-218df780-dc83-11ea-8c66-b91aba69c5ef.png)

#### After

![image](https://user-images.githubusercontent.com/170681/90044983-43877a00-dc83-11ea-85a2-1c90eaabc989.png)



### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
