### PR TITLE
Select: support empty string value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select` value can now be cleared via external state change
+- `Select` name attribute is passed to the input
 - `MenuItem` now supports `description`
 - `Select` and `SelectMulti` performance issue causing poor rendering when inside a `Dialog`
 

--- a/packages/components/src/Form/Inputs/Combobox/utils/getComboboxText.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/getComboboxText.ts
@@ -30,7 +30,7 @@ export function getComboboxText(
   value?: string | ComboboxOptionObject,
   options?: ComboboxOptionObject[]
 ): string {
-  if (!value) return ''
+  if (value === undefined) return ''
   if (typeof value === 'string') {
     if (options && options.length > 0) {
       const currentOption = options.find((option) => option.value === value)

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -29,7 +29,7 @@ import {
   renderWithTheme,
 } from '@looker/components-test-utils'
 import { cleanup, fireEvent, screen } from '@testing-library/react'
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 
 import { Button } from '../../../Button'
 import { ComboboxOptionIndicatorFunction } from '../Combobox'
@@ -540,11 +540,12 @@ describe('Select / SelectMulti', () => {
 })
 
 describe('Select', () => {
+  const options = [
+    { label: 'Foo', value: 'FOO' },
+    { label: 'Bar', value: 'BAR' },
+  ]
+
   test('value', () => {
-    const options = [
-      { label: 'Foo', value: 'FOO' },
-      { label: 'Bar', value: 'BAR' },
-    ]
     renderWithTheme(
       <Select
         options={options}
@@ -561,11 +562,26 @@ describe('Select', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
+  test('clearing the value externally', () => {
+    const Component = () => {
+      const [value, setValue] = useState('FOO')
+      return (
+        <>
+          <Button onClick={() => setValue('')}>Clear</Button>
+          <Select value={value} onChange={setValue} options={options} />
+        </>
+      )
+    }
+    renderWithTheme(<Component />)
+
+    const input = screen.getByDisplayValue('Foo')
+    const button = screen.getByText('Clear')
+
+    fireEvent.click(button)
+    expect(input).toHaveValue('')
+  })
+
   test('defaultValue', () => {
-    const options = [
-      { label: 'Foo', value: 'FOO' },
-      { label: 'Bar', value: 'BAR' },
-    ]
     renderWithTheme(
       <Select options={options} placeholder="Search" defaultValue="BAR" />
     )
@@ -577,10 +593,6 @@ describe('Select', () => {
 
   test('isClearable', () => {
     const handleChange = jest.fn()
-    const options = [
-      { label: 'Foo', value: 'FOO' },
-      { label: 'Bar', value: 'BAR' },
-    ]
     renderWithTheme(
       <Select
         options={options}
@@ -611,7 +623,6 @@ describe('Select', () => {
   })
 
   test('isClearable, no defaultValue', () => {
-    const options = [{ value: 'FOO' }, { value: 'BAR' }]
     renderWithTheme(
       <Select options={options} isClearable data-testid="wrapper" />
     )
@@ -622,10 +633,6 @@ describe('Select', () => {
   })
 
   test('default to first option', () => {
-    const options = [
-      { label: 'Foo', value: 'FOO' },
-      { label: 'Bar', value: 'BAR' },
-    ]
     renderWithTheme(<Select options={options} data-testid="wrapper" />)
 
     const input = screen.getByTestId('wrapper').querySelector('input')
@@ -633,47 +640,78 @@ describe('Select', () => {
     expect(input).toHaveValue('Foo')
   })
 
-  test('displayed value changes when option label changes', () => {
-    const Component = () => {
-      const [label, setLabel] = useState('Original Label')
-      const options = [
-        { label, value: 'value_stays_the_same' },
-        { label: 'Another Option', value: 'other' },
-      ]
-      return (
-        <>
-          <Button onClick={() => setLabel('Updated label')}>
-            Update label
-          </Button>
-          <Select value="value_stays_the_same" options={options} />
-        </>
-      )
-    }
-    renderWithTheme(<Component />)
+  describe('updating options', () => {
+    test('displayed value changes when option label changes', () => {
+      const Component = () => {
+        const [label, setLabel] = useState('Original Label')
+        const options = [
+          { label, value: 'value_stays_the_same' },
+          { label: 'Another Option', value: 'other' },
+        ]
+        return (
+          <>
+            <Button onClick={() => setLabel('Updated label')}>
+              Update label
+            </Button>
+            <Select value="value_stays_the_same" options={options} />
+          </>
+        )
+      }
+      renderWithTheme(<Component />)
 
-    const input = screen.getByDisplayValue('Original Label')
-    fireEvent.click(input)
-    expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
-      Array [
-        "Original Label",
-        "Another Option",
-      ]
-    `)
-    // Close list
-    fireEvent.click(document)
+      const input = screen.getByDisplayValue('Original Label')
+      fireEvent.click(input)
+      expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
+        Array [
+          "Original Label",
+          "Another Option",
+        ]
+      `)
+      // Close list
+      fireEvent.click(document)
 
-    fireEvent.click(screen.getByText('Update label'))
-    expect(input).toHaveDisplayValue('Updated label')
+      fireEvent.click(screen.getByText('Update label'))
+      expect(input).toHaveValue('Updated label')
 
-    fireEvent.click(input)
-    expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
-      Array [
-        "Updated label",
-        "Another Option",
-      ]
-    `)
+      fireEvent.click(input)
+      expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
+        Array [
+          "Updated label",
+          "Another Option",
+        ]
+      `)
 
-    // Close popover to silence act() warning
-    fireEvent.click(document)
+      // Close popover to silence act() warning
+      fireEvent.click(document)
+    })
+
+    test('filtering out the selected option does not trigger a change', () => {
+      // Tests a bug where as soon as the selected option gets filtered out,
+      // the input value reverts to the current value
+      const Component = () => {
+        const [filterTerm, setFilterTerm] = useState('')
+        const filteredOptions = useMemo(
+          () =>
+            options.filter((option) => option.label.indexOf(filterTerm) > -1),
+          [filterTerm]
+        )
+        return (
+          <Select
+            value="FOO"
+            options={filteredOptions}
+            isFilterable
+            onFilter={setFilterTerm}
+          />
+        )
+      }
+      renderWithTheme(<Component />)
+
+      const input = screen.getByDisplayValue('Foo')
+      fireEvent.change(input, { target: { value: 'Ba' } })
+      expect(input).toHaveValue('Ba')
+
+      // Close popover to silence act() warning
+      fireEvent.click(document)
+    })
   })
 })

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -578,7 +578,7 @@ describe('Select', () => {
     const button = screen.getByText('Clear')
 
     fireEvent.click(button)
-    expect(input).toHaveValue('')
+    expect(input).not.toHaveValue()
   })
 
   test('defaultValue', () => {
@@ -609,7 +609,7 @@ describe('Select', () => {
     const clearButton = screen.getByRole('button')
     fireEvent.click(clearButton)
 
-    expect(input).toHaveValue('')
+    expect(input).not.toHaveValue()
     expect(handleChange).toHaveBeenCalledWith('')
   })
 
@@ -619,7 +619,7 @@ describe('Select', () => {
 
     const input = screen.getByPlaceholderText('Search')
     // should not default to first option
-    expect(input).toHaveValue('')
+    expect(input).not.toHaveValue()
   })
 
   test('isClearable, no defaultValue', () => {
@@ -630,6 +630,38 @@ describe('Select', () => {
     const input = screen.getByTestId('wrapper').querySelector('input')
     // should not default to first option
     expect(input).not.toHaveValue()
+  })
+
+  test('empty string defaultValue', () => {
+    renderWithTheme(
+      <Select options={options} defaultValue="" data-testid="wrapper" />
+    )
+
+    const input = screen.getByTestId('wrapper').querySelector('input')
+    // should not default to first option
+    expect(input).not.toHaveValue()
+  })
+
+  test('empty string value', () => {
+    renderWithTheme(<Select options={options} value="" data-testid="wrapper" />)
+
+    const input = screen.getByTestId('wrapper').querySelector('input')
+    // should not default to first option
+    expect(input).not.toHaveValue()
+  })
+
+  test('empty string value, empty string option', () => {
+    renderWithTheme(
+      <Select
+        options={[{ label: 'An empty string', value: '' }, ...options]}
+        value=""
+        data-testid="wrapper"
+      />
+    )
+
+    const input = screen.getByTestId('wrapper').querySelector('input')
+    // should not default to first option
+    expect(input).toHaveValue('An empty string')
   })
 
   test('default to first option', () => {

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -672,78 +672,75 @@ describe('Select', () => {
     expect(input).toHaveValue('Foo')
   })
 
-  describe('updating options', () => {
-    test('displayed value changes when option label changes', () => {
-      const Component = () => {
-        const [label, setLabel] = useState('Original Label')
-        const options = [
-          { label, value: 'value_stays_the_same' },
-          { label: 'Another Option', value: 'other' },
-        ]
-        return (
-          <>
-            <Button onClick={() => setLabel('Updated label')}>
-              Update label
-            </Button>
-            <Select value="value_stays_the_same" options={options} />
-          </>
-        )
-      }
-      renderWithTheme(<Component />)
+  test('displayed value changes when option label changes', () => {
+    const Component = () => {
+      const [label, setLabel] = useState('Original Label')
+      const options = [
+        { label, value: 'value_stays_the_same' },
+        { label: 'Another Option', value: 'other' },
+      ]
+      return (
+        <>
+          <Button onClick={() => setLabel('Updated label')}>
+            Update label
+          </Button>
+          <Select value="value_stays_the_same" options={options} />
+        </>
+      )
+    }
+    renderWithTheme(<Component />)
 
-      const input = screen.getByDisplayValue('Original Label')
-      fireEvent.click(input)
-      expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
-        Array [
-          "Original Label",
-          "Another Option",
-        ]
-      `)
-      // Close list
-      fireEvent.click(document)
+    const input = screen.getByDisplayValue('Original Label')
+    fireEvent.click(input)
+    expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
+      Array [
+        "Original Label",
+        "Another Option",
+      ]
+    `)
+    // Close list
+    fireEvent.click(document)
 
-      fireEvent.click(screen.getByText('Update label'))
-      expect(input).toHaveValue('Updated label')
+    fireEvent.click(screen.getByText('Update label'))
+    expect(input).toHaveValue('Updated label')
 
-      fireEvent.click(input)
-      expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
-        Array [
-          "Updated label",
-          "Another Option",
-        ]
-      `)
+    fireEvent.click(input)
+    expect(getAllComboboxOptionText()).toMatchInlineSnapshot(`
+      Array [
+        "Updated label",
+        "Another Option",
+      ]
+    `)
 
