### PR TITLE
Tree: Set child AccordionDisclosure font-weight in styled-component selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Changed
+
+- `Tree` child `AccordionDisclosure` now receives font-weight value from styled-components selector
+
 ## [0.9.13] - 2020-08-24
 
 ### Fixed

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -214,11 +214,8 @@ export const TreeStyle = styled.div<TreeStyleProps>`
     & > ${AccordionDisclosureStyle} {
       background-clip: padding-box;
       background-color: ${({ hovered }) => hovered && uiTransparencyBlend(2)};
-      font-weight: ${({ visuallyAsBranch, theme }) => {
-        return visuallyAsBranch
-          ? theme.fontWeights.normal
-          : theme.fontWeights.semiBold
-      }};
+      font-weight: ${({ visuallyAsBranch, theme: { fontWeights } }) =>
+        visuallyAsBranch ? fontWeights.normal : fontWeights.semiBold};
       height: 25px;
       padding: ${({ theme }) => theme.space.xxsmall};
       ${({ depth, theme }) => generateIndent(depth, theme)}

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -130,12 +130,7 @@ const TreeLayout: FC<TreeProps> = ({
 
   const innerAccordion = (
     <Accordion {...indicatorProps} {...restProps}>
-      <AccordionDisclosure
-        ref={disclosureRef}
-        fontWeight={visuallyAsBranch ? 'normal' : 'semiBold'}
-      >
-        {treeItem}
-      </AccordionDisclosure>
+      <AccordionDisclosure ref={disclosureRef}>{treeItem}</AccordionDisclosure>
       <AccordionContent>{children}</AccordionContent>
     </Accordion>
   )
@@ -154,6 +149,7 @@ const TreeLayout: FC<TreeProps> = ({
         border={hasBorder}
         depth={depth}
         hovered={isHovered}
+        visuallyAsBranch={visuallyAsBranch}
       >
         {innerAccordion}
       </TreeStyle>
@@ -203,6 +199,7 @@ interface TreeStyleProps {
   border?: boolean
   depth: number
   hovered: boolean
+  visuallyAsBranch?: boolean
 }
 
 export const TreeStyle = styled.div<TreeStyleProps>`
@@ -217,6 +214,11 @@ export const TreeStyle = styled.div<TreeStyleProps>`
     & > ${AccordionDisclosureStyle} {
       background-clip: padding-box;
       background-color: ${({ hovered }) => hovered && uiTransparencyBlend(2)};
+      font-weight: ${({ visuallyAsBranch, theme }) => {
+        return visuallyAsBranch
+          ? theme.fontWeights.normal
+          : theme.fontWeights.semiBold
+      }};
       height: 25px;
       padding: ${({ theme }) => theme.space.xxsmall};
       ${({ depth, theme }) => generateIndent(depth, theme)}


### PR DESCRIPTION
### Reasoning

For reasons I'm still a bit hazy on, helltool is overriding the `font-weight` of `Tree`'s `AccordionDisclosure`. TLDR, what's happening is that helltool is inserting additional CSS stylings into some of the selectors generated by styled-components. For more context, see this Slack thread in the #components_exploration-experience channel:
https://looker.slack.com/archives/C017GM9RY3V/p1598381270001900

However, what I am relatively sure of is that moving the location where we set `font-weight` from the child `AccordionDisclosure`'s JSX to `Tree`'s styled-component selectors should resolve this (i.e. `Tree` respects the "visuallyAsBranch" prop when it comes to setting font-weight). 

This is because that the problem selector (i.e. the one receiving unexpected additional CSS stylings) is less specific than 
the `AccordionDisclosureStyle` child selector in `TreeItem`:
![Screen Shot 2020-08-25 at 3 06 12 PM](https://user-images.githubusercontent.com/16812885/91232806-b7df0600-e6e4-11ea-8728-e87def68f6ac.png)

Note that "Problem Selector" does NOT have a number of those CSS attributes in a `storybook` environment:
![Screen Shot 2020-08-25 at 3 08 44 PM](https://user-images.githubusercontent.com/16812885/91232929-fbd20b00-e6e4-11ea-9942-b5b79f1d9a5f.png)


### :sparkles: Changes

- `Tree` child `AccordionDisclosure` now receives font-weight value from styled-components selector

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
