### PR TITLE
Upgrade to focus-trap@6.1.3 (ie11 transpile fix)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
     "d3-hsv": "^0.1.0",
     "date-fns": "^2.16.1",
     "date-fns-tz": "^1.0.12",
-    "focus-trap": "^6.1.0",
+    "focus-trap": "^6.1.3",
     "hotkeys-js": "^3.8.1",
     "lodash": "^4.17.20",
     "polished": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10394,12 +10394,12 @@ focus-lock@^0.7.0:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
   integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
 
-focus-trap@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.0.tgz#836a4851b389b71fe26d4dcdfb43d5c8d6f2bfc6"
-  integrity sha512-TQf1gJ5UgAY2ZMXrTDls6ah10kJmh35w/4COQHncLILwAK7hme4tiOwYnq2JOU88pqu1LoPqO9Yn7EbvmnzRRQ==
+focus-trap@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.3.tgz#38b79099bec42b9efa9ee47b646a21033dd030fd"
+  integrity sha512-UXrRlMIZVwLRt4t/fdhExuD3nanc2oHlyJrjbUl01iR2Z59/uPOAj4V9A6k2aelLb/aKb3YKJG+S4HBTrnTWHA==
   dependencies:
-    tabbable "^5.1.0"
+    tabbable "^5.1.2"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -20951,10 +20951,10 @@ tabbable@^4.0.0:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
   integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
-tabbable@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.0.tgz#b81115168d0a8359ba69003b6a99d05f8480a664"
-  integrity sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ==
+tabbable@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.2.tgz#3c4eac2901d0000913d13ce147229eb1405b59ca"
+  integrity sha512-DNmnX4XgkjK7kxDnQ5IbyYoNke2izMk5b62All0qxzoCF3wE7H9CuZ2IPdfAN8v79E0rpjv2k78uWuIXupGa9g==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
### :sparkles: Changes

Upgrade focus-trap to 6.1.3 to fix IE11 transpile issue (IE11 won't boot with ES6)

Background: https://github.com/focus-trap/focus-trap/blob/master/CHANGELOG.md

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
