### PR TITLE
Fix Select + Dialog focus issue

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- `Select` inside a `Dialog` losing focus after clicking an option
+
 ### Changed
 
 - `InputFiltersChipEditor` can use CheckboxGroup or RadioGroup.

--- a/packages/components/src/utils/useFocusTrap.ts
+++ b/packages/components/src/utils/useFocusTrap.ts
@@ -74,10 +74,20 @@ export function useFocusTrap(
           clickOutsideDeactivates: true,
           escapeDeactivates: false,
           fallbackFocus: element,
+          initialFocus:
+            autoFocusElement || surfaceElement
+              ? () => {
+                  // Check first if focus is already within the element
+                  // otherwise if focus trap is disabled then re-enabled
+                  // (e.g. when a Select closes inside a Dialog)
+                  // focus will move unnecessarily back to the surface / autoFocus element
+                  if (element.contains(document.activeElement)) {
+                    return document.activeElement as HTMLElement
+                  }
+                  return autoFocusElement || surfaceElement
+                }
+              : undefined,
           onDeactivate: () => setOff(),
-          ...(autoFocusElement || surfaceElement
-            ? { initialFocus: autoFocusElement || surfaceElement }
-            : {}),
         })
       }
       disableFocusTrap && disableFocusTrap()


### PR DESCRIPTION
### :sparkles: Changes

- Test at `:3333/?path=/story/fieldselect--select-demo`
- Clicking an option on a `Select` in a `Dialog` results in the `Select` losing focus
- Because the focus trap is being re-enabled when the `Select` list closes, and now surface itself is set to `initialFocus`
- (This was probably already happening if there was a `[data-autofocus="true"]` element in the `Dialog`)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
