### PR TITLE
Select: support showCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+
+- `Select` now supports `showCreate` and `formatCreateLabel` that were previously only supported in `SelectMulti`
+
 ### Changed
 
 - `Tree` child `AccordionDisclosure` now receives font-weight value from styled-components selector
+
+### Fixed
+
+- `SelectMulti` failing to appropriately show "No options" when `showCreate` is used
+- `Select` overwriting search value with the current option value if the option's value and label are different
 
 ## [0.9.13] - 2020-08-24
 

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -864,4 +864,41 @@ describe('Select', () => {
     // Close popover to silence act() warning
     fireEvent.click(document)
   })
+
+  test('filtering after selecting an option where value != label', () => {
+    const customLabelOptions = [
+      { label: 'Foo', value: 'FOO' },
+      { label: 'Bar', value: 'BAR' },
+    ]
+    function TestComponent() {
+      const [filterTerm, setFilterTerm] = useState('')
+      const [value, setValue] = useState('')
+      // Just need to simulate the current option being filtered out
+      const filteredOptions = filterTerm === '' ? customLabelOptions : []
+      return (
+        <Select
+          options={filteredOptions}
+          value={value}
+          onChange={setValue}
+          isFilterable
+          onFilter={setFilterTerm}
+          placeholder="Search"
+        />
+      )
+    }
+
+    renderWithTheme(<TestComponent />)
+
+    const input = screen.getByPlaceholderText('Search')
+    fireEvent.click(input)
+    fireEvent.click(screen.getByText('Foo'))
+    expect(input).toHaveDisplayValue('Foo')
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'Testing' } })
+    expect(input).toHaveDisplayValue('Testing')
+
+    // Close popover to silence act() warning
+    fireEvent.click(document)
+  })
 })

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -537,6 +537,93 @@ describe('Select / SelectMulti', () => {
       fireEvent.click(document)
     })
   })
