### PR TITLE
TreeItem: Support Cmd + Enter callback prop

### DIFF
--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -93,7 +93,7 @@ export interface TreeItemProps
    * Callback that is triggered on CMD + Enter on Mac
    * or Windows key + Enter on PC
    */
-  onMetaEnter?: () => void
+  onMetaEnterKeyDown?: () => void
   /**
    * Determines if this TreeItem is in a selected state or not
    */
@@ -108,7 +108,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   children,
   className,
   gapSize = 'xsmall',
-  onMetaEnter,
+  onMetaEnterKeyDown,
   selected,
   truncate,
   ...props
@@ -177,7 +177,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
     }
 
     if (event.keyCode === 13 && event.metaKey) {
-      onMetaEnter && onMetaEnter()
+      onMetaEnterKeyDown && onMetaEnterKeyDown()
     }
 
     onKeyDown && onKeyDown(event)

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -44,6 +44,7 @@ import {
   uiTransparencyBlend,
 } from '@looker/design-tokens'
 import Omit from 'lodash/omit'
+import noop from 'lodash/noop'
 import { Space, FlexItem } from '../Layout'
 import { Icon, IconNames } from '../Icon'
 import { useHovered } from '../utils/useHovered'
@@ -108,7 +109,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   children,
   className,
   gapSize = 'xsmall',
-  onMetaEnter,
+  onMetaEnter = noop,
   selected,
   truncate,
   ...props
@@ -119,7 +120,13 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   const [isHovered] = useHovered(itemRef)
   const [isFocusVisible, setFocusVisible] = useState(false)
 
