### PR TITLE
Fix: IE11 click option in Select, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select` / `SelectMulti` / `InputTimeSelect` click to select option in IE11
 - `InputTimeSelect` can accept a time that is not included in the select dropdown options
 - `FieldInline` refactored to use MS-compatible grid (IE11 compatibility)
   - `FieldCheckbox`

--- a/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
@@ -27,6 +27,7 @@
 // Much of the following is pulled from https://github.com/reach/reach-ui
 // because their work is fantastic (but is not in TypeScript)
 import { Context, FocusEvent, useContext } from 'react'
+import { getNextFocusTarget } from '../../../../utils'
 import {
   ComboboxContextProps,
   ComboboxMultiContextProps,
@@ -64,10 +65,11 @@ export function useBlur<
       return
     }
     // we on want to close only if focus rests outside the select
+    const nextFocusTraget = getNextFocusTarget(e)
     const popoverCurrent = listRef ? listRef.current : null
     if (popoverCurrent) {
       const focusInList =
-        popoverCurrent && popoverCurrent.contains(e.relatedTarget as Node)
+        popoverCurrent && popoverCurrent.contains(nextFocusTraget as Node)
 
       requestAnimationFrame(() => {
         if (focusInList && state !== ComboboxState.INTERACTING) {

--- a/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
@@ -43,7 +43,7 @@ import { Chip } from '../../../Chip'
 import { inputHeight } from '../height'
 import { InputTextContent, InputText, InputTextBaseProps } from '../InputText'
 import { AdvancedInputControls } from '../AdvancedInputControls'
-import { useForkedRef, useWrapEvent } from '../../../utils'
+import { useForkedRef, useWrapEvent, getNextFocusTarget } from '../../../utils'
 import { visuallyHiddenStyle } from '../../../VisuallyHidden'
 
 export interface InputChipsInputControlProps {
@@ -295,9 +295,10 @@ export const InputChipsBaseInternal = forwardRef(
 
     function handleHiddenInputBlur(e: FocusEvent<HTMLInputElement>) {
       // Unless blur event is caused by clicking on a chip, deselect all chips
+      const nextFocusTarget = getNextFocusTarget(e)
       if (
-        e.relatedTarget &&
-        (e.relatedTarget as HTMLElement).parentNode !==
+        nextFocusTarget &&
+        (nextFocusTarget as HTMLElement).parentNode !==
           e.currentTarget.parentNode
       ) {
         deselectAll()

--- a/packages/components/src/utils/getNextFocusTarget.ts
+++ b/packages/components/src/utils/getNextFocusTarget.ts
@@ -23,39 +23,13 @@
  SOFTWARE.
 
  */
-import React, { useState } from 'react'
-import { render } from 'react-dom'
-import {
-  ComponentsProvider,
-  FieldSelect,
-  FieldChips,
-  SpaceVertical,
-} from '@looker/components'
-import 'core-js/stable'
+import { FocusEvent } from 'react'
 
-const App = () => {
-  const [values, setValues] = useState(['Cheddar', 'Gouda', 'Swiss'])
-  return (
-    <ComponentsProvider loadGoogleFonts>
-      <SpaceVertical width={500} p="large">
-        <FieldSelect
-          label="Select value via click"
-          options={[
-            { label: 'Cheddar', value: 'cheddar' },
-            { label: 'Gouda', value: 'gouda' },
-            { label: 'Swiss', value: 'swiss' },
-          ]}
-        />
-        <FieldChips
-          label="Select current values"
-          description="Then focus out of the field. Confirm values are deselected."
-          values={values}
-          onChange={setValues}
-        />
-      </SpaceVertical>
-    </ComponentsProvider>
-  )
-}
-document.addEventListener('DOMContentLoaded', () => {
-  render(<App />, document.getElementById('container'))
-})
+/**
+ * ONLY use for blur events, returns the “next focused element” – event.relatedTarget if available
+ * (modern browsers, where document.activeElement is not updated until after the blur event)
+ * and document.activeElement as a fallback (IE11, where it’s updated before the blur event).
+ * @param event the blur event
+ */
+export const getNextFocusTarget = (event?: FocusEvent) =>
+  event?.relatedTarget || document.activeElement

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -24,6 +24,7 @@
 
  */
 
+export * from './getNextFocusTarget'
 export * from './getWindowedListBoundaries'
 export * from './HoverDisclosure'
 export * from './moveFocus'

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "scripts": {
-    "start": "webpack-dev-server --host=0.0.0.0 --disable-host-check",
+    "start": "webpack serve --host=0.0.0.0 --disable-host-check",
     "analyze": "webpack --mode=production --profile"
   },
   "dependencies": {


### PR DESCRIPTION
### :sparkles: Changes

IE11 doesn't add `relatedTarget` to a blur event so the logic to keep the list open on input blur if the user is clicking into the list was failing, the list was closing prematurely, and the click on the option failed to register.

I added a utility `getNextFocusTarget` that uses `relatedTarget` if available and `document.activeElement` if not. The reason to not use `document.activeElement` across the board is that only IE11 updates that value _before_ the blur event. Other browsers don't update till _after_ the blur event.

`InputChips` was also using a blur event's `relatedTarget` for selecting chips behavior so I used `getNextFocusTarget` there as well.

Both components can be tested in the playground.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
