### PR TITLE
TabList changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-- `TabList` now supports `SpaceProps` and `fontSize`
+- `TabList` now supports `PaddingProps` and `fontSize`
 - `TabList` w/ `distribute` now uses default "small" `fontSize`
 
 - Preview: `InputFilters` component and tests (this component is not yet ready for general-use)
@@ -44,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Default values changed (now `body='Roboto'`, `brand='Red Hat Display'`, `code='Roboto Mono'`)
 - `theme.fontWeights.extraBold` & `theme.fontWeights.light` removed
 - `Tree` child `AccordionDisclosure` now receives font-weight value from styled-components selector
-- `Prompt` / `usePrompt` now _optionally_ support `clearOnCancel` behavior
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- `TabList` now supports `SpaceProps` and `fontSize`
+- `TabList` w/ `distribute` now uses default "small" `fontSize`
+
 - Preview: `InputFilters` component and tests (this component is not yet ready for general-use)
 - Preview: `ActionListControls` component (this component is not yet ready for general-use)
 
@@ -41,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Default values changed (now `body='Roboto'`, `brand='Red Hat Display'`, `code='Roboto Mono'`)
 - `theme.fontWeights.extraBold` & `theme.fontWeights.light` removed
 - `Tree` child `AccordionDisclosure` now receives font-weight value from styled-components selector
+- `Prompt` / `usePrompt` now _optionally_ support `clearOnCancel` behavior
 
 ### Fixed
 

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -32,14 +32,19 @@ import React, {
   useRef,
   Ref,
 } from 'react'
-import { SpaceProps, space } from '@looker/design-tokens'
+import {
+  fontSize,
+  FontSizeProps,
+  PaddingProps,
+  padding,
+  reset,
+} from '@looker/design-tokens'
 import styled, { css } from 'styled-components'
-import { fontSize, FontSizeProps } from 'styled-system'
 import { moveFocus, useForkedRef } from '../utils'
 import { TabContext } from './TabContext'
 import { Tab } from '.'
 
-export interface TabListProps extends SpaceProps, FontSizeProps {
+export interface TabListProps extends PaddingProps, FontSizeProps {
   children: JSX.Element[]
   selectedIndex?: number
   onSelectTab?: (index: any) => void
@@ -122,7 +127,8 @@ const distributeCSS = css`
 `
 
 export const TabList = styled(TabListLayout)`
-  ${space}
+  ${reset}
+  ${padding}
   ${fontSize}
 
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -32,12 +32,14 @@ import React, {
   useRef,
   Ref,
 } from 'react'
+import { SpaceProps, space } from '@looker/design-tokens'
 import styled, { css } from 'styled-components'
+import { fontSize, FontSizeProps } from 'styled-system'
 import { moveFocus, useForkedRef } from '../utils'
 import { TabContext } from './TabContext'
 import { Tab } from '.'
 
-export interface TabListProps {
+export interface TabListProps extends SpaceProps, FontSizeProps {
   children: JSX.Element[]
   selectedIndex?: number
   onSelectTab?: (index: any) => void
@@ -115,12 +117,14 @@ const distributeCSS = css`
   grid-auto-flow: column;
 
   ${Tab} {
-    font-size: ${(props) => props.theme.fontSizes.xsmall};
     padding: ${({ theme: { space } }) => `${space.xsmall} ${space.medium}`};
   }
 `
 
 export const TabList = styled(TabListLayout)`
+  ${space}
+  ${fontSize}
+
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};
   -ms-overflow-style: none; /* Internet Explorer 10+ */
   overflow-x: auto;
@@ -133,3 +137,7 @@ export const TabList = styled(TabListLayout)`
 
   ${({ distribute }) => (distribute ? distributeCSS : defaultLayoutCSS)}
 `
+
+TabList.defaultProps = {
+  fontSize: 'small',
+}

--- a/packages/design-tokens/src/system/index.ts
+++ b/packages/design-tokens/src/system/index.ts
@@ -31,6 +31,7 @@ export {
   color,
   display,
   flexbox,
+  fontSize,
   height,
   layout,
   overflow,


### PR DESCRIPTION
### :sparkles: Changes

- Tablist supports fontSize
- TabList supports SpacingProps
- `fontSize` = small regardless of `distribute` prop

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
