### PR TITLE
Select: options-related fixes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Dialog` no longer supports `surfaceStyles` (use built-in props instead)
 - `DialogManager` is no longer available (`Dialog` is completely compatible with previous interface)
 
+### Fixed
+
+- `Select` alignment of options when some have icons and others do not
+- `Select` remounts its options when the options prop changes, using a shallow comparison. This causes select via click to fail if the options prop "changes" (same values, new array instance) after a mousedown, e.g. if a parent component contains `usePopover`.
+
 ## [0.9.22]
 
 ### Fixed
@@ -44,20 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `InputFilters`
-  - improved styling when `Chips` wrap to additional lines
-  - `Popover` no longer moves when `Chip` is initially displayed
+- improved styling when `Chips` wrap to additional lines
+- `Popover` no longer moves when `Chip` is initially displayed
 - `Select` inside a `Dialog` losing focus after clicking an option
 - `Tooltip` adding extra space to its child's `className`
 
-## [0.9.20]
-
-### Added
-
-- `IconButton` supports `toggle` prop (uses `key` color when toggled and `aria-pressed`)
-- `Tooltip` and `useTooltip` now include a brief delay before showing
-  - `delay` prop controls the length
   - Improved test coverage / added image-snapshots
+
 - `Tree` `branchAlign` prop allows item be indented at the same depth as adjacent `TreeItem`(s)
 - `Tree` now supports `dividers` to produce a small visual space between each `TreeItem` displayed in the list so that adjacent items in a "selected" or active state have visual separation.
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,17 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Dialog` now supports `placement` - `center` (default), `top` & `cover`
 - `Drawer` now supports `placement` - `left` & `right` (default)
 
+### Fixed
+
+- `Select` alignment of options when some have icons and others do not
+- `Select` inappropriately shows "No options" when the current value is empty, after filtering a long list down to a single option then deleting the filter text
+- `Select` remounts its options when the options prop changes, using a shallow comparison. This causes select via click to fail if the options prop "changes" (same values, new array instance) after a mousedown, e.g. if a parent component contains `usePopover`.
+
 ### Removed
 
 - `Dialog` no longer supports `maxWidth` (it's now always `100%` - use `width`)
 - `Drawer` no longer supports `height` (use `minHeight`)
 - `Dialog` no longer supports `surfaceStyles` (use built-in props instead)
 - `DialogManager` is no longer available (`Dialog` is completely compatible with previous interface)
-
-### Fixed
-
-- `Select` alignment of options when some have icons and others do not
-- `Select` remounts its options when the options prop changes, using a shallow comparison. This causes select via click to fail if the options prop "changes" (same values, new array instance) after a mousedown, e.g. if a parent component contains `usePopover`.
 
 ## [0.9.22]
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -50,13 +50,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- improved styling when `Chips` wrap to additional lines
-- `Popover` no longer moves when `Chip` is initially displayed
+- `InputFilters`
+  - improved styling when `Chips` wrap to additional lines
+  - `Popover` no longer moves when `Chip` is initially displayed
 - `Select` inside a `Dialog` losing focus after clicking an option
 - `Tooltip` adding extra space to its child's `className`
 
-  - Improved test coverage / added image-snapshots
+## [0.9.20]
 
+### Added
+
+- `IconButton` supports `toggle` prop (uses `key` color when toggled and `aria-pressed`)
+- `Tooltip` and `useTooltip` now include a brief delay before showing
+  - `delay` prop controls the length
+  - Improved test coverage / added image-snapshots
 - `Tree` `branchAlign` prop allows item be indented at the same depth as adjacent `TreeItem`(s)
 - `Tree` now supports `dividers` to produce a small visual space between each `TreeItem` displayed in the list so that adjacent items in a "selected" or active state have visual separation.
 

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
@@ -33,6 +33,7 @@ import { Dialog, DialogContent } from '../../../Dialog'
 import { Divider } from '../../../Divider'
 import { Icon } from '../../../Icon'
 import { Flex, Space, SpaceVertical } from '../../../Layout'
+import { usePopover } from '../../../Popover'
 import { Heading, Text } from '../../../Text'
 import { Form } from '../../'
 import { Label } from '../../Label'
@@ -201,13 +202,27 @@ export const SelectContent = () => {
     if (searchTerm === '') return options1k
     return options1k.reduce(optionReducer(searchTerm), [])
   }, [searchTerm])
