### PR TITLE
Correct a mis-step with extracting polished

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We follow a [semantic versioning scheme](https://semver.org/). That means:
 1.  Open PR for change review
 1.  Merge PR
 1.  Pull latest master
-1.  `yarn lerna release`
+1.  `yarn release`
 
 ### 4. Tooling
 

--- a/packages/components/src/Button/ButtonBase.tsx
+++ b/packages/components/src/Button/ButtonBase.tsx
@@ -82,8 +82,7 @@ export const buttonCSS = css<ButtonBaseProps>`
   ${minWidth}
   ${width}
 
-  ${({ focusVisible, color }) =>
-    focusVisible && `box-shadow: 0 0 0 0.15rem ${buttonShadow(color)};`}
+  ${({ focusVisible, color }) => focusVisible && buttonShadow(color)}
 
   align-items: center;
   border-radius: ${({ theme }) => theme.radii.medium};

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Button Focus: renders outline when tabbing into focus, but not when cli
 
 exports[`Button Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 kFFdak ButtonBase-sc-1bpio6j-1 Button-sc-18euc9m-0 dXZmpP"
+  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 cFuMRs ButtonBase-sc-1bpio6j-1 Button-sc-18euc9m-0 dXZmpP"
 >
   focus
 </button>

--- a/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonOutline.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not w
 
 exports[`ButtonOutline Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 kFFdak ButtonBase-sc-1bpio6j-1 ButtonOutline-ncggc7-0 iADMFt"
+  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 cFuMRs ButtonBase-sc-1bpio6j-1 ButtonOutline-ncggc7-0 iADMFt"
 >
   focus
 </button>

--- a/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/ButtonTransparent.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but n
 
 exports[`ButtonTransparent Focus: renders outline when tabbing into focus, but not when clicking 2`] = `
 <button
-  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 kFFdak ButtonBase-sc-1bpio6j-1 ButtonTransparent-sc-799h13-0 dHitBk"
+  class="ButtonBase__ButtonOuter-sc-1bpio6j-0 cFuMRs ButtonBase-sc-1bpio6j-1 ButtonTransparent-sc-799h13-0 dHitBk"
 >
   focus
 </button>

--- a/packages/components/src/Button/iconButtonColor.ts
+++ b/packages/components/src/Button/iconButtonColor.ts
@@ -28,7 +28,7 @@ import { css } from 'styled-components'
 import { iconButtonColorDerivation } from '@looker/design-tokens'
 
 export const iconButtonColor = css<{ toggle?: boolean }>`
-  color: ${iconButtonColorDerivation};
+  ${iconButtonColorDerivation}
 
   &:hover,
   &:focus,

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -212,7 +212,7 @@ export const Calendar = styled<FC<CalendarProps>>(InternalCalendar)`
       &:not(.DayPicker-Day--to):not(.DayPicker-Day--from) {
         background-color: ${({ theme: { colors }, disabled }) =>
           disabled ? colors.neutralAccent : colors.keyAccent};
-        color: ${calendarMixColor};
+        ${calendarMixColor}
       }
 
       &:not(.DayPicker-Day--to):not(.DayPicker-Day--from):not(.DayPicker-Day--outside) {

--- a/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/Knob.tsx
@@ -71,7 +71,6 @@ export const KnobContainer = styled(KnobContainerLayout)`
   transition: ${({ theme }) => theme.transitions.moderate}ms;
 
   &:hover {
-    ${({ disabled }) =>
-      disabled && `box-shadow: 0 0 0.01rem 0.01rem ${knobShadowColor};`}
+    ${({ disabled }) => disabled && knobShadowColor}
   }
 `

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
@@ -104,7 +104,7 @@ export const ToggleSwitch = styled(ToggleSwitchLayout)`
     z-index: 1;
 
     &:focus + div {
-      box-shadow: 0 0 0 0.2rem ${toggleSwitchShadowColor};
+      ${toggleSwitchShadowColor}
     }
   }
 `

--- a/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -241,10 +241,8 @@ exports[`ToggleSwitch that is disabled 1`] = `
 }
 
 .c1:hover {
-  box-shadow: 0 0 0.01rem 0.01rem () => (0,_styledComponents.css)(["",""],(_ref5) => { var { theme;
+  box-shadow: 0 0 0.01rem 0.01rem rgba(122,85,227,0.5);
 }
-
-= _ref5; return (0,_rgba.default)(theme.colors.keyInteractive,0.5);});}
 
 .c3 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;

--- a/packages/components/src/Tabs/Tab.tsx
+++ b/packages/components/src/Tabs/Tab.tsx
@@ -63,8 +63,7 @@ const TabStyle = styled.button<TabProps>`
   border-bottom-color: ${({ selected, theme }) =>
     selected ? theme.colors.key : 'transparent'};
   border-radius: 0;
-  ${({ focusVisible }) =>
-    focusVisible && `box-shadow: 0 0 0 0.15rem ${tabShadowColor};`}
+  ${({ focusVisible }) => focusVisible && tabShadowColor}
   color: ${({ selected, theme }) =>
     selected ? theme.colors.text5 : theme.colors.text2};
   cursor: pointer;

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -77,19 +77,13 @@ exports[`focus behavior Tab Focus: renders focus ring for keyboard navigation 1`
   border-bottom: 3px solid;
   border-bottom-color: transparent;
   border-radius: 0;
-  box-shadow: 0 0 0 0.15rem () => (0,_styledComponents.css)(["",""],(_ref3) => { var { theme;
+  box-shadow: 0 0 0 0.15rem rgba(151,133,242,0.25);
+  color: #707781;
+  cursor: pointer;
+  font-family: Roboto,'Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
 }
 
-= _ref3; return (0,_rgba.default)(theme.colors.keyFocus,0.25);});color:#707781;cursor:pointer;font-family:Roboto,
-'Noto Sans JP',
-'Noto Sans CJK KR',
-'Noto Sans Arabic UI',
-'Noto Sans Devanagari UI',
-'Noto Sans Hebrew',
-'Noto Sans Thai UI',
-'Helvetica',
-'Arial',
-sans-serif;} .c0:active {
+.c0:active {
   border-bottom-color: #707781;
 }
 

--- a/packages/design-tokens/src/utils/helpers.ts
+++ b/packages/design-tokens/src/utils/helpers.ts
@@ -32,26 +32,28 @@ import { StatefulColor } from '../system/color/stateful'
 
 export const buttonShadow = (color: StatefulColor = 'key') =>
   css`
-    ${({ theme }) => rgba(theme.colors[color], 0.25)}
+    box-shadow: 0 0 0 0.15rem ${({ theme }) => rgba(theme.colors[color], 0.25)};
   `
 
 export const iconButtonColorDerivation = () => css`
-  ${({ theme }) => lighten(0.14, theme.colors.neutral)}
+  color: ${({ theme }) => lighten(0.14, theme.colors.neutral)};
 `
 
 export const tabShadowColor = () => css`
-  ${({ theme }) => rgba(theme.colors.keyFocus, 0.25)}
+  box-shadow: 0 0 0 0.15rem ${({ theme }) => rgba(theme.colors.keyFocus, 0.25)};
 `
 
 export const calendarMixColor = () => css`
-  ${({ theme: { colors } }) =>
-    mix(0.65, colors.keyAccent, colors.neutralInteractive)}
+  color: ${({ theme: { colors } }) =>
+    mix(0.65, colors.keyAccent, colors.neutralInteractive)};
 `
 
 export const knobShadowColor = () => css`
-  ${({ theme }) => rgba(theme.colors.keyInteractive, 0.5)}
+  box-shadow: 0 0 0.01rem 0.01rem
+    ${({ theme }) => rgba(theme.colors.keyInteractive, 0.5)};
 `
 
 export const toggleSwitchShadowColor = () => css`
-  ${({ theme }) => rgba(theme.colors.keyInteractive, 0.4)}
+  box-shadow: 0 0 0 0.2rem
+    ${({ theme }) => rgba(theme.colors.keyInteractive, 0.4)};
 `


### PR DESCRIPTION
### :sparkles: Changes

Correct a mis-step with extracting polished

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
