### PR TITLE
Fix Popover click outside issue with onMouseUp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Popover` cancel first click outside behavior not working with an `onMouseUp` used anywhere on the page
 - `SelectMulti` failing to appropriately show "No options" when `showCreate` is used
 - `Select` overwriting search value with the current option value if the option's value and label are different
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -369,13 +369,13 @@ function usePopoverToggle(
       // popover was closed via mousedown, but still need to cancel next click
       document.addEventListener('click', handleClickOutside, true)
       // and then cleanup mouseDownTarget
-      document.addEventListener('mouseup', handleMouseUp, true)
+      document.addEventListener('mouseup', handleMouseUp)
     }
 
     return () => {
       document.removeEventListener('mousedown', handleMouseDown, true)
       document.removeEventListener('click', handleClickOutside, true)
-      document.removeEventListener('mouseup', handleMouseUp, true)
+      document.removeEventListener('mouseup', handleMouseUp)
     }
   }, [
     cancelClickOutside,

--- a/storybook/src/Overlays/Popovers/Popover.stories.tsx
+++ b/storybook/src/Overlays/Popovers/Popover.stories.tsx
@@ -74,6 +74,23 @@ const options = [
   { label: 'Pineapples5', value: '45' },
   { label: 'Kiwis5', value: '55' },
 ]
+export const All = () => (
+  <SpaceVertical align="start">
+    <OverlayOpenDialog />
+    <RenderProps />
+    <RenderPropsSpread />
+    <Placement />
+    <PopoverFocusTrap />
+    <Grouped />
+    <MovingTarget />
+    <MouseUp />
+  </SpaceVertical>
+)
+
+export default {
+  component: All,
+  title: 'Overlays/Popover',
+}
 
 export const PopoverFocusTrap = () => {
   function getButtonAlert(text: string) {
@@ -354,6 +371,32 @@ export const MovingTarget = () => {
   )
 }
 
-export default {
-  title: 'Overlays/Popover',
+export const MouseUp = () => {
+  return (
+    <SpaceVertical>
+      <Paragraph>
+        Test that the the 1st click outside is cancelled and that clicking the
+        Popover's trigger a 2nd time closes the Popover
+      </Paragraph>
+      <Paragraph>
+        Previously, the useCapture = true on the mouseup listener caused the
+        click outside behavior to break on any page that has a React onMouseUp
+        on any element.
+      </Paragraph>
+      <Space>
+        <Popover content="Popover 1">
+          <Button>Open 1st Popover</Button>
+        </Popover>
+        <Popover content="Popover 2">
+          <Button>Open 2nd Popover</Button>
+        </Popover>
+        <Button
+          onClick={() => alert('I should be canceled if a Popover was open')}
+        >
+          Click
+        </Button>
+        <Button onMouseUp={() => alert('A simple onMouseUp')}>onMouseUp</Button>
+      </Space>
+    </SpaceVertical>
+  )
 }


### PR DESCRIPTION
### :sparkles: Changes

- Something changed in 16.9 (looked but I couldn't find exactly what it was) such that if a page has both an `onMouseUp` (anywhere) and `click` and `mouseup` event listeners added directly to the `document` with `useCapture=true` _after_ a `mousedown`, the click handler will not be called.
- Removing `useCapture` on the `mouseup` listener fixes this.
- Here's a sandbox showing the issue issue https://codesandbox.io/s/boring-platform-tbbf4
- See it fixed at [your local storybook]/?path=/story/overlays-popover--mouse-up
- To see it without `@looker/components`, check out this sandbox: https://codesandbox.io/s/magical-bush-70ngs
- I tried capturing this with a unit test but apparently jsdom is not subject to this behavior.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC
