### PR TITLE
Update spacing and font weight on form labels

### DIFF
--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -169,7 +169,7 @@ const fieldLabelCSS = (inline?: boolean) =>
       `
     : css`
         line-height: ${({ theme }) => theme.lineHeights.xsmall};
-        padding-bottom: ${({ theme }) => theme.space.xsmall};
+        padding-bottom: ${({ theme }) => theme.space.xxsmall};
       `
 
 export const Field = styled(FieldLayout)<FieldPropsInternal>`

--- a/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldCheckbox/__snapshots__/FieldCheckbox.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`A FieldCheckbox 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c0 {
@@ -240,7 +240,7 @@ exports[`A FieldCheckbox with checked value 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c0 {

--- a/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldRadio/__snapshots__/FieldRadio.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`A FieldRadio 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c0 {
@@ -233,7 +233,7 @@ exports[`A FieldRadio checked 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c0 {

--- a/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldText/__snapshots__/FieldText.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`A FieldText with default label 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c4 {
@@ -138,7 +138,7 @@ exports[`A FieldText with default label 1`] = `
 .c0 > .c1 {
   grid-area: label;
   line-height: 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
 .c0 .c10 {
@@ -282,7 +282,7 @@ exports[`A FieldText with label inline 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c4 {
@@ -304,7 +304,7 @@ exports[`A FieldText with label inline 1`] = `
 .c8 > .c1 {
   grid-area: label;
   line-height: 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
 .c0 {

--- a/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldTextArea/__snapshots__/FieldTextArea.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`A FieldTextArea with default label 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c4 {
@@ -83,7 +83,7 @@ exports[`A FieldTextArea with default label 1`] = `
 .c0 > .c1 {
   grid-area: label;
   line-height: 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
 .c0 .c9 {
@@ -169,7 +169,7 @@ exports[`A FieldTextArea with label inline 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c4 {
@@ -191,7 +191,7 @@ exports[`A FieldTextArea with label inline 1`] = `
 .c7 > .c1 {
   grid-area: label;
   line-height: 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
 .c0 {

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/__snapshots__/FieldToggleSwitch.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`A FieldToggleSwitch 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c0 {
@@ -204,7 +204,7 @@ exports[`A FieldToggleSwitch turned on 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c0 {

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -131,7 +131,7 @@ const FieldsetLayout = forwardRef(
 
     const content = (
       <LayoutComponent
-        gap={gap || (inline ? 'medium' : 'small')}
+        gap={gap || 'medium'}
         ref={ref}
         role="group"
         align="start"

--- a/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/components/src/Form/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`Fieldset 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c8 {
@@ -195,7 +195,7 @@ exports[`Fieldset 1`] = `
 .c4 > .c5 {
   grid-area: label;
   line-height: 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
 .c4 .c16 {
@@ -226,13 +226,13 @@ exports[`Fieldset 1`] = `
 
 @supports (-moz-appearance:none) {
   .c3 {
-    gap: 0.75rem;
+    gap: 1rem;
   }
 }
 
 @supports not (-moz-appearance:none) {
   .c3.c3 > * {
-    margin-top: 0.75rem;
+    margin-top: 1rem;
   }
 
   .c3.c3 > *:first-child {

--- a/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`Checkbox should accept disabled & checked="mixed" 1`] = `
 >
   <input
     aria-checked="mixed"
-    checked={true}
+    checked={false}
     disabled={true}
     id="checkboxID"
     onChange={[Function]}
@@ -697,7 +697,7 @@ exports[`Checkbox should accept readOnly & checked="mixed" 1`] = `
 >
   <input
     aria-checked="mixed"
-    checked={true}
+    checked={false}
     id="checkboxID"
     onChange={[Function]}
     type="checkbox"

--- a/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`Checkbox should accept disabled & checked="mixed" 1`] = `
 >
   <input
     aria-checked="mixed"
-    checked={false}
+    checked={true}
     disabled={true}
     id="checkboxID"
     onChange={[Function]}
@@ -697,7 +697,7 @@ exports[`Checkbox should accept readOnly & checked="mixed" 1`] = `
 >
   <input
     aria-checked="mixed"
-    checked={false}
+    checked={true}
     id="checkboxID"
     onChange={[Function]}
     type="checkbox"

--- a/packages/components/src/Form/Label/Label.tsx
+++ b/packages/components/src/Form/Label/Label.tsx
@@ -39,5 +39,5 @@ export const Label = styled.label<LabelProps>`
   ${reset}
   color: ${({ theme: { colors } }) => colors.text4};
   font-size: ${({ theme: { fontSizes } }) => fontSizes.xsmall};
-  font-weight: ${({ theme: { fontWeights } }) => fontWeights.semiBold};
+  font-weight: ${({ theme: { fontWeights } }) => fontWeights.medium};
 `

--- a/packages/components/src/Form/Label/__snapshots__/Label.test.tsx.snap
+++ b/packages/components/src/Form/Label/__snapshots__/Label.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`A Label 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 <label

--- a/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/components/src/Form/__snapshots__/Form.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Form with one child 1`] = `
   font-family: "Roboto","Noto Sans JP","Noto Sans CJK KR","Noto Sans Arabic UI","Noto Sans Devanagari UI","Noto Sans Hebrew","Noto Sans Thai UI","Helvetica","Arial",sans-serif;
   color: #343C42;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .c5 {
@@ -154,7 +154,7 @@ exports[`Form with one child 1`] = `
 .c1 > .c2 {
   grid-area: label;
   line-height: 1rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
 .c1 .c11 {

--- a/storybook/src/Forms/Fieldset.stories.tsx
+++ b/storybook/src/Forms/Fieldset.stories.tsx
@@ -36,18 +36,12 @@ import {
   Status,
   Tooltip,
   Divider,
+  Form,
 } from '@looker/components'
-
-import styled from 'styled-components'
 
 export default {
   title: 'Forms/Fieldset',
 }
-
-const FieldWrapper = styled.div`
-  margin: 30px auto;
-  width: 600px;
-`
 
 const Fields: FC<{ inline?: boolean }> = ({ inline }) => (
   <>
@@ -69,11 +63,11 @@ const Fields: FC<{ inline?: boolean }> = ({ inline }) => (
 )
 
 export const Basic = () => (
-  <FieldWrapper>
+  <Form m="xxlarge" maxWidth="600px">
     <Fieldset>
       <Fields />
     </Fieldset>
-  </FieldWrapper>
+  </Form>
 )
 
 export const Inline = () => (

--- a/storybook/src/Forms/Fieldset.stories.tsx
+++ b/storybook/src/Forms/Fieldset.stories.tsx
@@ -38,9 +38,16 @@ import {
   Divider,
 } from '@looker/components'
 
+import styled from 'styled-components'
+
 export default {
   title: 'Forms/Fieldset',
 }
+
+const FieldWrapper = styled.div`
+  margin: 30px auto;
+  width: 600px;
+`
 
 const Fields: FC<{ inline?: boolean }> = ({ inline }) => (
   <>
@@ -49,6 +56,7 @@ const Fields: FC<{ inline?: boolean }> = ({ inline }) => (
       placeholder="First name"
       required
       label="First name"
+      description="This is a description"
     />
     <FieldText inline={inline} label="Middle" placeholder="Middle" />
     <FieldText
@@ -61,9 +69,11 @@ const Fields: FC<{ inline?: boolean }> = ({ inline }) => (
 )
 
 export const Basic = () => (
-  <Fieldset>
-    <Fields />
-  </Fieldset>
+  <FieldWrapper>
+    <Fieldset>
+      <Fields />
+    </Fieldset>
+  </FieldWrapper>
 )
 
 export const Inline = () => (


### PR DESCRIPTION
### :sparkles: Changes

Refines the spacing between `Fields` and their `Label`, as well as fields in `FieldSets`.

This also moves label weight to `500` variant

#### Before

![image](https://user-images.githubusercontent.com/170681/93808459-da3f4300-fc00-11ea-9aa9-ef889fbad5c6.png)

---
#### After

![image](https://user-images.githubusercontent.com/170681/93808354-b67bfd00-fc00-11ea-8a80-d3f13b28461e.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