+
+  // For testing a bug where the options are overly-sensitive to "changes"
+  // This component re-renders on mousedown due to an upstream usePopover*
+  // thus these options will be newly instantiated on mousedown
+  // but the options should NOT un/re-mount – if they do, the click to select will not register
+  // b/c it will cause the list to clause prematurely b/c the clicked option has been unmounted
+  // and the "is the focused element inside the list" check to keep the list open fails
+
+  // * State changes in usePopover, like the one on mousedown,
+  // belong to SelectDemo, this component's parent,
+  // and parent state change causes child to re-render.
+  // If Popover were used instead, it would be a sibling to this component thus
+  // "protecting" it from the state change.
+  const unMemoizedOptions = [{ value: 'Cheddar' }, { value: 'Gouda' }]
+
   return (
-    <>
-      <Heading mb="large">Select</Heading>
+    <SpaceVertical align="start" maxWidth={600}>
+      <Heading>Select</Heading>
       <FieldSelect
         label="1k (windowed) options"
         width={300}
-        mb="medium"
         options={options1k}
         aria-label="Fruits"
         placeholder="Select Brand"
@@ -229,7 +244,6 @@ export const SelectContent = () => {
         </Flex>
         <FieldSelect
           width={300}
-          mb="medium"
           options={newOptions}
           aria-label="Fruits"
           placeholder="Controlled, searchable, clearable"
@@ -241,77 +255,66 @@ export const SelectContent = () => {
           alignSelf="flex-start"
         />
       </Flex>
-      <SpaceVertical align="start">
-        <Button mt="medium" mr="small" data-fruit="5" onClick={handleClick}>
-          Kiwis
-        </Button>
-        <Button mt="medium" data-fruit="3" onClick={handleClick}>
-          Oranges
-        </Button>
-      </SpaceVertical>
+      <Button mt="medium" mr="small" data-fruit="5" onClick={handleClick}>
+        Kiwis
+      </Button>
+      <Button mt="medium" data-fruit="3" onClick={handleClick}>
+        Oranges
+      </Button>
       <Divider my="xlarge" />
-      <SpaceVertical>
-        <FieldSelect
-          label="Default Value"
-          width={300}
-          mb="medium"
-          options={options}
-          aria-label="Fruits"
-          defaultValue="1"
-        />
-        <FieldSelect
-          label="Groups"
-          width={300}
-          mb="medium"
-          options={optionsWithGroups}
-          aria-label="Fruits"
-          defaultValue="1"
-        />
-        <FieldSelect
-          label="Descriptions"
-          width={300}
-          mb="medium"
-          options={optionsWithDescriptions}
-          aria-label="Fruits"
-          defaultValue="1"
-        />
-        <FieldSelect
-          label="Error"
-          width={300}
-          options={options}
-          aria-label="Fruits"
-          placeholder="Select One"
-          defaultValue="1"
-          validationMessage={{ message: 'An error message', type: 'error' }}
-        />
-        <FieldSelect
-          label="Disabled"
-          width={300}
-          mb="medium"
-          options={options}
-          aria-label="Fruits"
-          placeholder="Select One"
-          disabled
-          defaultValue="1"
-        />
-        <FieldSelect
-          label="Indicator"
-          width={300}
-          mb="medium"
-          options={[
-            ...options,
-            {
-              indicator: TestIndicator,
-              label: 'I have my own indicator',
-              value: 'indicator',
-            },
-          ]}
-          aria-label="Fruits"
-          defaultValue="1"
-          indicator={<Icon name="Favorite" />}
-        />
-      </SpaceVertical>
-    </>
+      <FieldSelect
+        label="Default Value"
+        options={options}
+        aria-label="Fruits"
+        defaultValue="1"
+      />
+      <FieldSelect
+        label="Groups"
+        options={optionsWithGroups}
+        aria-label="Fruits"
+        defaultValue="1"
+      />
+      <FieldSelect
+        label="Descriptions"
+        options={optionsWithDescriptions}
+        aria-label="Fruits"
+        defaultValue="1"
+      />
+      <FieldSelect
+        label="Error"
+        options={options}
+        aria-label="Fruits"
+        placeholder="Select One"
+        defaultValue="1"
+        validationMessage={{ message: 'An error message', type: 'error' }}
+      />
+      <FieldSelect
+        label="Disabled"
+        options={options}
+        aria-label="Fruits"
+        placeholder="Select One"
+        disabled
+        defaultValue="1"
+      />
+      <FieldSelect
+        label="Indicator"
+        options={[
+          ...options,
+          {
+            indicator: TestIndicator,
+            label: 'I have my own indicator',
+            value: 'indicator',
+          },
+        ]}
+        aria-label="Fruits"
+        defaultValue="1"
+        indicator={<Icon name="Favorite" />}
+      />
+      <FieldSelect
+        label="Test option re-render bug"
+        options={unMemoizedOptions}
+      />
+    </SpaceVertical>
   )
 }
 
@@ -323,14 +326,22 @@ export const SelectDemo = () => {
   const [isOpen, setOpen] = useState(false)
   const handleClick = () => setOpen(true)
   const handleClose = () => setOpen(false)
+  const { popover, domProps } = usePopover({
+    content: (
+      <Button m="large" onClick={handleClick}>
+        Open Dialog
+      </Button>
+    ),
+  })
   return (
     <SpaceVertical align="start">
+      {popover}
       <Dialog isOpen={isOpen} onClose={handleClose}>
         <DialogContent>
           <SelectContent />
         </DialogContent>
       </Dialog>
-      <Button onClick={handleClick}>Open</Button>
+      <Button {...domProps}>Open Popover</Button>
       <Card maxWidth="500px" maxHeight="300px">
         <CardContent>
           <Form
@@ -445,6 +456,7 @@ const iconOptions = [
   { icon: 'ChartLine', label: 'Line', value: 'line' },
   { icon: 'ChartMap', label: 'Map', value: 'map' },
   { icon: 'ChartPie', label: 'Pie', value: 'pie' },
+  { label: 'ChartNoIcon', value: 'noicon' },
   { icon: 'ChartScatterplot', label: 'Scatter Plot', value: 'scatterplot' },
   { icon: 'ChartSingleRecord', label: 'Single Record', value: 'singlerecord' },
   { icon: 'ChartSingleValue', label: 'Single Value', value: 'singlevalue' },

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
@@ -447,6 +447,7 @@ EmptyValue.parameters = {
 
 const iconOptions = [
   { icon: 'ChartArea', label: 'Area', value: 'area' },
+  { label: 'ChartNoIcon', value: 'noicon' },
   { icon: 'ChartBar', label: 'Bar', value: 'bar' },
   { icon: 'ChartBoxPlot', label: 'Box Plot', value: 'boxplot' },
   { icon: 'ChartColumn', label: 'Column', value: 'column' },
@@ -456,7 +457,6 @@ const iconOptions = [
   { icon: 'ChartLine', label: 'Line', value: 'line' },
   { icon: 'ChartMap', label: 'Map', value: 'map' },
   { icon: 'ChartPie', label: 'Pie', value: 'pie' },
-  { label: 'ChartNoIcon', value: 'noicon' },
   { icon: 'ChartScatterplot', label: 'Scatter Plot', value: 'scatterplot' },
   { icon: 'ChartSingleRecord', label: 'Single Record', value: 'singlerecord' },
   { icon: 'ChartSingleValue', label: 'Single Value', value: 'singlevalue' },

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
@@ -33,7 +33,7 @@ import { Dialog, DialogContent } from '../../../Dialog'
 import { Divider } from '../../../Divider'
 import { Icon } from '../../../Icon'
 import { Flex, Space, SpaceVertical } from '../../../Layout'
-import { usePopover } from '../../../Popover'
+import { PopoverContent, usePopover } from '../../../Popover'
 import { Heading, Text } from '../../../Text'
 import { Form } from '../../'
 import { Label } from '../../Label'
@@ -206,15 +206,16 @@ export const SelectContent = () => {
   // For testing a bug where the options are overly-sensitive to "changes"
   // This component re-renders on mousedown due to an upstream usePopover*
   // thus these options will be newly instantiated on mousedown
-  // but the options should NOT un/re-mount – if they do, the click to select will not register
-  // b/c it will cause the list to clause prematurely b/c the clicked option has been unmounted
-  // and the "is the focused element inside the list" check to keep the list open fails
+  // but the options should NOT un/re-mount – if they do, the click to
+  // select an option will not register. Instead it will close the Popover,
+  // b/c the clicked option has been unmounted and Popover's check for the
+  // target being "above" it will fail and its "close on click outside" behavior
+  // will be triggered
 
-  // * State changes in usePopover, like the one on mousedown,
-  // belong to SelectDemo, this component's parent,
-  // and parent state change causes child to re-render.
-  // If Popover were used instead, it would be a sibling to this component thus
-  // "protecting" it from the state change.
+  // * State changes in usePopover, like the one triggered by mousedown,
+  // belong to SelectDemo, this component's parent, and parent state changes
+  // cause child re-renders. If Popover were used instead, it would be a sibling
+  // to this component thus "protecting" it from the state change.
   const unMemoizedOptions = [{ value: 'Cheddar' }, { value: 'Gouda' }]
 
   return (
@@ -328,9 +329,9 @@ export const SelectDemo = () => {
   const handleClose = () => setOpen(false)
   const { popover, domProps } = usePopover({
     content: (
-      <Button m="large" onClick={handleClick}>
-        Open Dialog
-      </Button>
+      <PopoverContent>
+        <SelectContent />
+      </PopoverContent>
     ),
   })
   return (
@@ -341,7 +342,10 @@ export const SelectDemo = () => {
           <SelectContent />
         </DialogContent>
       </Dialog>
-      <Button {...domProps}>Open Popover</Button>
+      <Space>
+        <Button {...domProps}>Open Popover</Button>
+        <Button onClick={handleClick}>Open Dialog</Button>
+      </Space>
       <Card maxWidth="500px" maxHeight="300px">
         <CardContent>
           <Form

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -115,7 +115,6 @@ describe('Select / SelectMulti', () => {
           options={optionsToUse}
           placeholder="Search"
           onFilter={onFilter}
-          value=""
           key="select"
         />
       ),
@@ -127,7 +126,6 @@ describe('Select / SelectMulti', () => {
           options={optionsToUse}
           placeholder="Search"
           onFilter={onFilter}
-          values={[]}
           key="select-multi"
         />
       ),

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -882,6 +882,7 @@ describe('Select', () => {
         placeholder="Select a visualization"
         options={[
           { icon: 'ChartBar', label: 'Bar', value: 'bar' },
+          { label: 'No Icon', value: 'noicon' },
           { icon: 'ChartColumn', label: 'Column', value: 'column' },
           {
             icon: <>cool icon</>,
@@ -897,6 +898,7 @@ describe('Select', () => {
     const input = screen.getByPlaceholderText('Select a visualization')
     fireEvent.click(input)
     expect(screen.getAllByTestId('option-icon')).toHaveLength(3)
+    expect(screen.getAllByTestId('option-icon-placeholder')).toHaveLength(1)
 
     fireEvent.click(screen.getByText('Column'))
     const inputIcon = screen.getByTestId('input-icon')

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -84,16 +84,17 @@ const StyledIcon = styled(Icon)`
   /* For proper alignment with option text and check icon */
   height: ${({ theme }) => theme.lineHeights.small};
 `
-interface SelectOption {
+
+interface OptionLayoutProps {
   option: SelectOptionObject
   scrollIntoView?: boolean
 }
 
-const SelectOption = ({ option, scrollIntoView }: SelectOption) => {
+const OptionLayout = ({ option, scrollIntoView }: OptionLayoutProps) => {
   const { description, detail, icon, ...rest } = option
   const { hasIcons } = useContext(SelectOptionsContext)
 
-  if (detail || icon || description) {
+  if (detail || hasIcons || description) {
     const iconToUse = icon ? (
       <StyledIcon
         size="small"
@@ -103,7 +104,7 @@ const SelectOption = ({ option, scrollIntoView }: SelectOption) => {
         data-testid="option-icon"
       />
     ) : hasIcons ? (
-      <IconPlaceholder size="small" />
+      <IconPlaceholder size="small" data-testid="option-icon-placeholder" />
     ) : null
 
     return (
@@ -121,17 +122,12 @@ const SelectOption = ({ option, scrollIntoView }: SelectOption) => {
   return <ComboboxOption {...rest} />
 }
 
-const renderMultiOption = (
-  option: SelectOptionObject,
-  key: string,
-  scrollIntoView?: boolean
-) => {
+const MultiOptionLayout = ({ option, scrollIntoView }: OptionLayoutProps) => {
   const { description, detail, ...rest } = option
   if (description || detail) {
     return (
       <ComboboxMultiOption
         {...rest}
-        key={key}
         py="xxsmall"
         scrollIntoView={scrollIntoView}
       >
@@ -144,7 +140,7 @@ const renderMultiOption = (
       </ComboboxMultiOption>
     )
   }
-  return <ComboboxMultiOption {...rest} key={key} />
+  return <ComboboxMultiOption {...rest} />
 }
 
 export function SelectOptionWithDescription({
@@ -198,9 +194,9 @@ export const SelectOptionGroup = ({
       {options.map((option, index) => {
         const key = `${keyPrefix}-${index}`
         return isMulti ? (
-          renderMultiOption(option, key)
+          <MultiOptionLayout option={option} key={key} />
         ) : (
-          <SelectOption option={option} key={key} />
+          <OptionLayout option={option} key={key} />
         )
       })}
     </SelectOptionGroupContainer>
@@ -291,7 +287,7 @@ export function SelectOptions({
   }
 
   const optionsToRender = options && options.slice(start, end + 1)
-  const RenderToUse = isMulti ? renderMultiOption : SelectOption
+  const OptionLayoutToUse = isMulti ? MultiOptionLayout : OptionLayout
 
   const noOptions = (
     <EmptyListItem mb={0} px="medium" py="xlarge">
@@ -311,9 +307,13 @@ export function SelectOptions({
 
   return (
     <SelectOptionsContext.Provider value={{ hasIcons }}>
-      {options && scrollToFirst
-        ? RenderToUse(options[0] as SelectOptionObject, `${keyPrefix}-0`, true)
-        : null}
+      {options && scrollToFirst ? (
+        <OptionLayoutToUse
+          option={options[0] as SelectOptionObject}
+          key={`${keyPrefix}-0`}
+          scrollIntoView={true}
+        />
+      ) : null}
       {before}
       {optionsToRender && optionsToRender.length > 0
         ? [
@@ -329,10 +329,10 @@ export function SelectOptions({
                     isMulti={isMulti}
                   />
                 ) : (
-                  RenderToUse(
-                    option as SelectOptionObject,
-                    `${keyPrefix}-${correctedIndex}`
-                  )
+                  <OptionLayoutToUse
+                    option={option as SelectOptionObject}
+                    key={`${keyPrefix}-${correctedIndex}`}
+                  />
                 )
               }
             ),
@@ -340,13 +340,13 @@ export function SelectOptions({
           ]
         : createOption || noOptions}
       {after}
-      {options && scrollToLast
-        ? RenderToUse(
-            options[options.length - 1] as SelectOptionObject,
-            `${keyPrefix}-${options.length - 1}`,
-            true
-          )
-        : null}
+      {options && scrollToLast ? (
+        <OptionLayoutToUse
+          option={options[options.length - 1] as SelectOptionObject}
+          key={`${keyPrefix}-${options.length - 1}`}
+          scrollIntoView
+        />
+      ) : null}
     </SelectOptionsContext.Provider>
   )
 }

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -27,12 +27,12 @@
 import { IconNames, iconNameList } from '@looker/icons'
 import React, { ReactNode, useContext, useMemo } from 'react'
 import styled from 'styled-components'
-import { v4 as uuid } from 'uuid'
 import { Icon, IconProps } from '../../../Icon'
 import { Spinner } from '../../../Spinner'
 import { Box } from '../../../Layout'
 import { ListItemDetail, ListItem } from '../../../List'
 import { Heading, Paragraph, Text } from '../../../Text'
+import { useID } from '../../../utils'
 import {
   ComboboxContext,
   ComboboxMultiContext,
@@ -181,18 +181,12 @@ SelectOptionGroupTitle.defaultProps = {
   variant: 'subdued',
 }
 
-function useOptionKeyPrefix(options?: SelectOptionProps[]) {
-  // Create a new unique prefix every time the list of options changes
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => uuid(), [options])
-}
-
 export const SelectOptionGroup = ({
   options,
   label,
   isMulti,
 }: SelectOptionGroupProps & { isMulti?: boolean }) => {
-  const keyPrefix = useOptionKeyPrefix(options)
+  const keyPrefix = useID(options.length.toString())
   return (
     <SelectOptionGroupContainer>
       {label && (
@@ -282,7 +276,7 @@ export function SelectOptions({
     scrollToFirst,
     scrollToLast,
   } = useWindowedOptions(windowedOptions, options, isMulti)
-  const keyPrefix = useOptionKeyPrefix(options)
+  const keyPrefix = useID(options?.length.toString())
 
   if (isLoading) {
     return (

--- a/packages/components/src/Form/Inputs/Select/utils/options.ts
+++ b/packages/components/src/Form/Inputs/Select/utils/options.ts
@@ -109,7 +109,7 @@ export const optionsHaveIcons = (options?: SelectOptionProps[]) => {
   if (!options || options.length === 0) return false
   return options.some((option) => {
     const optionAsGroup = option as SelectOptionGroupProps
-    if (optionAsGroup) {
+    if (optionAsGroup.options) {
       return optionAsGroup.options.some(checkForIcon)
     } else {
       return checkForIcon(option as SelectOptionObject)

--- a/packages/components/src/Form/Inputs/Select/utils/options.ts
+++ b/packages/components/src/Form/Inputs/Select/utils/options.ts
@@ -102,3 +102,17 @@ export function notInOptions(
     ) === undefined
   )
 }
+
+const checkForIcon = (option: SelectOptionObject) => option.icon !== undefined
+
+export const optionsHaveIcons = (options?: SelectOptionProps[]) => {
+  if (!options || options.length === 0) return false
+  return options.some((option) => {
+    const optionAsGroup = option as SelectOptionGroupProps
+    if (optionAsGroup) {
+      return optionAsGroup.options.some(checkForIcon)
+    } else {
+      return checkForIcon(option as SelectOptionObject)
+    }
+  })
+}

--- a/packages/components/src/Form/Inputs/Select/utils/useWindowedOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/utils/useWindowedOptions.tsx
@@ -123,8 +123,10 @@ export function useWindowedOptions(
         'value',
         navigationOption.value,
       ])
-      start = selectedIndex
-      end = selectedIndex
+      if (selectedIndex > -1) {
+        start = selectedIndex
+        end = selectedIndex
+      }
     }
   }
   previouslyWindowedRef.current = windowedOptions

--- a/packages/components/src/List/IconPlaceholder.tsx
+++ b/packages/components/src/List/IconPlaceholder.tsx
@@ -24,12 +24,16 @@
 
  */
 
-import { size, SizeProps } from '@looker/design-tokens'
+import { CompatibleHTMLProps, size, SizeProps } from '@looker/design-tokens'
+import React from 'react'
 import styled from 'styled-components'
 
-export const IconPlaceholder = styled.div.attrs({ 'aria-hidden': true })<
+export type IconPlaceholderProps = CompatibleHTMLProps<HTMLDivElement> &
   SizeProps
->`
+
+export const IconPlaceholder = styled((props: IconPlaceholderProps) => (
+  <div aria-hidden {...props} />
+))`
   ${size}
   margin-right: ${({ theme }) => theme.space.xsmall};
 `

--- a/packages/components/src/List/IconPlaceholder.tsx
+++ b/packages/components/src/List/IconPlaceholder.tsx
@@ -24,7 +24,12 @@
 
  */
 
-export * from './IconPlaceholder'
-export * from './ListItemDetail'
-export * from './List'
-export * from './ListItem'
+import { size, SizeProps } from '@looker/design-tokens'
+import styled from 'styled-components'
+
+export const IconPlaceholder = styled.div.attrs({ 'aria-hidden': true })<
+  SizeProps
+>`
+  ${size}
+  margin-right: ${({ theme }) => theme.space.xsmall};
+`

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -24,18 +24,12 @@
 
  */
 
-import {
-  CompatibleHTMLProps,
-  size,
-  space,
-  SizeProps,
-  SpaceProps,
-} from '@looker/design-tokens'
+import { CompatibleHTMLProps } from '@looker/design-tokens'
 import { IconNames } from '@looker/icons'
 import styled from 'styled-components'
 import React, { FC, ReactNode, useContext, useState, useEffect } from 'react'
 import { Placement } from '@popperjs/core'
-import { ListItemDetail } from '../List'
+import { IconPlaceholder, ListItemDetail } from '../List'
 import { Paragraph } from '../Text'
 import { useID } from '../utils/useID'
 import { Icon } from '../Icon'
@@ -149,9 +143,7 @@ const MenuItemInternal: FC<MenuItemProps> = (props) => {
     ) : (
       renderIconPlaceholder && (
         <IconPlaceholder
-          aria-hidden
           data-testid={`menu-item-${renderedIconID}-icon-placeholder`}
-          mr="xsmall"
           size={compact ? 'small' : 'medium'}
         />
       )
@@ -219,11 +211,4 @@ export const MenuItem = styled(MenuItemInternal)`
   ${Icon} {
     align-self: ${({ description }) => (description ? 'flex-start' : 'center')};
   }
-`
-
-interface IconPlaceholderProps extends SizeProps, SpaceProps {}
-
-const IconPlaceholder = styled.div<IconPlaceholderProps>`
-  ${size}
-  ${space}
 `

--- a/packages/storybook-config/src/main.js
+++ b/packages/storybook-config/src/main.js
@@ -38,9 +38,6 @@ const addonEssentials = {
 const config = {
   addons: [addonEssentials],
   stories: ['../**/*.story.tsx'],
-  typescript: {
-    reactDocgen: false,
-  },
   webpackFinal: async (config) => {
     config.module.rules.push({
       test: /\.tsx?$/,

--- a/packages/storybook-config/src/main.js
+++ b/packages/storybook-config/src/main.js
@@ -38,6 +38,9 @@ const addonEssentials = {
 const config = {
   addons: [addonEssentials],
   stories: ['../**/*.story.tsx'],
+  typescript: {
+    reactDocgen: false,
+  },
   webpackFinal: async (config) => {
     config.module.rules.push({
       test: /\.tsx?$/,


### PR DESCRIPTION
### :sparkles: Changes

1. Fixed `Select` alignment of options when some have icons and others do not.
2. `Select` inappropriately shows "No options" when the current value is empty, after filtering a long list down to a single option then deleting the filter text. 
  _Test with the 2nd Select on :3333/?path=/story/fieldselect--select-content_
3. Fixed `Select` remounting its options when the options prop changes due to this fix for a different issue: https://github.com/looker-open-source/components/pull/1240. This causes select via click to fail if the options prop "changes" (same values, new array instance) after a mousedown, e.g. if a parent component contains `usePopover`. 
  _Test with the Open Popover button on :3333/?path=/story/fieldselect--select-demo_

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes (except the 3rd issue, which I wasn't able to simulate in RTL)
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue 1 Before
<img width="250" alt="Screen Shot 2020-10-26 at 1 44 30 PM" src="https://user-images.githubusercontent.com/53451193/97227805-3d3d7000-1793-11eb-93c6-d4f7454a4e35.png">

#### Issue 1 After
<img width="248" alt="Screen Shot 2020-10-26 at 1 47 08 PM" src="https://user-images.githubusercontent.com/53451193/97227756-2d259080-1793-11eb-8977-2fe20ea585b5.png">

#### Issue 2 Before
![2e00cb9a-09d5-4e76-9b62-4194ddfae0e0](https://user-images.githubusercontent.com/53451193/97227915-652cd380-1793-11eb-8ad6-5433bfeceda3.gif)

#### Issue 2 After
![772cfcc2-972e-4f12-9e53-a621a4e617bc](https://user-images.githubusercontent.com/53451193/97227910-6231e300-1793-11eb-8a1d-b4e1a3af5f5d.gif)

#### Issue 3 Before
![d8ed5024-c49c-4897-80ae-6390d070c05d](https://user-images.githubusercontent.com/53451193/97227971-7970d080-1793-11eb-8989-14f4565a328c.gif)

#### Issue 3 After
![fa86b795-3b88-4a08-8ef5-beb36bbe7683](https://user-images.githubusercontent.com/53451193/97228006-87265600-1793-11eb-9407-db34183f9a8b.gif)