### PR TITLE
Elliot/tree padding removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TreeItem` now defaults to `24px` minimum height (was previously `25px`)
 - `HoverDisclosure` toggles visibility with css rather than inserting elements into the DOM
 - `Tooltip` now has a default `maxWidth` of `30rem` (this can be overridden)
+- `Tree`, `TreeItem` removed padding
+- `TreeGroup`, removed horizontal padding
 
 ## [0.9.16] - 2020-10-02
 
@@ -43,17 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storybook configuration improvements
   - `addons-essentials` now used
   - Replace `withKnobs` with `Controls` & `Args`
-
-### Fixed
-
-- Page "jumps" when opening a `Popover` due to the scrollbar disappearing
-
-### Preview / Experimental
-
-- Experimental: `@looker/components-theme-editor` package
-- Preview: `InputFilters` component and tests (this component is not yet ready for general-use)
-- Preview: `ActionListControls` component (this component is not yet ready for general-use)
-- Preview: "Semantic" Layout components - `Layout`, `Header`, `Footer`, `Aside`
 
 ## [0.9.15] - 2020-09-21
 

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -190,10 +190,10 @@ const generateTreeBorder = (depth: number, theme: Theme) => {
 
 const generateIndent = (depth: number, theme: Theme) => {
   const {
-    space: { xxsmall, xsmall, small },
+    space: { none, xsmall, small },
   } = theme
 
-  const itemPaddingSize = xxsmall
+  const itemPaddingSize = none
   const indicatorIconSize = small
   const indicatorGapSize = xsmall
   const indentCalculation = `${itemPaddingSize} + (${indicatorIconSize} + ${indicatorGapSize}) * ${depth}`

--- a/packages/components/src/Tree/TreeGroup.tsx
+++ b/packages/components/src/Tree/TreeGroup.tsx
@@ -54,8 +54,7 @@ export const TreeGroupLabel = styled.div`
   border: 1px transparent solid;
   font-size: ${({ theme }) => theme.fontSizes.xxsmall};
   font-weight: ${({ theme }) => theme.fontWeights.semiBold};
-  padding: ${({ theme: { space } }) =>
-    `${space.xxsmall} ${space.xxsmall} ${space.xxxsmall}`};
+  padding: ${({ theme: { space } }) => `${space.xxsmall} 0 ${space.xxxsmall}`};
 `
 
 export const TreeGroup = styled(TreeGroupLayout)`

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -251,6 +251,7 @@ export const TreeItemLabel = styled(Space)<TreeItemLabelProps>`
   min-height: ${({ theme }) => theme.sizes.medium};
   min-width: 0;
   outline: none;
+  padding: ${({ theme: { space } }) => space.xxsmall};
 `
 
 const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -251,6 +251,7 @@ export const TreeItemLabel = styled(Space)<TreeItemLabelProps>`
   min-height: ${({ theme }) => theme.sizes.medium};
   min-width: 0;
   outline: none;
+  /* TODO: Make sure to remove this (or just remove px) after Truncation PR is merged in */
   padding: ${({ theme: { space } }) => space.xxsmall};
 `
 

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -257,8 +257,6 @@ const TreeItemDetail = styled.div<{ detailAccessory: boolean }>`
   align-items: center;
   display: flex;
   height: 100%;
-  padding-right: ${({ detailAccessory, theme }) =>
-    detailAccessory && theme.space.xxsmall};
 `
 
 export const TreeItem = styled(TreeItemLayout)`


### PR DESCRIPTION
### :sparkles: Changes
- Removed all padding from `Tree`
- Removed all padding from `TreeItem`
- Removed px from `TreeGroup`

**Note:** `Tree` elements still receive left padding using our auto-indent pattern.

It's worth noting that (afaik) these changes do not visually change any of our `Tree` components. Using `display: flex` and `align-items: center` and `height: 25px` essentially handles the "spacing" of `Tree`-related elements.

In addition, `TreeGroup` still has default `py` in order to keep with the Explore Team's desired specs. It might be worth giving `TreeGroup` a set height a similar fashion to `Tree` and `TreeItem`, but then we wouldn't be able to do what we do now which is have different amounts of spacing above and below a `TreeGroup`.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
![Screen Shot 2020-09-25 at 10 38 20 AM](https://user-images.githubusercontent.com/16812885/94299214-31ecef80-ff1c-11ea-84e6-3bc2fc01c1ba.png)
