### PR TITLE
Update ButtonItem to use body font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved test coverage / added image-snapshots
 - InputFilter to support multiline filter tokens
 - Reduced & consolidated dependencies on `polished` library
+- `ButtonItem` used inside `ButtonToggle` and `ButtonGroup` now uses `body`
 
 ### Fixed
 

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -112,7 +112,7 @@ export const ButtonItem = styled(ButtonLayout)`
   color: ${({ theme }) => theme.colors.text3};
   cursor: pointer;
   display: inline-flex;
-  font-family: ${({ theme }) => theme.fonts.brand};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.small};
   height: ${inputHeight};
   justify-content: center;

--- a/packages/components/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonGroup.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ButtonGroup controlled 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-family: Roboto,'Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
   font-size: 0.875rem;
   height: 36px;
   -webkit-box-pack: center;

--- a/packages/components/src/Button/__snapshots__/ButtonToggle.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonToggle.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ButtonToggle controlled 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-family: Roboto,'Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
   font-size: 0.875rem;
   height: 36px;
   -webkit-box-pack: center;


### PR DESCRIPTION
### :sparkles: Changes

Updates the font on `ButtonItem` to body font


### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
