### PR TITLE
Disable react docgen

### DIFF
--- a/packages/storybook-config/src/main.js
+++ b/packages/storybook-config/src/main.js
@@ -30,6 +30,9 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 module.exports = {
   addons: ['@storybook/addon-essentials'],
   stories: ['../**/*.story.tsx'],
+  typescript: {
+    reactDocgen: false,
+  },
   webpackFinal: async (config) => {
     config.module.rules.push({
       test: /\.tsx?$/,


### PR DESCRIPTION
### :sparkles: Changes

React docgen is one of the best features of storybook, but it's making it almost unusably slow. ~~Unfortunately, removing it does not appear to impact the speed of `yarn image-snapshots`.~~ Actually, it does appear to speed up snapshots. It finished in under 10 min.

https://github.com/storybookjs/storybook/blob/next/addons/docs/react/README.md#typescript-props-with-react-docgen

https://github.com/storybookjs/storybook/issues/7998