-      // Close popover to silence act() warning
-      fireEvent.click(document)
-    })
+    // Close popover to silence act() warning
+    fireEvent.click(document)
+  })
 
-    test('filtering out the selected option does not trigger a change', () => {
-      // Tests a bug where as soon as the selected option gets filtered out,
-      // the input value reverts to the current value
-      const Component = () => {
-        const [filterTerm, setFilterTerm] = useState('')
-        const filteredOptions = useMemo(
-          () =>
-            options.filter((option) => option.label.indexOf(filterTerm) > -1),
-          [filterTerm]
-        )
-        return (
-          <Select
-            value="FOO"
-            options={filteredOptions}
-            isFilterable
-            onFilter={setFilterTerm}
-          />
-        )
-      }
-      renderWithTheme(<Component />)
+  test('filtering out the selected option does not trigger a change', () => {
+    // Tests a bug where as soon as the selected option gets filtered out,
+    // the input value reverts to the current value
+    const Component = () => {
+      const [filterTerm, setFilterTerm] = useState('')
+      const filteredOptions = useMemo(
+        () => options.filter((option) => option.label.indexOf(filterTerm) > -1),
+        [filterTerm]
+      )
+      return (
+        <Select
+          value="FOO"
+          options={filteredOptions}
+          isFilterable
+          onFilter={setFilterTerm}
+        />
+      )
+    }
+    renderWithTheme(<Component />)
 
-      const input = screen.getByDisplayValue('Foo')
-      fireEvent.change(input, { target: { value: 'Ba' } })
-      expect(input).toHaveValue('Ba')
+    const input = screen.getByDisplayValue('Foo')
+    fireEvent.change(input, { target: { value: 'Ba' } })
+    expect(input).toHaveValue('Ba')
 
-      // Close popover to silence act() warning
-      fireEvent.click(document)
-    })
+    // Close popover to silence act() warning
+    fireEvent.click(document)
   })
 })

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -101,6 +101,7 @@ const SelectComponent = forwardRef(
       isFilterable,
       isClearable,
       placeholder,
+      name,
       onFilter,
       onChange,
       value,
@@ -162,6 +163,7 @@ const SelectComponent = forwardRef(
           {...ariaProps}
           disabled={disabled}
           placeholder={placeholder}
+          name={name}
           validationType={validationType}
           isClearable={isClearable}
           autoComplete={false}

--- a/packages/components/src/Form/Inputs/Select/utils/options.ts
+++ b/packages/components/src/Form/Inputs/Select/utils/options.ts
@@ -46,9 +46,11 @@ export function flattenOptions(options: SelectOptionProps[]) {
 
 export function getOption(value?: string, options?: SelectOptionProps[]) {
   const flattenedOptions = options && flattenOptions(options)
-  return value
-    ? { label: getComboboxText(value, flattenedOptions), value }
-    : undefined
+  const label = getComboboxText(value, flattenedOptions)
+  // If this is a filterable Select and the current option has been filtered out
+  // leave label out, so that the matching against the option saved in ComboboxContext won't fail
+  const labelProps = label ? { label } : {}
+  return value !== undefined ? { ...labelProps, value } : undefined
 }
 
 export function getOptions(

--- a/storybook/src/Forms/Select.stories.tsx
+++ b/storybook/src/Forms/Select.stories.tsx
@@ -396,17 +396,28 @@ export const ClearValue = () => {
 
   const [selectValue, setSelectValue] = useState('Option A')
 
+  const options = [{ value: 'Option A' }, { value: 'Option B' }]
+
   return (
     <Space p="large">
       <FieldToggleSwitch
-        label="Enable dropdown"
+        label="Use empty value"
         on={value}
         onChange={handleToggle}
       />
       <Select
-        value={value ? selectValue : ''}
+        value={value ? '' : selectValue}
+        placeholder="Can't change me when toggle is on"
         onChange={setSelectValue}
-        options={[{ value: 'Option A' }, { value: 'Option B' }]}
+        options={options}
+      />
+      <Select
+        value={value ? '' : selectValue}
+        onChange={setSelectValue}
+        options={[
+          { label: 'Option with empty string value', value: '' },
+          ...options,
+        ]}
       />
     </Space>
   )

--- a/storybook/src/Forms/Select.stories.tsx
+++ b/storybook/src/Forms/Select.stories.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { MouseEvent, useMemo, useState } from 'react'
+import React, { FormEvent, MouseEvent, useMemo, useState } from 'react'
 import {
   Card,
   CardContent,
@@ -39,6 +39,7 @@ import {
   Select,
   Fieldset,
   FieldSelect,
+  FieldToggleSwitch,
   DialogContent,
   ComboboxOptionObject,
   SelectOptionProps,
@@ -62,6 +63,7 @@ export const All = () => (
     <InlineError />
     <SelectDemo />
     <UpdateOptions />
+    <ClearValue />
   </Fieldset>
 )
 
@@ -382,6 +384,30 @@ export const UpdateOptions = () => {
     <Space>
       <Button onClick={toggle}>Use {isPlural ? 'singular' : 'plural'}</Button>
       <Select autoResize options={options} value={value} onChange={setValue} />
+    </Space>
+  )
+}
+
+export const ClearValue = () => {
+  const [value, setValue] = useState(false)
+  function handleToggle(e: FormEvent<HTMLInputElement>) {
+    setValue(e.currentTarget.checked)
+  }
+
+  const [selectValue, setSelectValue] = useState('Option A')
+
+  return (
+    <Space p="large">
+      <FieldToggleSwitch
+        label="Enable dropdown"
+        on={value}
+        onChange={handleToggle}
+      />
+      <Select
+        value={value ? selectValue : ''}
+        onChange={setSelectValue}
+        options={[{ value: 'Option A' }, { value: 'Option B' }]}
+      />
     </Space>
   )
 }

--- a/storybook/src/Forms/Select.stories.tsx
+++ b/storybook/src/Forms/Select.stories.tsx
@@ -63,7 +63,7 @@ export const All = () => (
     <InlineError />
     <SelectDemo />
     <UpdateOptions />
-    <ClearValue />
+    <EmptyValue />
   </Fieldset>
 )
 
@@ -388,7 +388,7 @@ export const UpdateOptions = () => {
   )
 }
 
-export const ClearValue = () => {
+export const EmptyValue = () => {
   const [value, setValue] = useState(false)
   function handleToggle(e: FormEvent<HTMLInputElement>) {
     setValue(e.currentTarget.checked)


### PR DESCRIPTION
### :sparkles: Changes

- Currently `Select` only respects an empty string as initial `value` or `defaultValue` if a `placeholder` is defined (and not also an empty string 😛) or if `isClearable` is true
  - There has been at least one use case in the core product that needed an empty initial value but neither `isClearable` nor `placeholder` were desirable. (`placeholder=" "` was the workaround used)
- Even with `isClearable` or `placeholder` select was not respecting a `value` change to `''` (see the new example in `Select.stories.tsx`)
  - The same use case in the core product that revealed this bug, also showed that the `name` prop wasn't getting passed down to the input.
- Also added support for empty string `value`/`defaultValue` and an option with _its_ value also empty (for example picking "Any option" from a dropdown filter)
- I found and fixed a related bug caused by https://github.com/looker-open-source/components/pull/1304 where in a `Select` with filtering behavior, if you pick an option and then start filtering, the input value reverts to the current value once that option has been "filtered out" (see screenshot below).

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![560307b4-bafe-4bcb-9e5a-940a135a83c5](https://user-images.githubusercontent.com/53451193/90072533-71cd7f80-dcac-11ea-8c99-c141c8090c36.gif)
