### PR TITLE
[Draft] Activated Icon Button

### DIFF
--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -81,6 +81,10 @@ export interface IconButtonProps
     SpaceProps {
   type?: 'button' | 'submit' | 'reset'
   /*
+   * If the button has a 'toggled' appearance
+   */
+  activated?: boolean
+  /*
    * @default 'neutral'
    */
   color?: StatefulColor
@@ -134,6 +138,7 @@ export const IconButtonStyle = styled.button<IconButtonProps>`
 const IconButtonComponent = forwardRef(
   (props: IconButtonProps, forwardRef: Ref<HTMLButtonElement>) => {
     const {
+      activated,
       icon,
       id,
       size = 'xsmall',
@@ -204,7 +209,10 @@ const IconButtonComponent = forwardRef(
 IconButtonComponent.displayName = 'IconButtonComponent'
 
 const outlineCSS = (props: IconButtonProps) => {
-  const { shape, color = iconButtonDefaultColor } = props
+  const {
+    shape,
+    color = props.activated ? 'key' : iconButtonDefaultColor,
+  } = props
 
   return css`
     border: 1px solid ${({ theme: { colors } }) => colors.ui3};
@@ -236,23 +244,38 @@ export const IconButton = styled(IconButtonComponent)<IconButtonProps>`
   ${space}
   /* remove padding applied to transparent buttons, so icon size is preserved correctly */
 
-  background: none;
+  background: ${({ theme, activated }) =>
+    activated ? theme.colors.keySubtle : 'none'};
   border: none;
-  color: ${({ theme, color = iconButtonDefaultColor }) =>
-    lighten(0.14, theme.colors[color])};
+  color: ${({
+    theme,
+    activated,
+    color = activated ? 'key' : iconButtonDefaultColor,
+  }) => theme.colors[color]};
   padding: 0;
 
   &:hover,
   &:focus,
   &.hover {
-    color: ${({ theme, color = iconButtonDefaultColor }) =>
-      theme.colors[`${color}Interactive`]};
+    background: ${({
+      theme,
+      activated,
+      color = activated ? 'key' : iconButtonDefaultColor,
+    }) => theme.colors[`${color}Subtle`]};
+    /* color: ${({
+      theme,
+      activated,
+      color = activated ? 'key' : iconButtonDefaultColor,
+    }) => theme.colors[`${color}Interactive`]}; */
   }
 
   &:active,
   &.active {
-    color: ${({ theme, color = iconButtonDefaultColor }) =>
-      theme.colors[`${color}Pressed`]};
+    background: ${({
+      theme,
+      activated,
+      color = activated ? 'key' : iconButtonDefaultColor,
+    }) => theme.colors[`${color}Accent`]};
   }
 
   ${(props) => props.outline && outlineCSS}

--- a/storybook/src/Buttons/IconButton.stories.tsx
+++ b/storybook/src/Buttons/IconButton.stories.tsx
@@ -78,8 +78,22 @@ export const Basic = () => {
     </>
   )
 }
+export const Activated = () => {
+  const [activated, updateActivated] = React.useState(true)
+  return (
+    <>
+      <Space>
+        <IconButton
+          activated={activated}
+          icon="Favorite"
+          label="Click to toggle"
+          onClick={() => updateActivated(!activated)}
+        />
+      </Space>
+    </>
+  )
+}
 
 export default {
-  component: Basic,
   title: 'Buttons/IconButtons',
 }


### PR DESCRIPTION
### :sparkles: Changes

This is a first pass of activated icon button pattern we have seen. @lukelooker interested in your take here. I changed how color is applied to the icon buttons to achieve this. This matches closer to where we want to go but I don't remember why we were lightening it before. 

The other idea I was toying around with is instead of all the tertiary applications of color here, we could create a new `IconToggleButton` component.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
