### PR TITLE
Add new feedback outline icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Select` now supports `showCreate` and `formatCreateLabel` that were previously only supported in `SelectMulti`
 - `GoogleFontsLoader`
 - `ComponentsProvider` now supports `loadGoogleFonts` which leverages `GoogleFontsLoader`
+- New `FeedbackOutline` icon artwork
 
 ### Changed
 

--- a/packages/icons/src/svg/FeedbackOutline.svg
+++ b/packages/icons/src/svg/FeedbackOutline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 2H4C2.9 2 2.01 2.9 2.01 4L2 22L6 18H20C21.1 18 22 17.1 22 16V4C22 2.9 21.1 2 20 2ZM20 16H5.17L4.58 16.59L4 17.17V4H20V16ZM11 12H13V14H11V12ZM11 6H13V10H11V6Z" fill="#1C2125"/>
+</svg>


### PR DESCRIPTION
### :sparkles: Changes

Adds `FeedbackOutline` icon

![image](https://user-images.githubusercontent.com/170681/92794211-3f26ad80-f364-11ea-859d-f783d31ac242.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
