### PR TITLE
Popover: honor 1st click outside

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Popover` and `Menu` no longer cancel the first click outside by default (use `cancelClickOutside` to override this)
+- `Popover`, `Menu`, and `Select` no longer cancel the first click outside by default (use `cancelClickOutside` to override this)
 - `DialogContent` no longer has `py` unless it overflows the available space (acting as `overflow: scroll`)
 
 ### Fixed

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Popover` and `Menu` no longer cancel the first click outside by default (use `cancelClickOutside` to override this)
 - `DialogContent` no longer has `py` unless it overflows the available space (acting as `overflow: scroll`)
 
 ### Fixed
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `groupedPopoversRef` and `groupedMenusRef` (`Popover` and `Menu` no longer cancel the first click outside)
 - `Dialog` no longer supports `maxWidth` (it's now always `100%` - use `width`)
 - `Drawer` no longer supports `height` (use `minHeight`)
 - `Dialog` no longer supports `surfaceStyles` (use built-in props instead)

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
@@ -184,7 +184,6 @@ const InputSearchLayout = forwardRef(
           <ComboboxList
             persistSelection
             windowedOptions={windowedOptions}
-            cancelClickOutside={false}
             indicator={indicator}
             width={autoResize ? 'auto' : undefined}
             aria-busy={isLoading}

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -177,7 +177,6 @@ const SelectComponent = forwardRef(
           <ComboboxList
             persistSelection
             windowedOptions={windowedOptions}
-            cancelClickOutside={!isFilterable}
             indicator={indicator}
             width={autoResize ? 'auto' : undefined}
             aria-busy={isLoading}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -148,7 +148,6 @@ const SelectMultiComponent = forwardRef(
             persistSelection
             closeOnSelect={closeOnSelect}
             windowedOptions={windowedOptions}
-            cancelClickOutside={!isFilterable && !freeInput}
             indicator={indicator}
             aria-busy={isLoading}
             {...ariaProps}

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -50,19 +50,11 @@ export interface MenuProps {
    * Use for controlled menu
    */
   setOpen?: (isOpen: boolean) => void
-
-  /**
-   * This prop exposes the groupedPopoversRef prop of the wrapped Popover component rendered by MenuList.
-   * This allows transitions between menus in a group without clicking twice
-   * (first to dismiss the current menu, and again to open the target menu)
-   */
-  groupedMenusRef?: RefObject<HTMLElement>
 }
 
 export const Menu: FC<MenuProps> = ({
   children,
   disabled,
-  groupedMenusRef,
   hoverDisclosureRef,
   id: propsID,
   isOpen: controlledIsOpen = false,
@@ -76,7 +68,6 @@ export const Menu: FC<MenuProps> = ({
 
   const context = {
     disabled,
-    groupedMenusRef,
     id,
     isOpen: isControlled.current ? controlledIsOpen : isOpen,
     setOpen: isControlled.current ? controlledSetOpen : setOpen,

--- a/packages/components/src/Menu/MenuContext.ts
+++ b/packages/components/src/Menu/MenuContext.ts
@@ -24,7 +24,7 @@
 
  */
 
-import { createContext, KeyboardEvent, RefObject } from 'react'
+import { createContext, KeyboardEvent } from 'react'
 
 export interface MenuContextProps {
   disabled?: boolean
@@ -34,7 +34,6 @@ export interface MenuContextProps {
   setOpen?: (isOpen: boolean) => void
   triggerElement?: HTMLElement | null
   triggerCallbackRef?: (node: HTMLElement | null) => void
-  groupedMenusRef?: RefObject<HTMLElement>
 }
 
 export interface MenuItemContextProps {

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -101,9 +101,7 @@ export const MenuListInternal = forwardRef(
     { children, compact, disabled, pin, placement, ...props }: MenuListProps,
     forwardedRef: Ref<HTMLUListElement>
   ) => {
-    const { groupedMenusRef, id, isOpen, setOpen, triggerElement } = useContext(
-      MenuContext
-    )
+    const { id, isOpen, setOpen, triggerElement } = useContext(MenuContext)
 
     const [renderIconPlaceholder, setRenderIconPlaceholder] = useState(false)
 
@@ -148,7 +146,6 @@ export const MenuListInternal = forwardRef(
     const isMenu = isOpen !== undefined
     const { popover } = usePopover({
       content: menuList,
-      groupedPopoversRef: groupedMenusRef,
       isOpen,
       pin,
       placement,

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -34,31 +34,6 @@ import { Popover } from './Popover'
 
 const SimpleContent = <div>simple content</div>
 
-const instantClick = jest.fn()
-const requiresDismissal = jest.fn()
-
-const PopoverGroup = () => {
-  const groupRef = useRef<null | HTMLDivElement>(null)
-
-  return (
-    <>
-      <div ref={groupRef}>
-        <Popover content={SimpleContent} groupedPopoversRef={groupRef}>
-          <a>Instant Click</a>
-        </Popover>
-
-        <a onClick={instantClick} id="instant">
-          Should activate instantly
-        </a>
-      </div>
-
-      <button onClick={requiresDismissal} id="dismissed">
-        Should require dismissal click
-      </button>
-    </>
-  )
-}
-
 describe('Popover', () => {
   afterEach(() => {
     const root = document.getElementById('modal-root')
@@ -147,7 +122,7 @@ describe('Popover', () => {
     fireEvent.click(document)
   })
 
-  test('Open popover cancels event on "dismissal click"', () => {
+  test('Open popover does not cancel event on "dismissal click"', () => {
     const doThing = jest.fn()
 
     const { getByText, queryByText } = renderWithTheme(
@@ -165,15 +140,15 @@ describe('Popover', () => {
     const closer = getByText('Do thing...')
     fireEvent.click(closer)
     expect(queryByText('simple content')).not.toBeInTheDocument()
-    expect(doThing).toBeCalledTimes(0)
+    expect(doThing).toBeCalledTimes(1)
   })
 
-  test('With cancelClickOutside = false, open popover does not cancel click event', () => {
+  test('With cancelClickOutside = true, open popover cancels 1st click event', () => {
     const doThing = jest.fn()
 
     const { getByText, queryByText } = renderWithTheme(
       <>
-        <Popover content={SimpleContent} cancelClickOutside={false}>
+        <Popover content={SimpleContent} cancelClickOutside>
           <button>Instant Click</button>
         </Popover>
         <a onClick={doThing}>Do thing...</a>
@@ -186,36 +161,7 @@ describe('Popover', () => {
     const closer = getByText('Do thing...')
     fireEvent.click(closer)
     expect(queryByText('simple content')).not.toBeInTheDocument()
-    expect(doThing).toBeCalledTimes(1)
-  })
-
-  test('Popover Group - item outside group does NOT receive first click event', () => {
-    const { getByText, queryByText } = renderWithTheme(<PopoverGroup />)
-    const trigger = getByText('Instant Click')
-    fireEvent.click(trigger) // open Popover
-
-    const dismissed = getByText('Should require dismissal click')
-    fireEvent.click(dismissed)
-    // @FAIL - Doesn't work because Popover is looking for an event sent via document.addEventListener
-    expect(queryByText('simple content')).not.toBeInTheDocument()
-    expect(requiresDismissal).toBeCalledTimes(0)
-  })
-
-  test('Popover Group  - item within group immediately receives onClick', () => {
-    const { getByText, queryByText } = renderWithTheme(<PopoverGroup />)
-    const trigger = getByText('Instant Click')
-    fireEvent.click(trigger) // open Popover
-
-    const instant = getByText('Should activate instantly')
-    fireEvent.click(instant)
-
-    /*
-     * Testing this with Jest is frustrating because the component expects to operating with a real DOM
-     * environment. Popover is looking for an event sent via document.addEventListener which isn't
-     * produced within Jest's environment. Attempts at mocking haven't been successful.
-     */
-    expect(queryByText('simple content')).not.toBeInTheDocument()
-    expect(instantClick).toBeCalledTimes(1)
+    expect(doThing).toBeCalledTimes(0)
   })
 
   test('Popover trigger is shown/hidden on hover of hoverDisclosureRef', () => {

--- a/packages/components/src/Popover/usePopover.tsx
+++ b/packages/components/src/Popover/usePopover.tsx
@@ -30,7 +30,6 @@ import React, {
   useEffect,
   useMemo,
   ReactNode,
-  RefObject,
   SyntheticEvent,
   useState,
   Ref,
@@ -92,17 +91,6 @@ export interface UsePopoverProps {
   portalElement?: HTMLDivElement | null
 
   /**
-   * By default Popover cancels event bubbling when a click event triggers the closure of the Popover.
-   * This was deemed a best practice as it prevents inadvertent destructive actions and mirrors behavior
-   * seen in many commonly used applications (e.g. Chrome).
-   *
-   * However, where several related Popover components are grouped together, cancelling event bubbling for
-   * the "dismissal click" can make for an awkward UX. In these cases the developer can specify a ref for a
-   * component that contains the related Popovers and the event-bubble cancellation will not take place.
-   */
-  groupedPopoversRef?: RefObject<HTMLElement>
-
-  /**
    * By default Popover will reposition itself if they overflow the widow.
    * You can use the pin property to override this behavior.
    */
@@ -132,7 +120,7 @@ export interface UsePopoverProps {
 
   /**
    * Whether to honor the first click outside the popover
-   * @default true
+   * @default false
    */
   cancelClickOutside?: boolean
 }
@@ -165,7 +153,6 @@ export interface UsePopoverResponseDom {
 export const usePopover = ({
   canClose,
   content,
-  groupedPopoversRef,
   pin = false,
   isOpen: controlledIsOpen = false,
   onClose,
@@ -197,7 +184,6 @@ export const usePopover = ({
     {
       canClose,
       cancelClickOutside,
-      groupedPopoversRef,
       isOpen: controlledIsOpen,
       setOpen: controlledSetOpen,
       triggerToggle,

--- a/packages/components/src/Popover/usePopoverToggle.tsx
+++ b/packages/components/src/Popover/usePopoverToggle.tsx
@@ -42,17 +42,11 @@ export const usePopoverToggle = (
     isOpen: controlledIsOpen = false,
     setOpen: controlledSetOpen,
     canClose,
-    groupedPopoversRef,
     triggerToggle,
-    cancelClickOutside = true,
+    cancelClickOutside = false,
   }: Pick<
     UsePopoverProps,
-    | 'isOpen'
-    | 'setOpen'
-    | 'canClose'
-    | 'groupedPopoversRef'
-    | 'triggerToggle'
-    | 'cancelClickOutside'
+    'isOpen' | 'setOpen' | 'canClose' | 'triggerToggle' | 'cancelClickOutside'
   >,
   portalElement: HTMLElement | null,
   triggerElement: HTMLElement | null
@@ -109,13 +103,7 @@ export const usePopoverToggle = (
         return
       }
 
-      if (
-        !cancelClickOutside ||
-        // Group-member clicked, allow event to propagate
-        (groupedPopoversRef &&
-          groupedPopoversRef.current &&
-          groupedPopoversRef.current.contains(event.target as Node))
-      ) {
+      if (!cancelClickOutside) {
         return
       }
 
@@ -155,7 +143,6 @@ export const usePopoverToggle = (
   }, [
     cancelClickOutside,
     canClose,
-    groupedPopoversRef,
     isOpen,
     setOpen,
     triggerElement,

--- a/storybook/src/Overlays/Popovers/Popover.stories.tsx
+++ b/storybook/src/Overlays/Popovers/Popover.stories.tsx
@@ -24,15 +24,15 @@
 
  */
 
-import React, { useEffect, useRef, useContext } from 'react'
+import React, { useEffect, useContext } from 'react'
 import { ScrollLockContext } from '@looker/components-providers'
 import {
   Box,
   Button,
   ButtonOutline,
-  ButtonTransparent,
   Dialog,
   FieldSelect,
+  FieldToggleSwitch,
   Heading,
   Menu,
   MenuDisclosure,
@@ -81,6 +81,7 @@ export default {
 }
 
 export const PopoverFocusTrap = () => {
+  const { value, toggle } = useToggle(false)
   function getButtonAlert(text: string) {
     return () => alert(text)
   }
@@ -88,10 +89,14 @@ export const PopoverFocusTrap = () => {
   return (
     <SpaceVertical mt="large">
       <Heading>Focus Trap Test</Heading>
-      <Paragraph>With cancelClickOutside=false</Paragraph>
+      <FieldToggleSwitch
+        on={value}
+        onChange={() => toggle()}
+        label="Cancel Click Outside"
+      />
       <Space>
         <Popover
-          cancelClickOutside={false}
+          cancelClickOutside={value}
           content={
             <PopoverContent p="large" width="360px">
               <Paragraph>
@@ -142,9 +147,7 @@ export const PopoverFocusTrap = () => {
         >
           <Button>Open Focus Trap Test Popover</Button>
         </Popover>
-        <ButtonOutline
-          onClick={() => alert('cancelClickOutside=false is working')}
-        >
+        <ButtonOutline onClick={() => alert(`You clicked the button!`)}>
           Click me with the popover open
         </ButtonOutline>
       </Space>
@@ -295,44 +298,6 @@ export const Placement = () => {
 
         <Popover content={popoverContent}>
           <Button>Default</Button>
-        </Popover>
-      </Box>
-    </Box>
-  )
-}
-
-export const Grouped = () => {
-  const groupRef = useRef<HTMLDivElement>(null)
-  const content = (
-    <PopoverContent p="large" width="360px">
-      Example Popover text.
-    </PopoverContent>
-  )
-  return (
-    <Box mt="large">
-      <Heading>Grouped Popovers</Heading>
-      <Box display="flex">
-        <Box
-          display="flex"
-          justifyContent="space-around"
-          ref={groupRef}
-          p="large"
-          border="3px solid green"
-        >
-          <Popover content={content} groupedPopoversRef={groupRef}>
-            <Button>Instant Click</Button>
-          </Popover>
-          <Popover content={content} groupedPopoversRef={groupRef}>
-            <Button mx="large">Instant Click</Button>
-          </Popover>
-          <Popover content={content}>
-            <ButtonOutline>Defer Click</ButtonOutline>
-          </Popover>
-        </Box>
-        <Popover content={content}>
-          <ButtonTransparent mx="xlarge" my="large">
-            Outside Group
-          </ButtonTransparent>
         </Popover>
       </Box>
     </Box>

--- a/www/src/documentation/components/overlays/menu.mdx
+++ b/www/src/documentation/components/overlays/menu.mdx
@@ -18,7 +18,6 @@ The entire menu can be disabled via the `disabled` prop.
 - `onFocus` - and `onMouseOver` - show the tooltip
 - `onBlur` - and `onMouseOut` - hides the tooltip
 - `ref` - tooltip and popover placement
-- `groupedMenusRef` - reference to the container of a group of menu
 
 ```jsx
 <Space>
@@ -105,37 +104,6 @@ Control the state of the menu with the React `useState` hook.
         </Menu>
       </Flex>
     </Card>
-  )
-}
-```
-
-## Grouped Menus
-
-```jsx
-;() => {
-  const containerRef = React.useRef()
-  return (
-    <Space ref={containerRef}>
-      <Menu groupedMenusRef={containerRef}>
-        <MenuDisclosure tooltip="Select your favorite kind">
-          <Button>Cheese</Button>
-        </MenuDisclosure>
-        <MenuList>
-          <MenuItem icon="FavoriteOutline">Gouda</MenuItem>
-          <MenuItem icon="FavoriteOutline">Swiss</MenuItem>
-        </MenuList>
-      </Menu>
-
-      <Menu groupedMenusRef={containerRef}>
-        <MenuDisclosure tooltip="Select your favorite pet">
-          <Button>Pet</Button>
-        </MenuDisclosure>
-        <MenuList>
-          <MenuItem icon="FavoriteOutline">Dog</MenuItem>
-          <MenuItem icon="FavoriteOutline">Cat</MenuItem>
-        </MenuList>
-      </Menu>
-    </Space>
   )
 }
 ```

--- a/www/src/documentation/components/overlays/popover.mdx
+++ b/www/src/documentation/components/overlays/popover.mdx
@@ -78,50 +78,6 @@ Placement can be adjusted with the `placement` prop. Valid positions are `top`, 
 }
 ```
 
-## Grouped Popovers
-
-By default Popover cancels event bubbling when a click event triggers the closure of the Popover. \* This was deemed a best practice as it prevents inadveted destructive actions and mirrors behavior seen in many commonly used applications (e.g. Chrome).
-
-However, where several related Popover components are grouped together, cancelling event bubbling for the "dismissal click" can make for an awkward UX. This functionality is used for items grouped to create a larger navigation component or associated controls such as a collection of filters.
-
-To create a group, assigned a reference to an containing element and then assign the reference to that element to `groupedPopoversRef` on each `Popover`. This will override the `Popover` component's usual behavior of cancelling event propagation on the clicks outside of the `Portal` associated with the `Popover`. The first click outside of the `Portal` will still close the `Popover` but click event propagation or otherwise suppressed and instead will be allowed to produce its usual behavior.
-
-```jsx
-;() => {
-  const groupRef = React.useRef()
-  const content = (
-    <PopoverContent p="large" width="360px">
-      Example Popover text.
-    </PopoverContent>
-  )
-  return (
-    <Space>
-      <Space
-        around
-        ref={groupRef}
-        p="large"
-        style={{ border: '3px solid green' }}
-      >
-        <Popover content={content} groupedPopoversRef={groupRef}>
-          <Button>Instant Click</Button>
-        </Popover>
-        <Popover content={content} groupedPopoversRef={groupRef}>
-          <Button mx="large">Instant Click</Button>
-        </Popover>
-        <Popover content={content}>
-          <ButtonOutline>Defer Click</ButtonOutline>
-        </Popover>
-      </Space>
-      <Popover content={content}>
-        <ButtonTransparent mx="xlarge" my="large">
-          Outside Group
-        </ButtonTransparent>
-      </Popover>
-    </Space>
-  )
-}
-```
-
 ## Disclosing the Trigger on Hover
 
 ```jsx


### PR DESCRIPTION
### :sparkles: Changes

- Reversed the default of `Popover`'s `cancelClickOutside` prop from true to false
- Removed `groupedPopoversRef` and the very recent `groupedMenusRef` since they won't be needed anymore

## Questions
1. Do we want to keep the `cancelClickOutside` prop? If so, should we document it or keep it on the DL?
2. Currently a **non-filterable** `Select` has `cancelClickOutside={true}` to mimic a native browser select. Do we still want this?

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