+
+  describe('showCreate', () => {
+    const commonProps = {
+      isFilterable: true,
+      placeholder: 'Search',
+      showCreate: true,
+    }
+    test.each([
+      [
+        'Select',
+        <Select defaultValue="test value" {...commonProps} key="select" />,
+      ],
+      [
+        'SelectMulti',
+        <SelectMulti
+          defaultValues={['test value']}
+          {...commonProps}
+          key="select-multi"
+        />,
+      ],
+    ])('create option replaces "No options" (%s)', (_, jsx) => {
+      renderWithTheme(jsx)
+
+      const input = screen.getByPlaceholderText('Search')
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'some text' } })
+
+      expect(screen.getByText('Create "some text"')).toBeVisible()
+      expect(screen.queryByText('No options')).not.toBeInTheDocument()
+
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'test value' } })
+
+      // create option doesn't show if inputValue is already in current values
+      expect(screen.getByText('No options')).toBeVisible()
+      expect(screen.queryByText('Create "test value"')).not.toBeInTheDocument()
+
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: '' } })
+
+      // No options should show if there are no options AND no input value
+      expect(screen.getByText('No options')).toBeVisible()
+      expect(screen.queryByText('Create ""')).not.toBeInTheDocument()
+
+      // Close popover to silence act() warning
+      fireEvent.click(document)
+    })
+
+    const formatCreateLabel = (inputValue: string) =>
+      `${inputValue} CREATE LABEL`
+    test.each([
+      [
+        'Select',
+        <Select
+          options={options}
+          {...commonProps}
+          formatCreateLabel={formatCreateLabel}
+          key="select"
+        />,
+      ],
+      [
+        'SelectMulti',
+        <SelectMulti
+          options={options}
+          {...commonProps}
+          formatCreateLabel={formatCreateLabel}
+          key="select-multi"
+        />,
+      ],
+    ])('custom label, checks options (%s)', (_, jsx) => {
+      renderWithTheme(jsx)
+
+      const input = screen.getByPlaceholderText('Search')
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'some text' } })
+
+      expect(screen.getByText('some text CREATE LABEL')).toBeVisible()
+
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'foo' } })
+
+      // create option doesn't show if inputValue is in options
+      expect(screen.queryByText('foo CREATE LABEL')).not.toBeInTheDocument()
+      // Close popover to silence act() warning
+      fireEvent.click(document)
+    })
+  })
 })
 
 describe('Select', () => {

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -116,6 +116,8 @@ const SelectComponent = forwardRef(
       autoResize,
       validationType,
       windowedOptions: windowedOptionsProp,
+      showCreate = false,
+      formatCreateLabel,
       ...props
     }: SelectProps,
     ref: Ref<HTMLInputElement>
@@ -188,7 +190,10 @@ const SelectComponent = forwardRef(
             <SelectOptions
               options={options}
               windowedOptions={windowedOptions}
+              isFilterable={isFilterable}
               noOptionsLabel={noOptionsLabel}
+              showCreate={showCreate}
+              formatCreateLabel={formatCreateLabel}
             />
           </ComboboxList>
         )}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.test.tsx
@@ -100,64 +100,6 @@ describe('SelectMulti', () => {
     // 1 chip remove button and 1 clear all button
     expect(getAllByRole('button')).toHaveLength(2)
   })
-
-  describe('showCreate', () => {
-    test('create option replaces "No options"', () => {
-      const { getByText, getByPlaceholderText, queryByText } = renderWithTheme(
-        <SelectMulti
-          defaultValues={['test value']}
-          placeholder="Search"
-          isFilterable
-          showCreate
-        />
-      )
-
-      const input = getByPlaceholderText('Search')
-      fireEvent.focus(input)
-      fireEvent.change(input, { target: { value: 'some text' } })
-
-      expect(getByText('Create "some text"')).toBeVisible()
-      expect(queryByText('No options')).not.toBeInTheDocument()
-
-      fireEvent.focus(input)
-      fireEvent.change(input, { target: { value: 'test value' } })
-
-      // create option doesn't show if inputValue is already in current values
-      expect(getByText('No options')).toBeVisible()
-      expect(queryByText('Create "test value"')).not.toBeInTheDocument()
-
-      // Close popover to silence act() warning
-      fireEvent.click(document)
-    })
-
-    test('custom label, checks options', () => {
-      const { getByText, getByPlaceholderText, queryByText } = renderWithTheme(
-        <SelectMulti
-          options={basicOptions}
-          placeholder="Search"
-          isFilterable
-          showCreate
-          formatCreateLabel={(inputValue: string) =>
-            `${inputValue} CREATE LABEL`
-          }
-        />
-      )
-
-      const input = getByPlaceholderText('Search')
-      fireEvent.focus(input)
-      fireEvent.change(input, { target: { value: 'some text' } })
-
-      expect(getByText('some text CREATE LABEL')).toBeVisible()
-
-      fireEvent.focus(input)
-      fireEvent.change(input, { target: { value: 'foo' } })
-
-      // create option doesn't show if inputValue is in options
-      expect(queryByText('foo CREATE LABEL')).not.toBeInTheDocument()
-      // Close popover to silence act() warning
-      fireEvent.click(document)
-    })
-  })
 })
 
 describe('closeOnSelect', () => {

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -35,11 +35,7 @@ import {
 } from '../Combobox'
 import { InputChipsCommonProps } from '../InputChips'
 import { SelectBaseProps } from './Select'
-import {
-  SelectMultiOptionsBaseProps,
-  SelectOptionObject,
-  SelectOptions,
-} from './SelectOptions'
+import { SelectOptionObject, SelectOptions } from './SelectOptions'
 import { getOptions } from './utils/options'
 import { useShouldWindowOptions } from './utils/useWindowedOptions'
 
@@ -47,8 +43,7 @@ export interface SelectMultiProps
   extends Omit<ComboboxMultiProps, 'values' | 'defaultValues' | 'onChange'>,
     Omit<SelectBaseProps, 'isClearable'>,
     Pick<InputChipsCommonProps, 'removeOnBackspace'>,
-    Pick<ComboboxMultiInputProps, 'freeInput'>,
-    SelectMultiOptionsBaseProps {
+    Pick<ComboboxMultiInputProps, 'freeInput'> {
   /**
    * Values of the current selected option (controlled)
    */

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -33,6 +33,7 @@ import { Box } from '../../../Layout'
 import { ListItem } from '../../../List'
 import { Heading, Paragraph } from '../../../Text'
 import {
+  ComboboxContext,
   ComboboxMultiContext,
   ComboboxMultiOption,
   ComboboxOption,
@@ -224,9 +225,6 @@ export interface SelectOptionsBaseProps {
    * Render only the options visible in the scroll window
    */
   windowedOptions?: boolean
-}
-
-export interface SelectMultiOptionsBaseProps {
   /**
    * Add an on-the-fly option mirroring the typed text (use when isFilterable = true)
    * When `true`, notInOptions is used to show/hide and can be included in a custom function
@@ -239,9 +237,7 @@ export interface SelectMultiOptionsBaseProps {
   formatCreateLabel?: (inputText: string) => ReactNode
 }
 
-export interface SelectOptionsProps
-  extends SelectOptionsBaseProps,
-    SelectMultiOptionsBaseProps {
+export interface SelectOptionsProps extends SelectOptionsBaseProps {
   isMulti?: boolean
 }
 
@@ -273,10 +269,11 @@ export function SelectOptions({
   )
 
   const createOption = isFilterable && showCreate && (
-    <SelectMultiCreateOption
+    <SelectCreateOption
       options={options}
       formatLabel={formatCreateLabel}
       noOptions={noOptions}
+      isMulti={isMulti}
       key="create"
     />
   )
@@ -325,39 +322,47 @@ export function SelectOptions({
   )
 }
 
-interface SelectMultiCreateOptionProps {
+interface SelectCreateOptionProps {
   options?: SelectOptionProps[]
   noOptions: ReactNode
   formatLabel?: (inputText: string) => ReactNode
+  isMulti?: boolean
 }
 
-function SelectMultiCreateOption({
+function SelectCreateOption({
   options,
   noOptions,
   formatLabel,
-}: SelectMultiCreateOptionProps) {
-  const {
-    data: { inputValue, options: currentOptions },
-  } = useContext(ComboboxMultiContext)
+  isMulti,
+}: SelectCreateOptionProps) {
+  const { data } = useContext(ComboboxContext)
+  const { data: dataMulti } = useContext(ComboboxMultiContext)
+
+  const inputValue = isMulti ? dataMulti.inputValue : data.inputValue
+  const currentOptions = isMulti
+    ? dataMulti.options
+    : data.option
+    ? [data.option]
+    : []
 
   const shouldShow = useMemo(() => {
     return notInOptions(currentOptions, options, inputValue)
   }, [currentOptions, options, inputValue])
 
-  if (!inputValue) return null
-
-  if (!shouldShow) {
+  if (!shouldShow || !inputValue) {
     if (!options || options.length === 0) return <>{noOptions}</>
     return null
   }
 
+  const OptionComponent = isMulti ? ComboboxMultiOption : ComboboxOption
+
   return (
-    <ComboboxMultiOption
+    <OptionComponent
       value={inputValue}
       highlightText={false}
-      indicator={false}
+      indicator={isMulti ? false : undefined}
     >
       {formatLabel ? formatLabel(inputValue) : `Create "${inputValue}"`}
-    </ComboboxMultiOption>
+    </OptionComponent>
   )
 }

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -357,11 +357,7 @@ function SelectCreateOption({
   const OptionComponent = isMulti ? ComboboxMultiOption : ComboboxOption
 
   return (
-    <OptionComponent
-      value={inputValue}
-      highlightText={false}
-      indicator={isMulti ? false : undefined}
-    >
+    <OptionComponent value={inputValue} highlightText={false} indicator={false}>
       {formatLabel ? formatLabel(inputValue) : `Create "${inputValue}"`}
     </OptionComponent>
   )

--- a/packages/components/src/Form/Inputs/Select/utils/options.ts
+++ b/packages/components/src/Form/Inputs/Select/utils/options.ts
@@ -46,7 +46,10 @@ export function flattenOptions(options: SelectOptionProps[]) {
 
 export function getOption(value?: string, options?: SelectOptionProps[]) {
   const flattenedOptions = options && flattenOptions(options)
-  const label = getComboboxText(value, flattenedOptions)
+  const matchingOption = flattenedOptions?.find(
+    (option) => option.value === value
+  )
+  const label = matchingOption?.label
   // If this is a filterable Select and the current option has been filtered out
   // leave label out, so that the matching against the option saved in ComboboxContext won't fail
   const labelProps = label ? { label } : {}
@@ -82,7 +85,7 @@ export function notInOptions(
   currentOptions: ComboboxOptionObject[],
   options?: SelectOptionProps[],
   inputValue?: string
-) {
+): inputValue is string {
   if (!inputValue) return false
   if (currentOptions.find((option) => compareOption(option, inputValue))) {
     return false

--- a/packages/components/src/Form/Inputs/Select/utils/options.ts
+++ b/packages/components/src/Form/Inputs/Select/utils/options.ts
@@ -85,7 +85,7 @@ export function notInOptions(
   currentOptions: ComboboxOptionObject[],
   options?: SelectOptionProps[],
   inputValue?: string
-): inputValue is string {
+) {
   if (!inputValue) return false
   if (currentOptions.find((option) => compareOption(option, inputValue))) {
     return false

--- a/storybook/src/Forms/Select.stories.tsx
+++ b/storybook/src/Forms/Select.stories.tsx
@@ -66,6 +66,8 @@ export const All = () => (
     <UpdateOptions />
     <EmptyValue />
     <OptionIcons />
+    <OptionIcons />
+    <CreateOption />
   </Fieldset>
 )
 
@@ -531,5 +533,29 @@ export const OptionIcons = () => {
         placeholder="Select a mobile platform"
       />
     </Space>
+  )
+}
+
+export const CreateOption = () => {
+  const [filterTerm, setFilterTerm] = useState('')
+  const newOptions = useMemo(() => {
+    return options.filter(
+      (option) =>
+        option.label.toLowerCase().indexOf(filterTerm.toLowerCase()) > -1
+    )
+  }, [filterTerm])
+  function formatCreateLabel(inputValue: string) {
+    return `Create a fruit: ${inputValue}`
+  }
+  return (
+    <FieldSelect
+      label="showCreate &amp; formatCreateLabel"
+      options={newOptions}
+      isFilterable
+      onFilter={setFilterTerm}
+      showCreate
+      formatCreateLabel={formatCreateLabel}
+      width={300}
+    />
   )
 }

--- a/www/src/documentation/components/forms/select-multi.mdx
+++ b/www/src/documentation/components/forms/select-multi.mdx
@@ -45,61 +45,6 @@ The `SelectMulti` component is an extension of the [`Select`](/components/forms/
 </Space>
 ```
 
-## showCreate
-
-As with `Select`, the `isFilterable` prop allows the user to type in the input, triggering the `onFilter` callback,
-which should be used to narrow the options passed to the `SelectMulti`.
-
-When `isFilterable` is true, use the `showCreate` prop along with the `formatCreateLabel`(defaults to 'Create "[input value]"')
-to allow the user to free-form values.
-
-```jsx
-;() => {
-  const [values, setValues] = React.useState([])
-  const [searchTerm, setSearchTerm] = React.useState('')
-
-  function handleChange(newValues) {
-    setValues(newValues)
-  }
-  function handleFilter(term) {
-    setSearchTerm(term)
-  }
-
-  const newOptions = React.useMemo(() => {
-    const options = [
-      { value: 'Apples' },
-      { value: 'Bananas' },
-      { value: 'Oranges' },
-      { value: 'Pineapples' },
-      { value: 'Kiwis' },
-    ]
-    if (searchTerm === '') return options
-    return options.filter((option) => {
-      return option.value.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
-    })
-  }, [searchTerm])
-
-  function formatCreateLabel(inputValue) {
-    return `Add new fruit: ${inputValue}`
-  }
-
-  return (
-    <SelectMulti
-      options={newOptions}
-      aria-label="Fruits"
-      placeholder="Controlled, searchable, creatable"
-      isFilterable
-      values={values}
-      onChange={handleChange}
-      onFilter={handleFilter}
-      showCreate
-      formatCreateLabel={formatCreateLabel}
-      createOptionPosition="first"
-    />
-  )
-}
-```
-
 ## closeOnSelect
 
 With the `closeOnSelect` prop, the option list closes after an option is selected.

--- a/www/src/documentation/components/forms/select.mdx
+++ b/www/src/documentation/components/forms/select.mdx
@@ -83,6 +83,50 @@ the user to delete the current value.
 }
 ```
 
+## showCreate
+
+When `isFilterable` is true, use the `showCreate` prop along with the `formatCreateLabel` (defaults to `'Create "${input value}"'`)
+to allow the user to enter a value not found in the options.
+
+```jsx
+;() => {
+  const [value, setValue] = React.useState('')
+  const [searchTerm, setSearchTerm] = React.useState('')
+
+  const newOptions = React.useMemo(() => {
+    const options = [
+      { value: 'Apples' },
+      { value: 'Bananas' },
+      { value: 'Oranges' },
+      { value: 'Pineapples' },
+      { value: 'Kiwis' },
+    ]
+    if (searchTerm === '') return options
+    return options.filter((option) => {
+      return option.value.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
+    })
+  }, [searchTerm])
+
+  function formatCreateLabel(inputValue) {
+    return `Add new fruit: ${inputValue}`
+  }
+
+  return (
+    <Select
+      options={newOptions}
+      aria-label="Fruits"
+      placeholder="Controlled, searchable, creatable"
+      isFilterable
+      value={value}
+      onChange={setValue}
+      onFilter={setSearchTerm}
+      showCreate
+      formatCreateLabel={formatCreateLabel}
+    />
+  )
+}
+```
+
 ## Name and ID
 
 A name and ID can be specified in the `<Select />` component. Names are important if the input is used in the context of a form, in which case a name is required for the value of the input to be captured.


### PR DESCRIPTION
### :sparkles: Changes

- Previously only `SelectMulti` supported `showCreate` and `formatCreateLabel` (when `isFilterable` is true)
- While `SelectMulti` may have more frequent use cases for these props, `Select` also needs them, since it otherwise has no way for the user to enter a custom value
- Noticed and fixed a couple related bugs:
  - `SelectMulti` failing to appropriately show "No options" when `showCreate` is used
  - `Select` overwriting search value with the current option value if the option's value and label are different

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
![59dfa0c4-d522-4730-b93b-7147c9592835](https://user-images.githubusercontent.com/53451193/91902153-20cefc80-ec56-11ea-81f9-cfc5aaa5b7cd.gif)
