### PR TITLE
usePopper: render off screen until true position is calculated

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Popover` flashing in the upper left corner of the screen on slow pages
 - `InputColor` no longer allows user to click swatch when `readOnly` is assigned
 - `Select` alignment of options when some have icons and others do not
 - `Select` inappropriately shows "No options" when the current value is empty, after filtering a long list down to a single option then deleting the filter text

--- a/packages/components/src/utils/usePopper.ts
+++ b/packages/components/src/utils/usePopper.ts
@@ -47,7 +47,8 @@ export function usePopper({ anchor, target, options }: UsePopperProps) {
       left: '0',
       margin: '0',
       position: 'fixed',
-      top: '0',
+      // Initially render off the screen while PopperJS calculates position
+      top: '-9999px',
     },
   })
   const [truePlacement, setTruePlacement] = useState(options.placement)


### PR DESCRIPTION
### :sparkles: Changes

- On very slow pages, Popover flashes in briefly in the upper left corner of the page (due the initial `styles` value) before moving to its proper place, with `PopperJS`-calculated positioning
- Hiding the surface with `opacity` or `visibility` causes all sorts of unit test havoc, but moving it off the screen with a negative `top` value should do the trick.
- `display: none` is definitely a no-go – it would break `PopperJS`'s ability to calculate the correct position based on the surface's dimensions
- I tried and failed to create an example page slow enough to reproduce the bug, but I'm 99% sure this will fix the issue – and it doesn't break anything
 
### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
