### PR TITLE
feat(TreeGroup): change the TreeGroup.label type to ReactNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- `TreeGroup` now can accept components as label
+
 ## [0.9.16] - 2020-10-02
 
 ### Added

--- a/packages/components/src/Tree/TreeGroup.test.tsx
+++ b/packages/components/src/Tree/TreeGroup.test.tsx
@@ -26,6 +26,8 @@
 
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
+import { Icon } from '../Icon'
+import { Text } from '../Text'
 import { TreeGroup, Tree, TreeItem } from '.'
 
 test('Renders label and children', () => {
@@ -34,6 +36,21 @@ test('Renders label and children', () => {
   )
 
   getByText('My Tree Group')
+  getByText('My Children')
+})
+
+test('renders components as label', () => {
+  const label = (
+    <span>
+      <Icon name="ChartPie" />
+      <Text>&nbsp;Visualizations</Text>
+    </span>
+  )
+  const { getByText } = renderWithTheme(
+    <TreeGroup label={label}>My Children</TreeGroup>
+  )
+
+  getByText('Visualizations')
   getByText('My Children')
 })
 

--- a/packages/components/src/Tree/TreeGroup.tsx
+++ b/packages/components/src/Tree/TreeGroup.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled from 'styled-components'
 import { color, TextColorProps } from '@looker/design-tokens'
 import { AccordionDisclosure } from '../Accordion'
@@ -34,7 +34,7 @@ export interface TreeGroupProps extends TextColorProps {
   /**
    * Visible label of the TreeGroup
    */
-  label: string
+  label: ReactNode
   className?: string
 }
 

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -350,7 +350,7 @@ However, you can override a parent `Tree`'s `detailHoverDisclosure` prop at the 
 
 `TreeGroup` can be used to label a grouping of `TreeItem`s. `TreeGroup` should be the child of a `Tree`and the parent of one or many `TreeItem`s.
 
-Use the `label` prop to set the text label of the `TreeGroup`.
+Use the `label` prop to set the label of the `TreeGroup`.
 
 Use the `color` prop to set the text color of both the `TreeGroup` and all of its children.
 


### PR DESCRIPTION
### :sparkles: Changes
Change the `TreeGroup.label` property type to a broader type ( ReactNode ). This change give more flexibility for the `TreeGroup` label, allowing us to use more complex components as a label.

### :white_check_mark: Requirements

- [X] Includes test coverage for all changes
- [X] Build and tests are passing
- [X] Update documentation
- [X] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [X] PR is ideally < ~400LOC
