### PR TITLE
Properly force PrismJS version = 1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
   },
   "resolutions": {
     "node-fetch": "2.6.1",
-    "node-forge": "0.10.0"
+    "node-forge": "0.10.0",
+    "prismjs": "1.21.0"
   },
   "lint-staged": {
     "**/*.ts?(x)": [

--- a/www/package.json
+++ b/www/package.json
@@ -23,7 +23,6 @@
     "gatsby-source-filesystem": "^2.3.32",
     "lodash": "^4.17.20",
     "polished": "^3.6.7",
-    "prismjs": "^1.21.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",
@@ -36,8 +35,5 @@
   "scripts": {
     "build": "gatsby build",
     "start": "gatsby develop --host 0.0.0.0"
-  },
-  "resolutions": {
-    "prismjs": "^1.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17728,24 +17728,10 @@ prism-react-renderer@^1.0.1, prism-react-renderer@^1.1.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
   integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
 
-prismjs@^1.21.0:
+prismjs@1.21.0, prismjs@^1.8.4, prismjs@~1.17.0:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
   integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==
-  optionalDependencies:
-    clipboard "^2.0.0"
-
-prismjs@^1.8.4:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.20.0.tgz#9b685fc480a3514ee7198eac6a3bf5024319ff03"
-  integrity sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==
-  optionalDependencies:
-    clipboard "^2.0.0"
-
-prismjs@~1.17.0:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
-  integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
   optionalDependencies:
     clipboard "^2.0.0"
 


### PR DESCRIPTION

### :sparkles: Changes

- Address github-reported dependency vulnerability.
- `resolutions` only works in "root" package.json

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
