### PR TITLE
Move prismTheme to www package + upgrade PrismJS

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -34,7 +34,6 @@
     "@types/styled-components": "^4.4.1",
     "csstype": "^3.0.2",
     "lodash": "^4.17.20",
-    "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-is": "^16.13.1",

--- a/www/package.json
+++ b/www/package.json
@@ -23,6 +23,7 @@
     "gatsby-source-filesystem": "^2.3.32",
     "lodash": "^4.17.20",
     "polished": "^3.6.7",
+    "prismjs": "^1.21.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",
@@ -35,5 +36,8 @@
   "scripts": {
     "build": "gatsby build",
     "start": "gatsby develop --host 0.0.0.0"
+  },
+  "resolutions": {
+    "prismjs": "^1.21.0"
   }
 }

--- a/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/www/src/MDX/Pre/CodeSandbox.tsx
@@ -25,7 +25,6 @@
  */
 
 import { Icon, IconButton, IconNames, Tooltip } from '@looker/components'
-import { prismTheme } from '@looker/design-tokens'
 import { PrismTheme, Language } from 'prism-react-renderer'
 import React, { FC, ReactNode, useState, useCallback } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
@@ -38,6 +37,7 @@ import {
 } from 'react-live'
 import styled from 'styled-components'
 import { allComponents } from './allComponents'
+import { prismTheme } from './prismTheme'
 
 interface CodeSandboxProps {
   code: string
@@ -213,14 +213,14 @@ const ActionButton = styled(IconButton)<ActionProps>`
 `
 
 const ActionLayout = styled.div<ActionProps>`
-  transition: background 0.35s;
-  width: auto;
+  background: ${({ theme, editorIsVisible }) =>
+    editorIsVisible ? theme.colors.ui5 : theme.colors.ui2};
   display: grid;
   grid-template-rows: auto auto 1fr;
   justify-content: right;
   padding: ${({ theme }) => `${theme.space.xsmall}`};
-  background: ${({ theme, editorIsVisible }) =>
-    editorIsVisible ? theme.colors.ui5 : theme.colors.ui2};
+  transition: background 350ms;
+  width: auto;
 `
 
 const SandboxWrapper = styled.div`
@@ -229,7 +229,7 @@ const SandboxWrapper = styled.div`
     margin-bottom: ${lineHeights.medium};
     border: 1px solid ${colors.ui2};
     border-radius: ${radii.medium};
-    color: ${colors.white};
+    color: ${colors.background};
   `}
 `
 
@@ -241,9 +241,9 @@ const PreviewWrapper = styled.div`
 
 const EditorWrapper = styled.div`
   background: ${({ theme }) => theme.colors.ui5};
-  line-height: ${({ theme }) => theme.lineHeights.medium};
   display: grid;
   grid-template-columns: 1fr auto;
+  line-height: ${({ theme }) => theme.lineHeights.medium};
   textarea,
   pre {
     ${({ theme: { space } }) => `
@@ -267,16 +267,15 @@ const ErrorWrapper = styled.div`
 `
 
 const IconWrapper = styled.div`
-  width: 45px;
-  height: 45px;
-  border-radius: 100%;
-  display: grid;
-  justify-content: center;
   align-content: center;
-  ${({ theme: { colors } }) => `
-    background: ${colors.critical};
-    color: ${colors.inverseOn};
-  `}
+  background: ${({ theme }) => theme.colors.critical};
+  border-radius: 100%;
+  color: ${({ theme }) => theme.colors.inverseOn};
+  display: grid;
+  height: 45px;
+  justify-content: center;
+  width: 45px;
+
   svg {
     transform: translateY(-2px);
   }

--- a/www/src/MDX/Pre/CodeStatic.tsx
+++ b/www/src/MDX/Pre/CodeStatic.tsx
@@ -25,9 +25,9 @@
  */
 
 import Highlight, { defaultProps, Language } from 'prism-react-renderer'
-import { prismTheme } from '@looker/design-tokens'
 import styled from 'styled-components'
 import React, { FC } from 'react'
+import { prismTheme } from './prismTheme'
 
 interface CodeStaticProps {
   code: string
@@ -68,5 +68,5 @@ const PreWrapper = styled.pre`
     padding: ${space.medium};
     line-height: ${lineHeights.medium};
     margin: ${lineHeights.medium} 0;
-  `};
+  `}
 `

--- a/www/src/MDX/Pre/prismTheme.ts
+++ b/www/src/MDX/Pre/prismTheme.ts
@@ -25,8 +25,9 @@
  */
 
 import { PrismTheme } from 'prism-react-renderer'
-import { theme } from './theme'
-import {
+import { palette, theme } from '@looker/design-tokens'
+
+const {
   blue200,
   blue400,
   green300,
@@ -34,8 +35,7 @@ import {
   red300,
   yellow200,
   yellow300,
-} from './legacy/palette'
-
+} = palette
 const { inverse, text1 } = theme.colors
 
 export const prismTheme: PrismTheme = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17741,6 +17741,13 @@ prism-react-renderer@^1.0.1, prism-react-renderer@^1.1.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
   integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
 
+prismjs@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
+  integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 prismjs@^1.8.4:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.20.0.tgz#9b685fc480a3514ee7198eac6a3bf5024319ff03"


### PR DESCRIPTION
### :sparkles: Changes

- Move prismTheme to www package
- Remove prism devDependency from design-tokens
- Upgrade PrismJS to address security vulnerability documented at: https://github.com/looker-open-source/components/network/alert/yarn.lock/prismjs/open

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
