### PR TITLE
Update swatch to have new disabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - InputFilter to support multiline filter tokens
 - Reduced & consolidated dependencies on `polished` library
 - `ButtonItem` used inside `ButtonToggle` and `ButtonGroup` now uses `body`
+- `Swatch` no longer turns gray when disabled, but has a reduced opacity instead
 
 ### Fixed
 

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.test.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.test.tsx
@@ -40,3 +40,7 @@ test('Swatch with hex value passed', () => {
 test('Swatch with width and height set', () => {
   assertSnapshot(<Swatch color="blue" width="50px" height="25px" />)
 })
+
+test('Swatch has a disabled state', () => {
+  assertSnapshot(<Swatch color="blue" width="50px" height="25px" disabled />)
+})

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
@@ -25,7 +25,11 @@
  */
 
 import styled from 'styled-components'
-import { CompatibleHTMLProps, reset } from '@looker/design-tokens'
+import {
+  CompatibleHTMLProps,
+  disabledSwatchColor,
+  reset,
+} from '@looker/design-tokens'
 import { height, HeightProps, width, WidthProps } from 'styled-system'
 import { inputCSS, inputTextHover } from '../../../Inputs/InputText'
 import { inputHeight } from '../../height'
@@ -60,7 +64,8 @@ export const Swatch = styled.div<SwatchProps>`
   ${inputCSS}
   ${width}
   ${height}
-  background-color: ${(props) => props.color};
+  background-color: ${({ color, disabled }) =>
+    disabled && color ? disabledSwatchColor(color) : color};
   flex-shrink: 0;
   margin-top: auto;
 
@@ -69,7 +74,6 @@ export const Swatch = styled.div<SwatchProps>`
   }
 
   ${(props) => props.color === 'transparent' && emptySwatch}
-  ${(props) => (props.disabled ? 'opacity: 0.85;' : '')}
 `
 
 Swatch.defaultProps = {

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
@@ -73,7 +73,7 @@ export const Swatch = styled.div<SwatchProps>`
   }
 
   ${(props) => props.color === 'transparent' && emptySwatch}
-  ${(props) => (props.disabled ? inputTextDisabled : '')}
+  ${(props) => (props.disabled ? 'opacity: 0.85;' : '')}
 `
 
 Swatch.defaultProps = {

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
@@ -31,7 +31,11 @@ import {
   reset,
 } from '@looker/design-tokens'
 import { height, HeightProps, width, WidthProps } from 'styled-system'
-import { inputCSS, inputTextHover } from '../../../Inputs/InputText'
+import {
+  inputCSS,
+  inputTextHover,
+  inputTextDisabled,
+} from '../../../Inputs/InputText'
 import { inputHeight } from '../../height'
 
 export interface SwatchProps
@@ -65,11 +69,15 @@ export const Swatch = styled.div<SwatchProps>`
   ${width}
   ${height}
   background-color: ${({ color, disabled }) =>
-    disabled && color ? disabledSwatchColor(color) : color};
+    disabled ? disabledSwatchColor(color) : color};
   flex-shrink: 0;
   margin-top: auto;
 
-  &:hover {
+  &:disabled {
+    ${inputTextDisabled}
+  }
+
+  &:hover:not([disabled]) {
     ${inputTextHover}
   }
 

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
@@ -27,11 +27,7 @@
 import styled from 'styled-components'
 import { CompatibleHTMLProps, reset } from '@looker/design-tokens'
 import { height, HeightProps, width, WidthProps } from 'styled-system'
-import {
-  inputCSS,
-  inputTextDisabled,
-  inputTextHover,
-} from '../../../Inputs/InputText'
+import { inputCSS, inputTextHover } from '../../../Inputs/InputText'
 import { inputHeight } from '../../height'
 
 export interface SwatchProps

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/__snapshots__/Swatch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/__snapshots__/Swatch.test.tsx.snap
@@ -18,7 +18,17 @@ exports[`Default Swatch 1`] = `
   position: relative;
 }
 
-.c0:hover {
+.c0:disabled {
+  background: #F5F6F7;
+  color: #939BA5;
+  cursor: default;
+}
+
+.c0:disabled:hover {
+  border-color: #DEE1E5;
+}
+
+.c0:hover:not([disabled]) {
   border-color: #C1C6CC;
 }
 
@@ -61,7 +71,17 @@ exports[`Swatch has a disabled state 1`] = `
   margin-top: auto;
 }
 
