### PR TITLE
feat(TreeItem): export the internal TreeItemDetail

### DIFF
--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -237,7 +237,7 @@ export const TreeItemLabel = styled(Space)<TreeItemLabelProps>`
   padding: ${({ theme: { space } }) => space.xxsmall};
 `
 
-const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`
+export const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`
   align-items: center;
   display: flex;
   height: 100%;

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -237,12 +237,10 @@ export const TreeItemLabel = styled(Space)<TreeItemLabelProps>`
   padding: ${({ theme: { space } }) => space.xxsmall};
 `
 
-export const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`
+const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`
   align-items: center;
   display: flex;
   height: 100%;
-  padding-right: ${({ detailAccessory, theme }) =>
-    detailAccessory && theme.space.xxsmall};
 `
 
 export const TreeItem = styled(TreeItemLayout)`


### PR DESCRIPTION
### :sparkles: Changes

Export the TreeItemDetail component from TreeItem to allow changes on the styling from upstream components.
Today if we want to remove the `padding-right` from the `TreeItemDetail` we can't today because the component is hidden inside the `TreeItem` component. In this case, it is not possible to do:
```
const TreeItemWithoutDetailPadding = styled(TreeItem)`
  ${TreeItemDetail} {
    padding-right: 0
  }
`
```

Exporting the `TreeItemDetail` component allow us to start styling it.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [X] Checked for i18n impacts
- [X] Checked for a11y impacts
- [X] PR is ideally < ~400LOC

### :camera: Screenshots
