### PR TITLE
Build ES module version of each package

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -57,6 +57,7 @@ module.exports = (api) => {
       [
         '@babel/preset-env',
         {
+          modules: process.env.BABEL_ENV === 'build' ? false : 'cjs',
           targets: {
             esmodules: true,
           },


### PR DESCRIPTION
I believe there was some work done in the past to export the packages as ES modules, but I don't think the config was exactly correct. I believe the babel config option that was used was `targets.esmodules: true`, but the correct one is `modules: false`. With this option, Babel will leave the output as ES modules. Currently, the files we publish are using the `exports` object, which is still the CommonsJS format.

This PR adds an additional build script specifically for ES modules. I have also updated the package.json in each package with the `module: "esm/file.js"` field which allows us to export both build types. On the consuming end, Webpack will prioritize the module field.