-.c0:hover {
+.c0:disabled {
+  background: #F5F6F7;
+  color: #939BA5;
+  cursor: default;
+}
+
+.c0:disabled:hover {
+  border-color: #DEE1E5;
+}
+
+.c0:hover:not([disabled]) {
   border-color: #C1C6CC;
 }
 
@@ -91,7 +111,17 @@ exports[`Swatch with hex value passed 1`] = `
   margin-top: auto;
 }
 
-.c0:hover {
+.c0:disabled {
+  background: #F5F6F7;
+  color: #939BA5;
+  cursor: default;
+}
+
+.c0:disabled:hover {
+  border-color: #DEE1E5;
+}
+
+.c0:hover:not([disabled]) {
   border-color: #C1C6CC;
 }
 
@@ -120,7 +150,17 @@ exports[`Swatch with width and height set 1`] = `
   margin-top: auto;
 }
 
-.c0:hover {
+.c0:disabled {
+  background: #F5F6F7;
+  color: #939BA5;
+  cursor: default;
+}
+
+.c0:disabled:hover {
+  border-color: #DEE1E5;
+}
+
+.c0:hover:not([disabled]) {
   border-color: #C1C6CC;
 }
 

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/__snapshots__/Swatch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/__snapshots__/Swatch.test.tsx.snap
@@ -44,6 +44,37 @@ exports[`Default Swatch 1`] = `
 />
 `;
 
+exports[`Swatch has a disabled state 1`] = `
+.c0 {
+  font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  background: #FFFFFF;
+  border: 1px solid #DEE1E5;
+  border-radius: 0.25rem;
+  color: #343C42;
+  font-size: 0.875rem;
+  width: 50px;
+  height: 25px;
+  background-color: blue;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: auto;
+  opacity: 0.85;
+}
+
+.c0:hover {
+  border-color: #C1C6CC;
+}
+
+<div
+  className="c0"
+  color="blue"
+  disabled={true}
+  height="25px"
+  width="50px"
+/>
+`;
+
 exports[`Swatch with hex value passed 1`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/__snapshots__/Swatch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/__snapshots__/Swatch.test.tsx.snap
@@ -54,12 +54,11 @@ exports[`Swatch has a disabled state 1`] = `
   font-size: 0.875rem;
   width: 50px;
   height: 25px;
-  background-color: blue;
+  background-color: rgba(0,0,255,0.85);
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   margin-top: auto;
-  opacity: 0.85;
 }
 
 .c0:hover {

--- a/packages/design-tokens/src/utils/helpers.ts
+++ b/packages/design-tokens/src/utils/helpers.ts
@@ -56,4 +56,5 @@ export const toggleSwitchShadowColor = () => css`
   ${({ theme }) => rgba(theme.colors.keyInteractive, 0.4)}
 `
 
-export const disabledSwatchColor = (color: string) => rgba(color, 0.85)
+export const disabledSwatchColor = (color?: string) =>
+  color && color !== 'transparent' ? rgba(color, 0.85) : undefined

--- a/packages/design-tokens/src/utils/helpers.ts
+++ b/packages/design-tokens/src/utils/helpers.ts
@@ -55,3 +55,5 @@ export const knobShadowColor = () => css`
 export const toggleSwitchShadowColor = () => css`
   ${({ theme }) => rgba(theme.colors.keyInteractive, 0.4)}
 `
+
+export const disabledSwatchColor = (color: string) => rgba(color, 0.85)

--- a/storybook/src/Forms/Color.stories.tsx
+++ b/storybook/src/Forms/Color.stories.tsx
@@ -25,7 +25,7 @@
  */
 
 import React, { useState } from 'react'
-import { FieldColor, FieldSelect } from '@looker/components'
+import { FieldColor, FieldSelect, InputColor } from '@looker/components'
 
 export default { title: 'Forms/Color' }
 
@@ -51,3 +51,5 @@ export const ControlledColor = () => {
     </>
   )
 }
+
+export const InputColorExample = () => <InputColor value="purple" disabled />

--- a/www/src/documentation/components/forms/input-color.mdx
+++ b/www/src/documentation/components/forms/input-color.mdx
@@ -13,5 +13,6 @@ The `InputColor` component has an input to add a color value and a color wheel t
   <InputColor value="green" />
   <InputColor defaultValue="purple" />
   <InputColor disabled />
+  <InputColor defaultValue="green" disabled />
 </SpaceVertical>
 ```


### PR DESCRIPTION
### :sparkles: Changes

This PR adjust how a swatch displays its disabled state. 

![image](https://user-images.githubusercontent.com/170681/96922774-23cfb780-1465-11eb-90a5-053c4804084b.png)


### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
