### PR TITLE
Fix CHANGELOG for change that snuck in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- `IconButton` w/ `size="small"` icon size adjusted to `small` (was `xsmall`)
+- `Space` revert mistakenly applied `flex-shrink: 0`
 - `useDialog` needs to support scenario it is controlled but `onClose` isn't specified
 - Reverts: `HoverDisclosure` toggles visibility with css rather than inserting elements into the DOM
-- `Space` revert mistakenly applied `flex-shrink: 0`
 
 ## [0.9.17] - 2020-10-12
 


### PR DESCRIPTION
### :sparkles: Changes

Accidentilly landed IconButton icon size change in previous PR. This updates the CHANGELOG accordingly



### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
