### PR TITLE
Fix horiz padding on autoResize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.13] - 2020-08-24
+
+### Fixed
+
+- Horizontal padding for inputs using `autoResize` prop
+
 ## [0.9.12] - 2020-08-24
 
 ### Added

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`A FieldText with default label 1`] = `
   width: 100%;
 }
 
+.c5 .c8 input,
 .c5 .c8 span {
   padding: 0 0.5rem;
 }
@@ -250,6 +251,7 @@ exports[`A FieldText with label inline 1`] = `
   width: 100%;
 }
 
+.c5 .c9 input,
 .c5 .c9 span {
   padding: 0 0.5rem;
 }

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`Fieldset 1`] = `
   width: 100%;
 }
 
+.c9 .c12 input,
 .c9 .c12 span {
   padding: 0 0.5rem;
 }

--- a/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputSearch/__snapshots__/InputSearch.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`InputSearch default 1`] = `
   width: 100%;
 }
 
+.c0 .c4 input,
 .c0 .c4 span {
   padding: 0 0.5rem;
 }
@@ -232,6 +233,7 @@ exports[`InputSearch hideSearchIcon removes the icon 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -305,6 +305,7 @@ export const InputText = styled(InputTextLayout)<InputTextProps>`
     height: 100%;
     max-width: 100%;
     width: 100%;
+    input,
     span {
       padding: 0 ${({ theme: { space } }) => space.xsmall};
     }

--- a/packages/components/src/Form/Inputs/InputText/__snapshots__/InputText.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputText/__snapshots__/InputText.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`InputText default 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -176,6 +177,7 @@ exports[`InputText should accept disabled 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -281,6 +283,7 @@ exports[`InputText should accept readOnly 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -382,6 +385,7 @@ exports[`InputText should accept required 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -483,6 +487,7 @@ exports[`InputText with a placeholder 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -584,6 +589,7 @@ exports[`InputText with a value 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -685,6 +691,7 @@ exports[`InputText with aria-describedby 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }
@@ -786,6 +793,7 @@ exports[`InputText with name and id 1`] = `
   width: 100%;
 }
 
+.c0 .c2 input,
 .c0 .c2 span {
   padding: 0 0.5rem;
 }

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`Form with one child 1`] = `
   width: 100%;
 }
 
+.c6 .c9 input,
 .c6 .c9 span {
   padding: 0 0.5rem;
 }


### PR DESCRIPTION
### :sparkles: Changes

Re-add padding to the internal input in `InputText` when `autoResize` is used, after it got lost in https://github.com/looker-open-source/components/pull/1336/files#diff-d0f856b4a667dca8d688eed0eedc54e0

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue
![image](https://user-images.githubusercontent.com/53451193/91091420-66af1380-e60b-11ea-9ff4-017870801b57.png)

#### Fixed
![image](https://user-images.githubusercontent.com/53451193/91091355-5008bc80-e60b-11ea-9740-be2d28a1996f.png)
