### PR TITLE
ActionListItemAction: Renamed "role" prop to "itemRole" prop

### DIFF
--- a/packages/components/src/ActionList/ActionListItemAction.tsx
+++ b/packages/components/src/ActionList/ActionListItemAction.tsx
@@ -34,7 +34,12 @@ export interface ActionListItemActionProps
   children?: ReactNode
   detail?: ReactNode
   icon?: IconNames
-  role?: 'button' | 'link'
+  /**
+   * Determines if the ActionListItemAction is an <a/> or <button/> element
+   * Note: The value passed into this prop is passed into the underlying MenuItem's itemRole prop
+   * @default 'button'
+   */
+  itemRole?: 'link' | 'button'
 }
 
 /**


### PR DESCRIPTION
### :sparkles: Changes

- `ActionListItemAction` Renamed "role" prop to "itemRole" prop
  - The purpose of the prop is to pass either "link" or "button" down to the underlying `MenuItem`'s `itemRole` prop. However, the name of that prop on `ActionListItemAction` was `role` rather than `itemRole`. Because props from `ActionListItemAction` are destructured  onto the underlying `MenuItem`, the underlying `MenuItem` was not able to receive a value for its `itemRole` via the `ActionListItemAction`.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
`itemRole` prop receiving "link", "button", and not being used:
![Screen Shot 2020-09-03 at 2 00 38 PM](https://user-images.githubusercontent.com/16812885/92166798-16e00180-edee-11ea-9e84-9abe32434425.png)

`ActionListItemAction` with `itemRole="link"`:
![Screen Shot 2020-09-03 at 2 01 22 PM](https://user-images.githubusercontent.com/16812885/92166930-5c043380-edee-11ea-8d05-37d211614f4d.png)

`ActionListItemAction` with `itemRole="button"`:
![Screen Shot 2020-09-03 at 2 01 30 PM](https://user-images.githubusercontent.com/16812885/92166896-4d1d8100-edee-11ea-9819-e9924e0677fd.png)

`ActionListItemAction` with no explicitly passed in `itemRole` prop:
![Screen Shot 2020-09-03 at 2 01 44 PM](https://user-images.githubusercontent.com/16812885/92166920-56a6e900-edee-11ea-8599-db30ced3297d.png)
