### PR TITLE
feat(TreeItem/TreeItemLabel): change the TreeItemLabel hover behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Storybook configuration improvements
   - `addons-essentials` now used
   - Replace `withKnobs` with `Controls` & `Args`
+- `TreeItemLabel` keep the hover behavior for selected `TreeItem`
 
 ## [0.9.15] - 2020-09-21
 

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -229,7 +229,7 @@ interface TreeItemLabelProps {
 
 export const TreeItemLabel = styled(Space)<TreeItemLabelProps>`
   background-color: ${({ hovered, selected }) =>
-    selected ? uiTransparencyBlend(1) : hovered && uiTransparencyBlend(2)};
+    hovered ? uiTransparencyBlend(2) : selected && uiTransparencyBlend(1)};
   flex: 1;
   font-size: ${({ theme: { fontSizes } }) => fontSizes.xsmall};
   height: 100%;


### PR DESCRIPTION
### :sparkles: Changes

The current behavior turn off the hover when the tree item is selected.
On this PR we change the logic so TreeItemLabel always have a hover state, even when selected.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [X] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [X] PR is ideally < ~400LOC

