### PR TITLE
Prompt clearOnCancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Default values changed (now `body='Roboto'`, `brand='Red Hat Display'`, `code='Roboto Mono'`)
 - `theme.fontWeights.extraBold` & `theme.fontWeights.light` removed
 - `Tree` child `AccordionDisclosure` now receives font-weight value from styled-components selector
+- `Prompt` / `usePrompt` now _optionally_ support `clearOnCancel` behavior
 
 ### Fixed
 

--- a/packages/components/src/Dialog/Prompt/Prompt.test.tsx
+++ b/packages/components/src/Dialog/Prompt/Prompt.test.tsx
@@ -110,9 +110,32 @@ test('<Prompt/> with custom props', () => {
   expect(onSaveCallback).toHaveBeenCalledTimes(0)
 })
 
-test('<Prompt /> clears value after closing', () => {
+test('<Prompt /> does not clear value after closing', () => {
   const { getByText, getByPlaceholderText } = renderWithTheme(
     <Prompt {...requiredProps}>
+      {(open) => <Button onClick={open}>Open Prompt</Button>}
+    </Prompt>
+  )
+
+  const opener = getByText('Open Prompt')
+  fireEvent.click(opener)
+
+  const cancelButton = getByText('Cancel')
+  let input = getByPlaceholderText(requiredProps.inputLabel)
+
+  fireEvent.change(input, { target: { value: 'Hello World' } })
+  expect(input).toHaveValue('Hello World')
+  fireEvent.click(cancelButton)
+
+  fireEvent.click(opener)
+  // Note: Need to re-query for the input; not doing so results in stale value on the input element
+  input = getByPlaceholderText(requiredProps.inputLabel)
+  expect(input).toHaveValue('Hello World')
+})
+
+test('<Prompt /> clears value after closing with clearOnCancel', () => {
+  const { getByText, getByPlaceholderText } = renderWithTheme(
+    <Prompt clearOnCancel {...requiredProps}>
       {(open) => <Button onClick={open}>Open Prompt</Button>}
     </Prompt>
   )

--- a/packages/components/src/Dialog/Prompt/PromptDialog.tsx
+++ b/packages/components/src/Dialog/Prompt/PromptDialog.tsx
@@ -81,6 +81,11 @@ export interface PromptBaseProps {
    * A React Element that is placed at the bottom left of the dialog
    */
   secondary?: ReactNode
+  /**
+   * clearOnCancel
+   * @default false
+   */
+  clearOnCancel?: boolean
 }
 
 export interface PromptDialogProps extends PromptBaseProps {
@@ -107,6 +112,7 @@ export const PromptDialog: FC<PromptDialogProps> = ({
   defaultValue = '',
   close,
   isOpen,
+  clearOnCancel,
 }) => {
   const [value, setValue] = useState(defaultValue)
   const hasValue = !!value.trim()
@@ -116,7 +122,6 @@ export const PromptDialog: FC<PromptDialogProps> = ({
   }, [defaultValue])
 
   const handleClose = useCallback(() => {
-    setValue('')
     close()
   }, [close])
 
@@ -134,7 +139,9 @@ export const PromptDialog: FC<PromptDialogProps> = ({
     } else {
       handleClose()
     }
-  }, [handleClose, onCancel])
+
+    clearOnCancel && setValue('')
+  }, [clearOnCancel, handleClose, onCancel])
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && hasValue) {

--- a/storybook/src/Overlays/Prompt.stories.tsx
+++ b/storybook/src/Overlays/Prompt.stories.tsx
@@ -23,18 +23,10 @@
  SOFTWARE.
 
  */
-import React, { FC } from 'react'
-import { Button, Prompt, Space, usePrompt } from '@looker/components'
-
-export const All = () => (
-  <Space>
-    <Basic />
-    <Hook />
-  </Space>
-)
+import React, { FC, useState } from 'react'
+import { Button, Prompt, usePrompt } from '@looker/components'
 
 export default {
-  component: All,
   title: 'Overlays/Prompt',
 }
 
@@ -66,15 +58,23 @@ export const Basic: FC = () => {
 }
 
 export const Hook = () => {
+  const [tracking, setTracking] = useState('pizza')
+
   const [prompt, open] = usePrompt({
+    clearOnCancel: true,
+    defaultValue: tracking,
     inputLabel: 'Name of Cheese',
-    onSave: (value: string) => alert(`You chose ${value}`),
+    onSave: (value: string, close: () => void) => {
+      close()
+      setTracking(`${value} saved`)
+    },
     saveLabel: 'Save',
     title: 'Choose a cheese!',
   })
 
   return (
     <>
+      <p>Value: {tracking}</p>
       {prompt}
       <Button onClick={open}>usePrompt</Button>
     </>

--- a/www/src/documentation/components/dialogs/prompt.mdx
+++ b/www/src/documentation/components/dialogs/prompt.mdx
@@ -16,7 +16,10 @@ However, unlike the `<Confirm/>`, the `<Prompt/>` component comes with a built i
     alert('Prompt closed')
     close()
   }}
-  onSave={(value) => alert(`You chose ${value}`)}
+  onSave={(value, close) => {
+    alert(`You chose ${value}`)
+    close()
+  }}
 >
   {(open) => <Button onClick={open}>Prompt</Button>}
 </Prompt>


### PR DESCRIPTION
### :sparkles: Changes

- `Prompt` no longer does `clearOnCancel` by default (but can optionally enable it if desired)

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
