### PR TITLE
Fix lodash import to "single method"

### DIFF
--- a/packages/components/src/Form/Inputs/InputFilters/InputFilters.tsx
+++ b/packages/components/src/Form/Inputs/InputFilters/InputFilters.tsx
@@ -26,7 +26,7 @@
 
 import styled from 'styled-components'
 import React, { FC, useState, useRef } from 'react'
-import { partition } from 'lodash'
+import partition from 'lodash/partition'
 import { Select } from '../Select'
 import { InputText } from '../InputText'
 import { Icon } from '../../../Icon'


### PR DESCRIPTION
Would it be worth adding `eslint-plugin-lodash` to the `eslint-config` package if just for the import-scope rule?

https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/import-scope.md