### PR TITLE
Preparatory work for Styled Components 5 & latest TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "prettier": "^2.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-is": "^16.13.1",
     "styled-components": "^4.4.1",
     "typescript": "^3.8.3",
     "webpack": "^4.44.2"

--- a/packages/components-providers/package.json
+++ b/packages/components-providers/package.json
@@ -22,10 +22,12 @@
     "@types/react": "^16.9.49",
     "@types/styled-components": "^4.4.1",
     "react": "^16.13.1",
+    "react-is": "^16.13.1",
     "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.11",
+    "react-is": "^16.11",
     "styled-components": "^4"
   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"

--- a/packages/components-test-utils/package.json
+++ b/packages/components-test-utils/package.json
@@ -25,11 +25,13 @@
     "enzyme": "^3.11.0",
     "jest-styled-components": "^6.3.4",
     "react": "^16.13.1",
+    "react-is": "^16.13.1",
     "react-test-renderer": "^16.13.1",
     "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.11"
+    "react": "^16.11",
+    "react-is": "^16.11"
   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components-theme-editor/package.json
+++ b/packages/components-theme-editor/package.json
@@ -24,10 +24,12 @@
     "@types/react": "^16.9.49",
     "@types/styled-components": "^4.4.1",
     "react": "^16.13.1",
+    "react-is": "^16.13.1",
     "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.11",
+    "react-is": "^16.11",
     "styled-components": "^4"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,11 +53,13 @@
     "jest-styled-components": "^6.3.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-is": "^16.13.1",
     "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "react": "^16.11",
+    "react-dom": "^16.11",
+    "react-is": "^16.11",
     "styled-components": "^4"
   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"

--- a/packages/components/src/Dialog/Surface.tsx
+++ b/packages/components/src/Dialog/Surface.tsx
@@ -52,7 +52,6 @@ interface SurfaceProps
     ColorProps,
     LayoutProps {
   surfaceStyles?: CSSObject
-  anchor?: 'right'
   animationState?: string
 }
 

--- a/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
@@ -135,7 +135,7 @@ export const InputColorComponent = forwardRef(
     }
 
     const handleColorChange = (hs: HueSaturation) => {
-      setColorState({ h: 0, s: 100, ...hs, v: get(color, 'v', 1) })
+      setColorState({ ...hs, v: get(color, 'v', 1) })
     }
 
     const handleSliderChange = (event: FormEvent<HTMLInputElement>) =>

--- a/packages/components/src/Link/Link.test.tsx
+++ b/packages/components/src/Link/Link.test.tsx
@@ -43,7 +43,7 @@ describe('Link', () => {
   test('Underline', () => {
     renderWithTheme(<Link underline>My link</Link>)
     const link = screen.getByText('My link')
-    expect(link).toHaveStyle('text-decoration: underline')
+    expect(link).toHaveStyleRule('text-decoration: underline')
   })
 
   test('color', () => {

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -25,7 +25,8 @@
  */
 
 import React from 'react'
-import { createWithTheme } from '@looker/components-test-utils'
+import { createWithTheme, renderWithTheme } from '@looker/components-test-utils'
+import { screen } from '@testing-library/react'
 import { List } from './List'
 import { ListItem } from './ListItem'
 
@@ -68,15 +69,16 @@ test('A numerically ordered List', () => {
 })
 
 test('A numerically ordered List marked as nomarker', () => {
-  const component = createWithTheme(
-    <List type="number" nomarker>
+  renderWithTheme(
+    <List type="number" nomarker data-testid="list">
       <ListItem>🥑</ListItem>
       <ListItem>🍕</ListItem>
       <ListItem>🥨</ListItem>
     </List>
   )
-  const tree = component.toJSON()
-  expect(tree).toHaveStyleRule('list-style-type', 'none')
+
+  const list = screen.getByTestId('list')
+  expect(list).toHaveStyle('list-style-type: none')
   // Padding unset due to default reset applied
-  expect(tree).toMatchSnapshot()
+  expect(list).toMatchSnapshot()
 })

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -113,21 +113,22 @@ exports[`A numerically ordered List marked as nomarker 1`] = `
 }
 
 <ol
-  className="c0"
+  class="c0"
+  data-testid="list"
   type="none"
 >
   <li
-    className="c1"
+    class="c1"
   >
     🥑
   </li>
   <li
-    className="c1"
+    class="c1"
   >
     🍕
   </li>
   <li
-    className="c1"
+    class="c1"
   >
     🥨
   </li>

--- a/packages/components/src/utils/getCurrentNode.ts
+++ b/packages/components/src/utils/getCurrentNode.ts
@@ -36,6 +36,7 @@ export function getCurrentNode<E extends HTMLElement = HTMLElement>(
   elementOrRefObject: ElementOrRef<E>
 ): E | null {
   if (!elementOrRefObject) return null
+  // @ts-expect-error: Need to find a better way to do union below
   return (elementOrRefObject as E).addEventListener
     ? (elementOrRefObject as E)
     : (elementOrRefObject as RefObject<E>).current

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -30,11 +30,13 @@
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-is": "^16.13.1",
     "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "react": "^16.11",
+    "react-dom": "^16.11",
+    "react-is": "^16.11",
     "styled-components": "^4"
   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,6 +18,7 @@
     "core-js": "^3.6.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-is": "^16.13.1",
     "styled-components": "^4.4.1"
   },
   "devDependencies": {

--- a/www/package.json
+++ b/www/package.json
@@ -27,6 +27,7 @@
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
+    "react-is": "^16.13.1",
     "react-helmet": "^6.1.0",
     "react-live": "^2.2.2",
     "styled-components": "^4.4.1"


### PR DESCRIPTION
### :sparkles: Changes

This pulls in a small collection of changes that will be needed when we make the upgrade to Styled Components 5. 

While that upgrade is waiting for our repository migration I figured it'd make sense to incorporate these changes so we're ready to go when we can do the upgrade freely.


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
