### PR TITLE
[draft] Use consistent icon sizes across components

### DIFF
--- a/packages/components/src/Button/ButtonBase.tsx
+++ b/packages/components/src/Button/ButtonBase.tsx
@@ -42,8 +42,13 @@ import {
   WidthProps,
   width,
 } from 'styled-system'
-import { buttonSize, ButtonSizes, ButtonSizeProps } from './size'
-import { ButtonIcon, buttonIcon, ButtonIconProps } from './icon'
+import {
+  buttonSize,
+  ButtonSizes,
+  ButtonSizeProps,
+  iconInButtonSizeMap,
+} from './size'
+import { ButtonIcon, buttonIcon, ButtonIconProps, iconSizes } from './icon'
 
 export interface ButtonBaseProps
   extends Omit<CompatibleHTMLProps<HTMLButtonElement>, 'type'>,
@@ -135,6 +140,8 @@ const ButtonJSX = forwardRef(
       onBlur && onBlur(event)
     }
 
+    const iconSize = iconInButtonSizeMap[props.size || 'small']
+
     return (
       <ButtonOuter
         {...restProps}
@@ -143,9 +150,9 @@ const ButtonJSX = forwardRef(
         onBlur={handleOnBlur}
         ref={ref}
       >
-        {iconBefore && <ButtonIcon name={iconBefore} />}
+        {iconBefore && <ButtonIcon name={iconBefore} size={iconSize} />}
         {children}
-        {iconAfter && <ButtonIcon name={iconAfter} />}
+        {iconAfter && <ButtonIcon name={iconAfter} size={iconSize} />}
       </ButtonOuter>
     )
   }

--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -49,7 +49,7 @@ import { useTooltip } from '../Tooltip'
 import { useForkedRef, useWrapEvent } from '../utils'
 import { VisuallyHidden } from '../VisuallyHidden'
 import { ButtonBase, ButtonBaseProps, buttonCSS } from './ButtonBase'
-import { buttonSizeMap } from './size'
+import { iconInButtonSizeMap, buttonSizeMap } from './size'
 
 const iconButtonDefaultColor = 'neutral'
 
@@ -194,7 +194,7 @@ const IconButtonComponent = forwardRef(
         {...rest}
       >
         <VisuallyHidden>{label}</VisuallyHidden>
-        <Icon name={icon} size={buttonSizeMap[size] - 6} aria-hidden={true} />
+        <Icon name={icon} size={iconInButtonSizeMap[size]} aria-hidden={true} />
         {tooltip}
       </ButtonBase>
     )

--- a/packages/components/src/Button/icon.ts
+++ b/packages/components/src/Button/icon.ts
@@ -72,18 +72,18 @@ export const iconSizes = (props: ButtonProps) => {
   let iconSize = 18
   switch (props.size) {
     case 'xxsmall':
-    case 'xsmall':
       iconSize = 12
       break
+    case 'xsmall':
     case 'small':
       iconSize = 16
       break
     case 'large':
-      iconSize = 20
+      iconSize = 18
       break
     case 'medium':
     default:
-      iconSize = 18
+      iconSize = 20
   }
 
   return css`
@@ -97,6 +97,5 @@ export const ButtonIcon = styled(Icon)``
 export const buttonIcon = (props: ButtonProps) => css`
   ${ButtonIcon} {
     ${iconMargins(props)}
-    ${iconSizes(props)}
   }
 `

--- a/packages/components/src/Button/icon.ts
+++ b/packages/components/src/Button/icon.ts
@@ -68,30 +68,6 @@ export const iconMargins = (props: ButtonProps) => {
   }
 }
 
-export const iconSizes = (props: ButtonProps) => {
-  let iconSize = 18
-  switch (props.size) {
-    case 'xxsmall':
-      iconSize = 12
-      break
-    case 'xsmall':
-    case 'small':
-      iconSize = 16
-      break
-    case 'large':
-      iconSize = 18
-      break
-    case 'medium':
-    default:
-      iconSize = 20
-  }
-
-  return css`
-    height: ${iconSize}px;
-    width: ${iconSize}px;
-  `
-}
-
 export const ButtonIcon = styled(Icon)``
 
 export const buttonIcon = (props: ButtonProps) => css`

--- a/packages/components/src/Button/size.ts
+++ b/packages/components/src/Button/size.ts
@@ -63,6 +63,14 @@ export const buttonSizeMap = {
   medium: 36,
   large: 44,
 }
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+export const iconInButtonSizeMap = {
+  xxsmall: 'xxsmall',
+  xsmall: 'xsmall',
+  small: 'xsmall',
+  medium: 'small',
+  large: 'medium',
+}
 
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 export const buttonSize = variant({

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -151,7 +151,7 @@ const InputTextLayout = forwardRef(
     const iconBeforeOrPrefix = (iconBefore || typeof before === 'string') && (
       <InputTextContent pl="xxsmall">
         {iconBefore ? (
-          <Icon name={iconBefore} title={iconBeforeTitle} size={20} />
+          <Icon name={iconBefore} title={iconBeforeTitle} size="small" />
         ) : (
           <Text fontSize="small">{before}</Text>
         )}
@@ -163,7 +163,7 @@ const InputTextLayout = forwardRef(
     const iconAfterOrSuffix = (iconAfter || typeof after === 'string') && (
       <InputTextContent pl="xsmall" pr="xxsmall">
         {iconAfter ? (
-          <Icon name={iconAfter} title={iconAfterTitle} size={20} />
+          <Icon name={iconAfter} title={iconAfterTitle} size="small" />
         ) : (
           <Text fontSize="small">{after}</Text>
         )}

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -142,7 +142,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
         artwork={iconArtwork}
         color="text1"
         name={icon}
-        size={24 / (compact ? 1.25 : 1)}
+        size={compact ? 'small' : 'medium'}
         mr="xsmall"
       />
     ) : (
@@ -151,7 +151,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
           aria-hidden
           data-testid={`menu-item-${renderedIconID}-icon-placeholder`}
           mr="xsmall"
-          size={24 / (compact ? 1.25 : 1)}
+          size={compact ? 'small' : 'medium'}
         />
       )
     )

--- a/storybook/src/Icon.stories.tsx
+++ b/storybook/src/Icon.stories.tsx
@@ -48,7 +48,6 @@ export const Sizes = () => (
       <Icon name="Trash" size="small" />
       <Icon name="Trash" size="medium" />
       <Icon name="Trash" size="large" />
-      <Icon name="Trash" />
     </Space>
   </SpaceVertical>
 )


### PR DESCRIPTION
### :sparkles: Changes

This PR adjust icons in various components to ensure consistent sizing 

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
