### PR TITLE
Update tree group label spacing to better reflect specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MenuItem` now supports `description`
 - `Select` and `SelectMulti` performance issue causing poor rendering when inside a `Dialog`
 
+### Changed
+- Spacing and density adjusted on `TreeGroup` label to better match desinsity of `TreeItems`
+
 ## [0.9.11] - 2020-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Select` and `SelectMulti` performance issue causing poor rendering when inside a `Dialog`
 
 ### Changed
-- Spacing and density adjusted on `TreeGroup` label to better match desinsity of `TreeItems`
+
+- Spacing and density adjusted on `TreeGroup` label to better match density of `TreeItem`s
 
 ## [0.9.11] - 2020-08-07
 

--- a/packages/components/src/Tree/TreeGroup.tsx
+++ b/packages/components/src/Tree/TreeGroup.tsx
@@ -54,7 +54,8 @@ export const TreeGroupLabel = styled.div`
   border: 1px transparent solid;
   font-size: ${({ theme }) => theme.fontSizes.xxsmall};
   font-weight: ${({ theme }) => theme.fontWeights.semiBold};
-  padding: ${({ theme: { space } }) => `${space.xsmall} ${space.xxsmall}`};
+  padding: ${({ theme: { space } }) =>
+    `${space.xxsmall} ${space.xxsmall} ${space.xxxsmall}`};
 `
 
 export const TreeGroup = styled(TreeGroupLayout)`


### PR DESCRIPTION
### :sparkles: Changes

Updates the spacing on the tree group label to better reflect specs

#### Before and After
![image](https://user-images.githubusercontent.com/170681/90172832-6afc4680-dd58-11ea-9c0d-2a4709c2b854.png)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