-  const { onBlur, onClick, onKeyDown, onKeyUp, ...restProps } = Omit(props, [
+  const {
+    onBlur,
+    onClick = noop,
+    onKeyDown,
+    onKeyUp,
+    ...restProps
+  } = Omit(props, [
     'color',
     'detail',
     'detailAccessory',
@@ -168,16 +175,8 @@ const TreeItemLayout: FC<TreeItemProps> = ({
       return
     }
 
-    if (
-      event.key === 'Enter' &&
-      !event.metaKey &&
-      event.target === event.currentTarget
-    ) {
-      onClick && onClick()
-    }
-
-    if (event.key === 'Enter' && event.metaKey) {
-      onMetaEnter && onMetaEnter()
+    if (event.key === 'Enter') {
+      event.metaKey ? onMetaEnter() : onClick()
     }
 
     onKeyDown && onKeyDown(event)

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -93,7 +93,7 @@ export interface TreeItemProps
    * Callback that is triggered on CMD + Enter on Mac
    * or Windows key + Enter on PC
    */
-  onMetaEnterKeyDown?: () => void
+  onMetaEnter?: () => void
   /**
    * Determines if this TreeItem is in a selected state or not
    */
@@ -108,7 +108,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   children,
   className,
   gapSize = 'xsmall',
-  onMetaEnterKeyDown,
+  onMetaEnter,
   selected,
   truncate,
   ...props
@@ -177,7 +177,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
     }
 
     if (event.keyCode === 13 && event.metaKey) {
-      onMetaEnterKeyDown && onMetaEnterKeyDown()
+      onMetaEnter && onMetaEnter()
     }
 
     onKeyDown && onKeyDown(event)

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -90,6 +90,11 @@ export interface TreeItemProps
    */
   onClick?: () => void
   /**
+   * Callback that is triggered on CMD + Enter on Mac
+   * or Windows key + Enter on PC
+   */
+  onMetaEnter?: () => void
+  /**
    * Determines if this TreeItem is in a selected state or not
    */
   selected?: boolean
@@ -103,6 +108,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   children,
   className,
   gapSize = 'xsmall',
+  onMetaEnter,
   selected,
   truncate,
   ...props
@@ -162,8 +168,16 @@ const TreeItemLayout: FC<TreeItemProps> = ({
       return
     }
 
-    if (event.keyCode === 13 && event.target === event.currentTarget) {
+    if (
+      event.keyCode === 13 &&
+      !event.metaKey &&
+      event.target === event.currentTarget
+    ) {
       onClick && onClick()
+    }
+
+    if (event.keyCode === 13 && event.metaKey) {
+      onMetaEnter && onMetaEnter()
     }
 
     onKeyDown && onKeyDown(event)

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -152,7 +152,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   }
 
   const handleKeyUp = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.keyCode === 9 && event.currentTarget === event.target)
+    if (event.key === 'Tab' && event.currentTarget === event.target)
       setFocusVisible(true)
 
     onKeyUp && onKeyUp(event)
@@ -169,15 +169,15 @@ const TreeItemLayout: FC<TreeItemProps> = ({
     }
 
     if (
-      event.keyCode === 13 &&
+      event.key === 'Enter' &&
       !event.metaKey &&
       event.target === event.currentTarget
     ) {
       onClick && onClick()
     }
 
-    if (event.keyCode === 13 && event.metaKey) {
-      onMetaEnter ? onMetaEnter() : onClick && onClick()
+    if (event.key === 'Enter' && event.metaKey) {
+      onMetaEnter && onMetaEnter()
     }
 
     onKeyDown && onKeyDown(event)

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -121,10 +121,10 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   const [isFocusVisible, setFocusVisible] = useState(false)
 
   const {
-    onBlur,
+    onBlur = noop,
     onClick = noop,
-    onKeyDown,
-    onKeyUp,
+    onKeyDown = noop,
+    onKeyUp = noop,
     ...restProps
   } = Omit(props, [
     'color',
@@ -155,14 +155,14 @@ const TreeItemLayout: FC<TreeItemProps> = ({
     }
 
     setFocusVisible(false)
-    onClick && onClick()
+    onClick()
   }
 
   const handleKeyUp = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Tab' && event.currentTarget === event.target)
       setFocusVisible(true)
 
-    onKeyUp && onKeyUp(event)
+    onKeyUp(event)
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -179,12 +179,12 @@ const TreeItemLayout: FC<TreeItemProps> = ({
       event.metaKey ? onMetaEnter() : onClick()
     }
 
-    onKeyDown && onKeyDown(event)
+    onKeyDown(event)
   }
 
   const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
     setFocusVisible(false)
-    onBlur && onBlur(event)
+    onBlur(event)
   }
 
   const defaultIconSize = 12
@@ -198,6 +198,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
   )
 
   const TextWrapper = truncate ? Truncate : Fragment
+  const isTreeItemTabbable = onClick || onMetaEnter ? 0 : -1
 
   return (
     <HoverDisclosureContext.Provider value={{ visible: isHovered }}>
@@ -210,7 +211,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
         ref={itemRef}
-        tabIndex={onClick ? 0 : -1}
+        tabIndex={isTreeItemTabbable}
         {...restProps}
       >
         <TreeItemLabel gap={gapSize} hovered={isHovered} selected={selected}>

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -177,7 +177,7 @@ const TreeItemLayout: FC<TreeItemProps> = ({
     }
 
     if (event.keyCode === 13 && event.metaKey) {
-      onMetaEnter && onMetaEnter()
+      onMetaEnter ? onMetaEnter() : onClick && onClick()
     }
 
     onKeyDown && onKeyDown(event)

--- a/packages/components/src/Tree/stories/FieldPicker.story.tsx
+++ b/packages/components/src/Tree/stories/FieldPicker.story.tsx
@@ -114,7 +114,7 @@ const PickerItem = ({ children = 'Cost', truncate = false }) => {
           }
           detailHoverDisclosure={!overlay}
           onClick={() => alert('Clicked on cost!')}
-          onMetaEnterKeyDown={() => alert("Cmd + Enter'ed on cost!")}
+          onMetaEnter={() => alert("Cmd + Enter'ed on cost!")}
           selected={!!overlay}
           icon="FieldNumber"
         >

--- a/packages/components/src/Tree/stories/FieldPicker.story.tsx
+++ b/packages/components/src/Tree/stories/FieldPicker.story.tsx
@@ -114,6 +114,7 @@ const PickerItem = ({ children = 'Cost', truncate = false }) => {
           }
           detailHoverDisclosure={!overlay}
           onClick={() => alert('Clicked on cost!')}
+          onMetaEnter={() => alert("Cmd + Enter'ed on cost!")}
           selected={!!overlay}
           icon="FieldNumber"
         >

--- a/packages/components/src/Tree/stories/FieldPicker.story.tsx
+++ b/packages/components/src/Tree/stories/FieldPicker.story.tsx
@@ -114,7 +114,7 @@ const PickerItem = ({ children = 'Cost', truncate = false }) => {
           }
           detailHoverDisclosure={!overlay}
           onClick={() => alert('Clicked on cost!')}
-          onMetaEnter={() => alert("Cmd + Enter'ed on cost!")}
+          onMetaEnterKeyDown={() => alert("Cmd + Enter'ed on cost!")}
           selected={!!overlay}
           icon="FieldNumber"
         >

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -181,12 +181,17 @@ Use the `gapSize` prop to control the distance between elements in your `TreeIte
 
 Use the `selected` prop to display a light grey background on a given `TreeItem`.
 
+Use the `onClick` prop to trigger a callback on click or when pressing the "Enter" key on a focused `TreeItem`. However, this callback will not be triggered when pressing "Enter" while holding the meta key down (i.e. "Command" or "Windows").
+
+Use the `onMetaEnterKeyDown` prop to trigger a callback when pressing the "Enter" key while holding the meta key down.
+
 ```jsx
 <Tree label="Cheeses" defaultOpen>
   <TreeItem
     icon="LogoRings"
     detail={<Text variant="text2">is great</Text>}
     onClick={() => alert('Clicked Swiss')}
+    onMetaEnterKeyDown={() => alert('Clicked Swiss while holding meta key')}
     selected
   >
     Swiss

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -183,7 +183,7 @@ Use the `selected` prop to display a light grey background on a given `TreeItem`
 
 Use the `onClick` prop to trigger a callback on click or when pressing the "Enter" key on a focused `TreeItem`.
 
-Use the `onMetaEnter` prop to trigger a callback when pressing the "Enter" key while holding the meta key down (i.e. "Command" key or "Windows" key) on a focused `TreeItem`. If `onMetaEnter` receives a callback, then the `onClick` callback will not be triggered when pressing the "Enter" key plus the meta key.
+Use the `onMetaEnter` prop to trigger a callback when pressing the "Enter" key in combination with the meta key (i.e. "Command" or "Windows" key) on a focused `TreeItem`.
 
 ```jsx
 <Tree label="Cheeses" defaultOpen>

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -181,9 +181,9 @@ Use the `gapSize` prop to control the distance between elements in your `TreeIte
 
 Use the `selected` prop to display a light grey background on a given `TreeItem`.
 
-Use the `onClick` prop to trigger a callback on click or when pressing the "Enter" key on a focused `TreeItem`. However, this callback will not be triggered when pressing "Enter" while holding the meta key down (i.e. "Command" or "Windows").
+Use the `onClick` prop to trigger a callback on click or when pressing the "Enter" key on a focused `TreeItem`.
 
-Use the `onMetaEnter` prop to trigger a callback when pressing the "Enter" key while holding the meta key down.
+Use the `onMetaEnter` prop to trigger a callback when pressing the "Enter" key while holding the meta key down (i.e. "Command" key or "Windows" key) on a focused `TreeItem`. If `onMetaEnter` receives a callback, then the `onClick` callback will not be triggered when pressing the "Enter" key plus the meta key.
 
 ```jsx
 <Tree label="Cheeses" defaultOpen>

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -183,7 +183,7 @@ Use the `selected` prop to display a light grey background on a given `TreeItem`
 
 Use the `onClick` prop to trigger a callback on click or when pressing the "Enter" key on a focused `TreeItem`. However, this callback will not be triggered when pressing "Enter" while holding the meta key down (i.e. "Command" or "Windows").
 
-Use the `onMetaEnterKeyDown` prop to trigger a callback when pressing the "Enter" key while holding the meta key down.
+Use the `onMetaEnter` prop to trigger a callback when pressing the "Enter" key while holding the meta key down.
 
 ```jsx
 <Tree label="Cheeses" defaultOpen>
@@ -191,7 +191,7 @@ Use the `onMetaEnterKeyDown` prop to trigger a callback when pressing the "Enter
     icon="LogoRings"
     detail={<Text variant="text2">is great</Text>}
     onClick={() => alert('Clicked Swiss')}
-    onMetaEnterKeyDown={() => alert('Clicked Swiss while holding meta key')}
+    onMetaEnter={() => alert('Clicked Swiss while holding meta key')}
     selected
   >
     Swiss


### PR DESCRIPTION
### :sparkles: Changes

- Added "onMetaEnterKeyDown" prop to `TreeItem`

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC