### PR TITLE
Fix Tooltip className space

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Select` inside a `Dialog` losing focus after clicking an option
+- `Tooltip` adding extra space to its child's `className`
 
 ### Changed
 

--- a/packages/components/src/Menu/MenuDisclosure.tsx
+++ b/packages/components/src/Menu/MenuDisclosure.tsx
@@ -135,7 +135,7 @@ export const MenuDisclosure: FC<MenuDisclosureProps> = ({
       'aria-haspopup': true,
       className: `${childProps.className || ''}${
         isOpen ? ' active' : ''
-      } ${tooltipClassName}`,
+      } ${tooltipClassName}`.trim(),
       disabled,
       id: `button-${id}`,
       ref: triggerCallbackRef,

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -56,7 +56,9 @@ export const Tooltip: FC<TooltipProps> = ({ children, ...props }) => {
   if (isValidElement(children)) {
     target = cloneElement(children, {
       ...domProps,
-      className: `${children.props.className || ''} ${domProps.className}`,
+      className:
+        `${children.props.className || ''} ${domProps.className}`.trim() ||
+        undefined,
     })
   } else if (isRenderProp(children)) {
     target = children(domProps)


### PR DESCRIPTION
### :sparkles: Changes

Remove extra space `Tooltip` adds to its child's `className`

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
