### PR TITLE
Equal space for distributed tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED]
 
 ### Fixed
-
+- `Tabs` fix for distributed so each tab takes up an equal amount of space.
 - `Select` value can now be cleared via external state change
 - `Select` name attribute is passed to the input
 - `MenuItem` now supports `description`

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -111,6 +111,7 @@ const defaultLayoutCSS = css`
 
 const distributeCSS = css`
   display: grid;
+  grid-auto-columns: 1fr;
   grid-auto-flow: column;
 
   ${Tab} {


### PR DESCRIPTION
### :sparkles: Changes

This PR adjusts distributed tabs so that they take up an equal amount of space like the spec calls for.

You can see the effects of this change in this screenshot. Before the tab Rebecca Purple was quite a bit larger than the second tab with the emoji. With this change, you can see in the after screenshot where the tabs no all take up equal space

![image](https://user-images.githubusercontent.com/170681/90188100-bb32d300-dd6f-11ea-9631-dcae930f9218.png)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [x] Checked for i18n impacts
- [x] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
