### PR TITLE
[LENS-1138] IE11 Range Slider Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Lqa` icon artwrok
 
 ### Fixed
+
 - `Tabs` fix for distributed so each tab takes up an equal amount of space.
 - `Select` value can now be cleared via external state change
 - `Select` name attribute is passed to the input
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update Space gap for consistent rendering across browsers
   - Set min-width on `InputText` to fix `Select` layout bug at small sizes
   - Resolve Slider style inconsistencies by rendering a div rather than the vanilla slider input
+- IE11 layout fixes
+  - RangeSlider value labels now move with the thumb controls
 
 ### Changed
 

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -428,7 +428,8 @@ const ThumbLabel = styled.div<ThumbLabelProps>`
   position: absolute;
   text-align: center;
   top: -24px;
-  transform: translateX(calc(${({ position = 0 }) => `${position}px`} - 50%));
+  transform: translateX(${({ position = 0 }) => `${position}px`})
+    translateX(-50%);
   user-select: none;
   z-index: ${({ focus }) => (focus ? 1 : 0)};
 `

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -25,12 +25,21 @@
  */
 import React from 'react'
 import { render } from 'react-dom'
-import { ComponentsProvider, Paragraph } from '@looker/components'
+import {
+  ComponentsProvider,
+  RangeSlider,
+  Card,
+  CardContent,
+} from '@looker/components'
 import 'core-js/stable'
 
 const App = () => (
   <ComponentsProvider>
-    <Paragraph>Hello world</Paragraph>
+    <Card raised m="large">
+      <CardContent>
+        <RangeSlider />
+      </CardContent>
+    </Card>
   </ComponentsProvider>
 )
 

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -25,21 +25,12 @@
  */
 import React from 'react'
 import { render } from 'react-dom'
-import {
-  ComponentsProvider,
-  RangeSlider,
-  Card,
-  CardContent,
-} from '@looker/components'
+import { ComponentsProvider, Paragraph } from '@looker/components'
 import 'core-js/stable'
 
 const App = () => (
   <ComponentsProvider>
-    <Card raised m="large">
-      <CardContent>
-        <RangeSlider />
-      </CardContent>
-    </Card>
+    <Paragraph>Hello world</Paragraph>
   </ComponentsProvider>
 )
 


### PR DESCRIPTION
https://looker.atlassian.net/browse/LENS-1138

### :sparkles: Changes

- Updates `RangeSlider` css so that the value label position will align with the thumb label control in ie11

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
<img width="788" alt="Screen Shot 2020-08-17 at 4 44 39 PM" src="https://user-images.githubusercontent.com/238293/90455363-bdb46600-e0aa-11ea-91d8-048c4b03b5fe.png">

