### PR TITLE
Dialog improvements (animation, remove backdrop customization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `IconButton` supports `toggle` prop (uses `key` color when toggled and `aria-pressed`)
+- Improved test coverage / added image-snapshots
 
 ### Changed
 
-- Improved test coverage / added image-snapshots
+- `useDialog` (`Dialog` & `Drawer`) refactored
+  - Removed use of `react-transition-group` dependency
+  - Added support for `aria-busy`
+  - Simplified implementation of `DialogRender` component
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed use of `react-transition-group` dependency
   - Added support for `aria-busy`
   - Simplified implementation of `DialogRender` component
+- `theme.transitions` durations are now integers (in milliseconds) rather than strings
 
 ### Fixed
 
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - IconButton support for `color` (`neutral` for all now)
+- `Drawer` no longer supports `backdrop` prop for customizing backdrop presentation
 
 ## [0.9.19] - 2020-10-15
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,6 @@
     "react-day-picker": "^7.4.8",
     "react-hotkeys-hook": "^2.3.1",
     "react-resize-detector": "^5.2.0",
-    "react-transition-group": "^4.3.0",
     "resize-observer-polyfill": "^1.5.1",
     "styled-system": "^5.1.5",
     "uuid": "^8.3.1"
@@ -54,7 +53,6 @@
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "@types/react-resize-detector": "^5.0.0",
-    "@types/react-transition-group": "^4.4.0",
     "@types/styled-components": "^4.4.1",
     "@types/uuid": "^8.3.0",
     "csstype": "^3.0.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,6 +33,7 @@
     "hotkeys-js": "^3.8.1",
     "lodash": "^4.17.20",
     "polished": "^4.0.2",
+    "react-awesome-reveal": "^3.3.1",
     "react-day-picker": "^7.4.8",
     "react-hotkeys-hook": "^2.3.1",
     "react-resize-detector": "^5.2.0",

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -97,7 +97,7 @@ export const ButtonItem = styled(ButtonLayout)`
   justify-content: center;
   margin: 0;
   padding: 0 ${({ theme }) => theme.space.small};
-  transition: background ${({ theme }) => theme.transitions.durationQuick} ease;
+  transition: background ${({ theme }) => theme.transitions.quick}ms ease;
   user-select: none;
 
   ${space}

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -44,8 +44,7 @@ export interface CardProps
 }
 
 const cardTransition = () => css`
-  ${(props) =>
-    `${props.theme.transitions.durationQuick} ${props.theme.easings.ease}`}
+  ${({ theme }) => `${theme.transitions.quick}ms ${theme.easings.ease}`}
 `
 
 const raised = (props: CardProps) =>

--- a/packages/components/src/Dialog/Backdrop.tsx
+++ b/packages/components/src/Dialog/Backdrop.tsx
@@ -38,32 +38,24 @@ export interface BackdropProps
 
 // Backdrop styles are applied here (rather than using the inline `style={...}` prop) to ensure that
 // transitions will still apply to backdrop
-export const Backdrop = styled.div.attrs((props: BackdropProps) => ({
-  backgroundColor: props.visible ? props.backgroundColor : 'transparent',
+export const Backdrop = styled.div.attrs(() => ({
   'data-testid': 'backdrop',
-}))<BackdropProps>`
+}))`
   ${reset}
   ${color}
 
-  ${(props) => props.inlineStyle}
-
+  background: ${({ theme }) => theme.colors.ui5};
   bottom: 0;
   cursor: default;
   left: 0;
-  opacity: ${(props) => props.opacity};
+  opacity: 0.6;
   position: fixed;
   right: 0;
   top: 0;
-  transition: opacity ${(props) => props.theme.transitions.durationSimple};
+  transition: opacity ${({ theme }) => theme.transitions.simple}ms;
 
   &.entering,
   &.exiting {
     opacity: 0.01;
   }
 `
-
-Backdrop.defaultProps = {
-  backgroundColor: 'ui5',
-  opacity: 0.6,
-  visible: true,
-}

--- a/packages/components/src/Dialog/Dialog.test.tsx
+++ b/packages/components/src/Dialog/Dialog.test.tsx
@@ -113,21 +113,6 @@ describe('Dialog', () => {
     await waitForElementToBeRemoved(() => screen.getByText('Dialog content'))
   })
 
-  test('Backdrop custom styles', () => {
-    renderWithTheme(
-      <Dialog
-        defaultOpen
-        backdrop={{ backgroundColor: 'pink' }}
-        content={<SimpleContent />}
-      />
-    )
-
-    const backdrop = screen.getByTestId('backdrop')
-
-    expect(backdrop).toBeInTheDocument()
-    expect(backdrop).toHaveStyle({ backgroundColor: 'pink' })
-  })
-
   test('Surface custom styles', () => {
     renderWithTheme(
       <Dialog

--- a/packages/components/src/Dialog/DialogSurface.tsx
+++ b/packages/components/src/Dialog/DialogSurface.tsx
@@ -32,8 +32,6 @@ export const DialogSurface = styled(SurfaceBase)`
   box-shadow: ${({ theme }) => theme.shadows[5]};
   position: relative;
   transition: transform ${surfaceTransition}, opacity ${surfaceTransition};
-  /* opacity: 1;
-  transform: none; */
 
   &.entering,
   &.exiting {

--- a/packages/components/src/Dialog/DialogSurface.tsx
+++ b/packages/components/src/Dialog/DialogSurface.tsx
@@ -32,16 +32,12 @@ export const DialogSurface = styled(SurfaceBase)`
   box-shadow: ${({ theme }) => theme.shadows[5]};
   position: relative;
   transition: transform ${surfaceTransition}, opacity ${surfaceTransition};
+  /* opacity: 1;
+  transform: none; */
 
-  &.entering,
-  &.exiting {
+  &.transitioning {
     opacity: 0.01;
     transform: translateY(100%);
-  }
-
-  &.exited {
-    opacity: 1;
-    transform: translateY(0%);
   }
 `
 

--- a/packages/components/src/Dialog/DialogSurface.tsx
+++ b/packages/components/src/Dialog/DialogSurface.tsx
@@ -35,7 +35,8 @@ export const DialogSurface = styled(SurfaceBase)`
   /* opacity: 1;
   transform: none; */
 
-  &.transitioning {
+  &.entering,
+  &.exiting {
     opacity: 0.01;
     transform: translateY(100%);
   }

--- a/packages/components/src/Dialog/SurfaceBase.tsx
+++ b/packages/components/src/Dialog/SurfaceBase.tsx
@@ -53,12 +53,10 @@ const SurfaceLayout: FC<SurfaceProps> = ({
   const wrapperRef = useRef<null | HTMLDivElement>(null)
 
   useEffect(() => {
-    const t = window.setTimeout(() => {
+    const t = setTimeout(() => {
       enableFocusTrap && enableFocusTrap()
-    }, theme.transitions.durationModerate)
-    return () => {
-      window.clearTimeout(t)
-    }
+    }, theme.transitions.moderate)
+    return () => clearTimeout(t)
   }, [enableFocusTrap])
 
   useGlobalHotkeys('esc', closeModal, wrapperRef)
@@ -74,8 +72,7 @@ const SurfaceLayout: FC<SurfaceProps> = ({
 }
 
 export const surfaceTransition = () => css`
-  ${({ theme }) =>
-    `${theme.transitions.durationModerate} ${theme.easings.ease}`}
+  ${({ theme }) => `${theme.transitions.moderate}ms ${theme.easings.ease}`}
 `
 
 export const SurfaceBase = styled(SurfaceLayout).attrs(() => ({

--- a/packages/components/src/Dialog/useAnimation.ts
+++ b/packages/components/src/Dialog/useAnimation.ts
@@ -73,12 +73,9 @@ export const useAnimationState = (
     if (isOpen && state === 'entered') return
 
     if (isOpen) {
-      const entering = setTimeout(() => setState('entering'), 0)
+      setState('entering')
       const open = setTimeout(() => setState('entered'), timing)
-      return () => {
-        clearTimeout(entering)
-        clearTimeout(open)
-      }
+      return () => clearTimeout(open)
     } else {
       setState('exiting')
       const closed = setTimeout(() => setState('exited'), timing)

--- a/packages/components/src/Dialog/useAnimation.ts
+++ b/packages/components/src/Dialog/useAnimation.ts
@@ -1,0 +1,94 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { transitions } from '@looker/design-tokens'
+import { useEffect, useState } from 'react'
+
+type Entering = 'entering'
+type Entered = 'entered'
+type Exiting = 'exiting'
+type Exited = 'exited'
+
+type AnimationStates = Entering | Entered | Exiting | Exited
+
+const busyStates = ['entering', 'exiting']
+
+interface UseAnimationStateReturn {
+  /**
+   * className will transition from 'entering` => `entered` => `exiting` => `exited`
+   */
+  className: string
+  /**
+   * renderDOM indicates whether or not the DOM elements to be associated should
+   * be rendered.
+   */
+  renderDOM: boolean
+  /**
+   * Animation is actively running (use to trigger `aria-busy` application)
+   */
+  busy: boolean
+}
+
+/**
+ *
+ * Hook that encapsulates timing behavior to allow for CSS transitions to complete before DOM elements are
+ * removed from the DOM as well as offering classNames to hook transitions to and `busy` response that details
+ *
+ *
+ * @param isOpen - Toggle visibility
+ * @param timing - How long does the transition take to complete. Elements will be removed from the DOM once this time is elapsed
+ */
+export const useAnimationState = (
+  isOpen: boolean,
+  timing = transitions.moderate
+): UseAnimationStateReturn => {
+  const [state, setState] = useState<AnimationStates>('exited')
+
+  useEffect(() => {
+    /* Short-circuit state changes that don't matter */
+    if (!isOpen && state === 'exited') return
+    if (isOpen && state === 'entered') return
+
+    if (isOpen) {
+      const entering = setTimeout(() => setState('entering'), 0)
+      const open = setTimeout(() => setState('entered'), timing)
+      return () => {
+        clearTimeout(entering)
+        clearTimeout(open)
+      }
+    } else {
+      setState('exiting')
+      const closed = setTimeout(() => setState('exited'), timing)
+      return () => clearTimeout(closed)
+    }
+  }, [isOpen, state, timing])
+
+  return {
+    busy: busyStates.includes(state),
+    className: state,
+    renderDOM: state !== 'exited',
+  }
+}

--- a/packages/components/src/Dialog/useDialog.tsx
+++ b/packages/components/src/Dialog/useDialog.tsx
@@ -25,7 +25,6 @@
  */
 
 import React, { CSSProperties, FC, ReactNode, useState } from 'react'
-import { CSSObject } from 'styled-components'
 import { ResponsiveValue } from 'styled-system'
 import { DrawerPlacements } from '../Drawer/useDrawer'
 import { Portal } from '../Portal'
@@ -110,14 +109,6 @@ export interface UseDialogProps {
   surfaceStyles?: CSSProperties
 
   /**
-   * Optional backdrop styles to merge with the Backdrop implementation. These
-   * must be a CSSProperty compatible key / value paired object. For example
-   * {backgroundColor: 'pink'}.
-   * @deprecated - this is slated for removal
-   */
-  backdrop?: CSSProperties
-
-  /**
    * Specify a custom surface to use for Dialog surface.
    * This is intended for internal components use only (specifically `Drawer`)
    * @private
@@ -150,7 +141,6 @@ export const useDialog = ({
   canClose,
   onClose,
   setOpen: controlledSetOpen,
-  backdrop,
   maxWidth,
   width,
   surfaceStyles,
@@ -219,16 +209,7 @@ export const useDialog = ({
       }}
     >
       <Portal ref={portalRef}>
-        <Backdrop
-          className={className}
-          onClick={handleClose}
-          visible={backdrop === undefined ? true : !!backdrop}
-          style={
-            !!backdrop && backdrop !== true
-              ? (backdrop as CSSObject)
-              : undefined
-          }
-        />
+        <Backdrop className={className} onClick={handleClose} />
         <RenderSurface
           aria-busy={busy ? true : undefined}
           className={className}
@@ -253,17 +234,3 @@ export const useDialog = ({
     setOpen,
   }
 }
-
-// const AnimationHandler = ({ show, children }) => {
-//   const [render, setRender] = useState(show)
-
-//   useEffect(() => {
-//     if (show) setRender(true)
-//   }, [show])
-
-//   const onAnimationEnd = () => {
-//     if (!show) setRender(false)
-//   }
-
-//   return render && <div onAnimationEnd={onAnimationEnd}>{children}</div>
-// }

--- a/packages/components/src/Drawer/DrawerSurface.tsx
+++ b/packages/components/src/Drawer/DrawerSurface.tsx
@@ -41,8 +41,4 @@ export const DrawerSurface = styled(SurfaceBase)`
     opacity: 0.01;
     transform: translateX(100%);
   }
-  &.exited {
-    opacity: 1;
-    transform: translateX(0%);
-  }
 `

--- a/packages/components/src/Drawer/useDrawer.tsx
+++ b/packages/components/src/Drawer/useDrawer.tsx
@@ -33,7 +33,7 @@ export type DrawerPlacements = 'right'
 export interface UseDrawerProps
   extends Omit<
     UseDialogProps,
-    'maxWidth' | 'height' | 'placement' | 'surfaceStyles' | 'backdrop'
+    'maxWidth' | 'height' | 'placement' | 'surfaceStyles'
   > {
   /**
    * Explicitly specifying a width will set the Surface to be the lesser of the specified width or the viewport width.

--- a/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
@@ -43,7 +43,7 @@ const Knob = styled(({ className }) => <div className={className} />)`
   left: ${({ size }) => rem(size * 0.1)};
   position: absolute;
   transform: ${({ on, size }) => (on ? `translateX(${rem(size * 0.75)})` : '')};
-  transition: ${({ theme }) => theme.transitions.durationModerate};
+  transition: ${({ theme }) => theme.transitions.moderate}ms;
   width: ${({ size }) => rem(size * 0.8)};
 `
 
@@ -70,7 +70,7 @@ export const KnobContainer = styled(KnobContainerLayout)`
   position: absolute;
   right: 0;
   top: 0;
-  transition: ${({ theme }) => theme.transitions.durationModerate};
+  transition: ${({ theme }) => theme.transitions.moderate}ms;
 
   &:hover {
     box-shadow: ${({ disabled, theme: { colors } }) =>

--- a/packages/components/src/Menu/MenuItemLayout.tsx
+++ b/packages/components/src/Menu/MenuItemLayout.tsx
@@ -62,8 +62,8 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
   outline: none;
   text-decoration: none;
   transition: ${({ theme: { easings, transitions } }) =>
-    `background ${transitions.durationQuick} ${easings.ease},
-    color ${transitions.durationQuick} ${easings.ease}`};
+    `background ${transitions.quick}ms ${easings.ease},
+    color ${transitions.quick}ms ${easings.ease}`};
 
   button,
   a {
@@ -116,8 +116,7 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
 
   ${Icon} {
     transition: color
-      ${({ theme: { easings, transitions } }) =>
-        `${transitions.durationQuick} ${easings.ease}`};
+      ${({ theme }) => `${theme.transitions.quick}ms ${theme.easings.ease}`};
   }
 
   :hover,

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -39,6 +39,8 @@ export * from './utils/pick'
 export { generateTheme } from './utils/theme'
 export type { ThemeCustomizations } from './utils/theme'
 
+export { transitions } from './tokens/transitions'
+
 export { pickSpecifiableColors } from './utils/color/pickSpecifiableColors'
 export {
   intentUIBlend,

--- a/packages/design-tokens/src/system/transitions.ts
+++ b/packages/design-tokens/src/system/transitions.ts
@@ -25,13 +25,6 @@
  */
 
 export interface Transitions {
-  durationRapid: string
-  durationQuick: string
-  durationSimple: string
-  durationModerate: string
-  durationComplex: string
-  durationIntricate: string
-
   rapid: number
   quick: number
   simple: number

--- a/packages/design-tokens/src/system/transitions.ts
+++ b/packages/design-tokens/src/system/transitions.ts
@@ -31,4 +31,11 @@ export interface Transitions {
   durationModerate: string
   durationComplex: string
   durationIntricate: string
+
+  rapid: number
+  quick: number
+  simple: number
+  moderate: number
+  complex: number
+  intricate: number
 }

--- a/packages/design-tokens/src/tokens/transitions.ts
+++ b/packages/design-tokens/src/tokens/transitions.ts
@@ -26,13 +26,27 @@
 
 import { Transitions } from '../system'
 
+const rapid = 100
+const quick = 150
+const simple = 200
+const moderate = 300
+const complex = 400
+const intricate = 500
+
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 export const transitions: Transitions = {
-  durationRapid: '100ms',
-  durationQuick: '150ms',
-  durationSimple: '200ms',
-  durationModerate: '300ms',
-  durationComplex: '300ms',
-  durationIntricate: '500ms',
+  durationRapid: `${rapid}ms`,
+  durationQuick: `${quick}ms`,
+  durationSimple: `${simple}ms`,
+  durationModerate: `${moderate}ms`,
+  durationComplex: `${complex}ms`,
+  durationIntricate: `${intricate}ms`,
+
+  rapid,
+  quick,
+  simple,
+  moderate,
+  complex,
+  intricate,
 }
 /* eslint-enable sort-keys */

--- a/packages/design-tokens/src/tokens/transitions.ts
+++ b/packages/design-tokens/src/tokens/transitions.ts
@@ -35,13 +35,6 @@ const intricate = 500
 
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 export const transitions: Transitions = {
-  durationRapid: `${rapid}ms`,
-  durationQuick: `${quick}ms`,
-  durationSimple: `${simple}ms`,
-  durationModerate: `${moderate}ms`,
-  durationComplex: `${complex}ms`,
-  durationIntricate: `${intricate}ms`,
-
   rapid,
   quick,
   simple,

--- a/www/src/Shared/ComponentResources/Resource.tsx
+++ b/www/src/Shared/ComponentResources/Resource.tsx
@@ -44,9 +44,10 @@ const Style = styled(ListItem).attrs({
 
   svg {
     margin-right: ${(props) => props.theme.space.xsmall};
+    transition: transform
+      ${({ theme }) =>
+        `${theme.transitions.moderate}ms ${theme.easings.easeOut}`};
     width: 1.5rem;
-    transition: ${(props) =>
-      `transform ${props.theme.transitions.durationModerate} ${props.theme.easings.easeOut}`};
   }
 
   &:hover {

--- a/www/src/documentation/components/dialogs/index.mdx
+++ b/www/src/documentation/components/dialogs/index.mdx
@@ -113,16 +113,7 @@ The most common pattern for a `Dialog` is the [`Confirm`](/components/dialogs/co
 
 ### Backdrop
 
-This provides the backdrop behind dialogs. It can be customized via the `backdrop` property. These must be a CSSProperty compatible key / value paired object.
-
-```jsx
-<Dialog
-  backdrop={{ background: 'purple', opacity: 1 }}
-  content={<>Stuff and text</>}
->
-  <Button>Purple Backdrop</Button>
-</Dialog>
-```
+This provides the backdrop behind dialogs.
 
 ### Surface
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,7 +1840,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -5233,13 +5233,6 @@
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
   integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
-  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
   dependencies:
     "@types/react" "*"
 
@@ -9053,7 +9046,7 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
+csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
@@ -9622,14 +9615,6 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-helpers@^5.0.1:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
-  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^2.6.7"
 
 dom-iterator@^1.0.0:
   version "1.0.0"
@@ -19568,16 +19553,6 @@ react-textarea-autosize@^8.1.1:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
-
-react-transition-group@^4.3.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
-  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react@^16.14.0:
   version "16.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,6 +1956,18 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
+"@emotion/core@^10.0.35":
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
+  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
 "@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
@@ -2008,7 +2020,7 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
 
-"@emotion/styled@^10.0.0", "@emotion/styled@^10.0.14", "@emotion/styled@^10.0.17":
+"@emotion/styled@^10.0.0", "@emotion/styled@^10.0.14", "@emotion/styled@^10.0.17", "@emotion/styled@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
   integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
@@ -7953,7 +7965,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -19107,6 +19119,17 @@ rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-awesome-reveal@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/react-awesome-reveal/-/react-awesome-reveal-3.3.1.tgz#b263c063f897516630eaa8dcf0b96fc3136706e3"
+  integrity sha512-+BGbNYOzMoUQ1dkhpQeXisnGOWkugGhSZRdrtG8N6nbd15eFdseRIWNM1wTd684W6t/MsFcKP7HWgyUBO10m6A==
+  dependencies:
+    "@emotion/core" "^10.0.35"
+    "@emotion/styled" "^10.0.27"
+    classnames "^2.2.6"
+    react-intersection-observer "^8.28.4"
+    react-is "^16.13.1"
+
 react-circular-progressbar@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-circular-progressbar/-/react-circular-progressbar-2.0.3.tgz#fa8eb59f8db168d2904bae4590641792c80f5991"
@@ -19372,6 +19395,11 @@ react-inspector@^5.0.1:
     "@babel/runtime" "^7.0.0"
     is-dom "^1.0.0"
     prop-types "^15.0.0"
+
+react-intersection-observer@^8.28.4:
+  version "8.29.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.29.0.tgz#8349a6301bfc24329a029036c6bed30f9864f3ad"
+  integrity sha512-Bqp7GBa5Aieo8C33Bz0e5WuUnFUKN3WOayKMT/2f0ujfW+YpzOEdNE4MK/TnaHp+cisK7n1At3qcFaNPfhHbqw==
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"


### PR DESCRIPTION
### :sparkles: Changes

- `useDialog` (`Dialog` & `Drawer`) refactored
  - Removed use of `react-transition-group` dependency
  - Added support for `aria-busy`
  - Simplified implementation of `DialogRender` component

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
