### PR TITLE
Support autoFocus in Combobox-based components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Select`, `SelectMulti`, `InputTimeSelect`, and `InputSearch` now support `autoFocus` as well as `data-autofocus` (for use in `Dialog` and `Popover`)
+- The `autoFocus` prop will now work for inputs in `Popover` and `Dialog`
+- `Select`, `SelectMulti`, `InputTimeSelect`, and `InputSearch` now support `autoFocus`
 - `Dialog` & `Drawer` now support semantic sizes (`xxsmall - xlarge`)
 - `Dialog` now supports `placement` - `center` (default), `top` & `cover`
 - `Drawer` now supports `placement` - `left` & `right` (default)

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Select`, `SelectMulti`, `InputTimeSelect`, and `InputSearch` now support `autoFocus` as well as `data-autofocus` (for use in `Dialog` and `Popover`)
 - `Dialog` & `Drawer` now support semantic sizes (`xxsmall - xlarge`)
 - `Dialog` now supports `placement` - `center` (default), `top` & `cover`
 - `Drawer` now supports `placement` - `left` & `right` (default)

--- a/packages/components/src/Form/Fields/FieldCheckboxGroup/FieldCheckboxGroup.story.tsx
+++ b/packages/components/src/Form/Fields/FieldCheckboxGroup/FieldCheckboxGroup.story.tsx
@@ -94,6 +94,7 @@ const defaultValueCheckbox = ['swiss', 'cheddar']
 const Template: Story<FieldCheckboxGroupProps> = (args) => (
   <FieldCheckboxGroup
     {...args}
+    autoFocus
     defaultValue={defaultValueCheckbox}
     label="Cheeses"
     description="Pick all your cheeses"

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
@@ -234,7 +234,7 @@ export const SelectContent = () => {
         aria-label="Fruits"
         placeholder="Select Brand"
         defaultValue="Boulder Creek"
-        data-autofocus="true"
+        autoFocus
       />
       <Label>
         Use alignSelf="flex-start" to avoid filling height as a flex child

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
@@ -234,6 +234,7 @@ export const SelectContent = () => {
         aria-label="Fruits"
         placeholder="Select Brand"
         defaultValue="Boulder Creek"
+        data-autofocus="true"
       />
       <Label>
         Use alignSelf="flex-start" to avoid filling height as a flex child
@@ -376,6 +377,7 @@ export const SelectDemo = () => {
               aria-label="Fruits"
               defaultValue="1"
               isClearable
+              autoFocus
             />
           </Form>
         </CardContent>

--- a/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.story.tsx
@@ -27,7 +27,12 @@
 import { Story } from '@storybook/react/types-6-0'
 import React, { useMemo, useState, useEffect } from 'react'
 import { Button } from '../../../Button'
-import { Dialog, DialogContent } from '../../../Dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from '../../../Dialog'
 import { Icon } from '../../../Icon'
 import { Space, SpaceVertical } from '../../../Layout'
 import { List, ListItem } from '../../../List'
@@ -280,6 +285,7 @@ export const SelectMultiDemo = () => {
   return (
     <SpaceVertical p="large" width={400}>
       <Dialog isOpen={isOpen} onClose={handleClose}>
+        <DialogHeader>SelectMulti in a Dialog</DialogHeader>
         <DialogContent>
           <FieldSelectMulti
             options={newOptions1k}
@@ -290,8 +296,10 @@ export const SelectMultiDemo = () => {
             showCreate
             defaultValues={['Boulder Creek']}
             freeInput
+            data-autofocus="true"
           />
         </DialogContent>
+        <DialogFooter />
       </Dialog>
       <Button onClick={handleClick}>Open</Button>
       <Heading>FieldSelectMulti</Heading>
@@ -308,6 +316,7 @@ export const SelectMultiDemo = () => {
           description="this is the description"
           values={['cheddar']}
           options={cheeseOptions}
+          autoFocus
         />
       </SpaceVertical>
       <Heading>SelectMulti</Heading>

--- a/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.story.tsx
@@ -296,7 +296,7 @@ export const SelectMultiDemo = () => {
             showCreate
             defaultValues={['Boulder Creek']}
             freeInput
-            data-autofocus="true"
+            autoFocus
           />
         </DialogContent>
         <DialogFooter />

--- a/packages/components/src/Form/Fields/FieldTimeSelect/FieldTimeSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldTimeSelect/FieldTimeSelect.story.tsx
@@ -93,6 +93,7 @@ export const Controlled = () => {
           label="Standard Time"
           value={controlledTime}
           onChange={setControlledTime}
+          autoFocus
         />
         <FieldTimeSelect
           label="Military Time"

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -25,12 +25,11 @@
  */
 
 import noop from 'lodash/noop'
-import pick from 'lodash/pick'
 import React, { forwardRef, Ref, useState, FormEvent, useEffect } from 'react'
 import styled from 'styled-components'
 import { reset, space, SpaceProps } from '@looker/design-tokens'
 import isUndefined from 'lodash/isUndefined'
-import { InputProps, inputPropKeys } from '../InputProps'
+import { InputProps, pickInputProps } from '../InputProps'
 import { ValidationType } from '../../ValidationMessage'
 import { inputTextValidation } from '../InputText'
 
@@ -82,7 +81,7 @@ const CheckboxLayout = forwardRef(
       <div className={className}>
         <input
           type="checkbox"
-          {...pick(restProps, inputPropKeys)}
+          {...pickInputProps(restProps)}
           checked={!!isChecked}
           aria-checked={checked}
           aria-invalid={validationType === 'error' ? 'true' : undefined}

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import pick from 'lodash/pick'
 import React, { ChangeEvent, forwardRef, Ref, useState } from 'react'
 import isFunction from 'lodash/isFunction'
 import styled from 'styled-components'
@@ -33,7 +32,7 @@ import {
   typography,
   TypographyProps,
 } from '@looker/design-tokens'
-import { inputPropKeys, InputProps, InputTextTypeProps } from '../InputProps'
+import { pickInputProps, InputProps, InputTextTypeProps } from '../InputProps'
 import { innerInputStyle } from '../innerInputStyle'
 
 export interface InlineInputTextProps
@@ -75,7 +74,7 @@ const InlineInputTextLayout = forwardRef(
           placeholder={placeholder}
           type={type}
           ref={ref}
-          {...omitStyledProps(pick(props, inputPropKeys))}
+          {...omitStyledProps(pickInputProps(props))}
         />
         <StyledText>{displayValue || placeholder || ' '}</StyledText>
       </span>

--- a/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
+++ b/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import pick from 'lodash/pick'
 import React, { ChangeEvent, forwardRef, Ref, useState } from 'react'
 import isFunction from 'lodash/isFunction'
 import styled from 'styled-components'
@@ -35,7 +34,7 @@ import {
   CompatibleHTMLProps,
   LayoutProps,
 } from '@looker/design-tokens'
-import { inputPropKeys } from '../InputProps'
+import { pickInputProps } from '../InputProps'
 
 export interface InlineTextAreaProps
   extends Omit<LayoutProps, 'size'>,
@@ -75,7 +74,7 @@ export const InlineTextAreaLayout = forwardRef(
           ref={ref}
           underlineOnlyOnHover={underlineOnlyOnHover}
           value={displayValue}
-          {...pick(props, inputPropKeys)}
+          {...pickInputProps(props)}
         />
         <VisibleText displayValue={displayValue}>
           {displayValue || placeholder}

--- a/packages/components/src/Form/Inputs/InputProps.ts
+++ b/packages/components/src/Form/Inputs/InputProps.ts
@@ -24,11 +24,14 @@
 
  */
 
+import pick from 'lodash/pick'
 import { CompatibleHTMLProps } from '@looker/design-tokens'
 import { ValidationType } from '../ValidationMessage'
 
 export interface InputProps extends CompatibleHTMLProps<HTMLInputElement> {
   validationType?: ValidationType
+  'data-autofocus'?: string
+  'data-testid'?: string
 }
 
 export interface InputTextTypeProps {
@@ -92,3 +95,19 @@ export const inputPropKeys = [
   'aria-describedby',
   'aria-labelledby',
 ]
+/**
+ * Adds data-autofocus attribute for use with focus-trap (Popover & Dialog)
+ * Can't use the autofocus dom attribute b/c React does not pass it down
+ * https://github.com/facebook/react/issues/11851
+ */
+export const getAutoFocusProps = (autoFocus?: boolean) => {
+  return autoFocus ? { autoFocus, 'data-autofocus': 'true' } : {}
+}
+
+export const pickInputProps = <T extends { autoFocus?: boolean }>({
+  autoFocus,
+  ...props
+}: T) => {
+  const inputProps = pick(props, inputPropKeys)
+  return { ...getAutoFocusProps(autoFocus), ...inputProps }
+}

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.story.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.story.tsx
@@ -92,6 +92,7 @@ export const Advanced = () => {
       options={options}
       noOptionsLabel="Nothing matched your search"
       isClearable={false}
+      autoFocus
     />
   )
 }

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
@@ -90,6 +90,8 @@ const InputSearchLayout = forwardRef(
     {
       options,
       disabled,
+      autoFocus,
+      'data-autofocus': dataAutofocus,
       isClearable = true,
       placeholder,
       name,
@@ -169,6 +171,8 @@ const InputSearchLayout = forwardRef(
           iconBefore={hideSearchIcon ? undefined : 'Search'}
           iconBeforeTitle={hideSearchIcon ? undefined : 'Search'}
           disabled={disabled}
+          autoFocus={autoFocus}
+          data-autofocus={dataAutofocus}
           placeholder={placeholder}
           name={name}
           validationType={props.validationType}

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
@@ -91,7 +91,6 @@ const InputSearchLayout = forwardRef(
       options,
       disabled,
       autoFocus,
-      'data-autofocus': dataAutofocus,
       isClearable = true,
       placeholder,
       name,
@@ -172,7 +171,6 @@ const InputSearchLayout = forwardRef(
           iconBeforeTitle={hideSearchIcon ? undefined : 'Search'}
           disabled={disabled}
           autoFocus={autoFocus}
-          data-autofocus={dataAutofocus}
           placeholder={placeholder}
           name={name}
           validationType={props.validationType}

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import pick from 'lodash/pick'
 import omit from 'lodash/omit'
 import { IconNames } from '@looker/icons'
 import {
@@ -36,7 +35,12 @@ import {
 } from '@looker/design-tokens'
 import React, { forwardRef, MouseEvent, ReactNode, Ref, useRef } from 'react'
 import styled, { css } from 'styled-components'
-import { InputProps, inputPropKeys, InputTextTypeProps } from '../InputProps'
+import {
+  InputProps,
+  inputPropKeys,
+  InputTextTypeProps,
+  pickInputProps,
+} from '../InputProps'
 import { innerInputStyle } from '../innerInputStyle'
 import { SimpleLayoutProps } from '../../../Layout/utils/simple'
 import { Icon } from '../../../Icon'
@@ -194,7 +198,7 @@ const InputTextLayout = forwardRef(
     )
 
     const inputProps = {
-      ...pick(omitStyledProps(props), inputPropKeys),
+      ...pickInputProps(omitStyledProps(props)),
       'aria-invalid': validationType === 'error' ? true : undefined,
       type,
     }

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -53,6 +53,7 @@ import {
   simpleLayoutCSS,
   SimpleLayoutProps,
 } from '../../../Layout/utils/simple'
+import { getAutoFocusProps } from '../InputProps'
 import {
   formatTimeString,
   TimeFormats,
@@ -62,6 +63,7 @@ import {
 import { ValidationType } from '../../ValidationMessage'
 
 export interface InputTimeProps extends Omit<SimpleLayoutProps, 'size'> {
+  autoFocus?: boolean
   format?: TimeFormats
   defaultValue?: string
   value?: string
@@ -265,6 +267,7 @@ const InputTimeInternal = forwardRef(
     {
       className,
       defaultValue,
+      autoFocus,
       disabled,
       format = '12h',
       id,
@@ -481,6 +484,7 @@ const InputTimeInternal = forwardRef(
           disabled={disabled}
           readOnly={readOnly}
           required={required}
+          {...getAutoFocusProps(autoFocus)}
         />
         <div>:</div>
         <StyledInput

--- a/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.tsx
+++ b/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.tsx
@@ -86,10 +86,6 @@ export interface InputTimeSelectProps
   onChange?: (val?: string) => void
   validationType?: ValidationType
   onValidationFail?: (value: string) => void
-  /**
-   * Sets initial focus when inside a Dialog or Popover
-   */
-  'data-autofocus'?: string
 }
 
 // if format is `12h`, repeat hours 1-12 twice
@@ -281,7 +277,6 @@ const InputTimeSelectLayout = forwardRef(
       validationType,
       disabled,
       autoFocus,
-      'data-autofocus': dataAutofocus,
       id,
       ...props
     }: InputTimeSelectProps,
@@ -390,7 +385,6 @@ const InputTimeSelectLayout = forwardRef(
           validationType={validationType}
           disabled={disabled}
           autoFocus={autoFocus}
-          data-autofocus={dataAutofocus}
           id={id}
           {...ariaProps}
         />

--- a/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.tsx
+++ b/packages/components/src/Form/Inputs/InputTimeSelect/InputTimeSelect.tsx
@@ -86,6 +86,10 @@ export interface InputTimeSelectProps
   onChange?: (val?: string) => void
   validationType?: ValidationType
   onValidationFail?: (value: string) => void
+  /**
+   * Sets initial focus when inside a Dialog or Popover
+   */
+  'data-autofocus'?: string
 }
 
 // if format is `12h`, repeat hours 1-12 twice
@@ -276,6 +280,8 @@ const InputTimeSelectLayout = forwardRef(
       defaultValue,
       validationType,
       disabled,
+      autoFocus,
+      'data-autofocus': dataAutofocus,
       id,
       ...props
     }: InputTimeSelectProps,
@@ -383,6 +389,8 @@ const InputTimeSelectLayout = forwardRef(
           autoComplete={false}
           validationType={validationType}
           disabled={disabled}
+          autoFocus={autoFocus}
+          data-autofocus={dataAutofocus}
           id={id}
           {...ariaProps}
         />

--- a/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
@@ -50,6 +50,7 @@ function getCheckedProps(
 const CheckboxGroupLayout = forwardRef(
   (
     {
+      autoFocus,
       disabled,
       inline,
       name: propsName,
@@ -81,8 +82,9 @@ const CheckboxGroupLayout = forwardRef(
       [onChange, value]
     )
 
-    const checkboxes = options.map((option) => {
+    const checkboxes = options.map((option, index) => {
       const checkedProps = getCheckedProps(option.value, value, defaultValue)
+      const autoFocusProps = index === 0 && autoFocus ? { autoFocus } : {}
       const handleChange = getChangeHandler(option.value)
 
       return (
@@ -96,6 +98,7 @@ const CheckboxGroupLayout = forwardRef(
           validationType={validationType}
           value={option.value}
           {...checkedProps}
+          {...autoFocusProps}
         />
       )
     })

--- a/packages/components/src/Form/Inputs/OptionsGroup/OptionsGroup.ts
+++ b/packages/components/src/Form/Inputs/OptionsGroup/OptionsGroup.ts
@@ -42,6 +42,7 @@ export interface OptionsGroupProps<ValueType extends string | string[]>
   extends OptionsGroupLayout {
   name?: string
   id?: string
+  autoFocus?: boolean
   disabled?: boolean
   required?: boolean
   options: OptionsGroupOptionProps[]

--- a/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
@@ -49,6 +49,7 @@ function getCheckedProps(
 const RadioGroupLayout = forwardRef(
   (
     {
+      autoFocus,
       disabled,
       inline,
       name: propsName,
@@ -70,13 +71,14 @@ const RadioGroupLayout = forwardRef(
       [onChange]
     )
 
-    const radios = options.map((option) => {
+    const radios = options.map((option, index) => {
       const checkedProps = getCheckedProps(
         option.value,
         isControlled,
         value,
         defaultValue
       )
+      const autoFocusProps = index === 0 && autoFocus ? { autoFocus } : {}
 
       return (
         <FieldRadio
@@ -87,6 +89,7 @@ const RadioGroupLayout = forwardRef(
           name={name}
           onChange={getChangeHandler(option.value)}
           {...checkedProps}
+          {...autoFocusProps}
         />
       )
     })

--- a/packages/components/src/Form/Inputs/Radio/Radio.tsx
+++ b/packages/components/src/Form/Inputs/Radio/Radio.tsx
@@ -24,11 +24,10 @@
 
  */
 
-import pick from 'lodash/pick'
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import { reset, space, SpaceProps } from '@looker/design-tokens'
-import { InputProps, inputPropKeys } from '../InputProps'
+import { InputProps, pickInputProps } from '../InputProps'
 import { FauxRadio } from './FauxRadio'
 
 export interface RadioProps
@@ -43,7 +42,7 @@ const RadioLayout = forwardRef(
 
     return (
       <div className={className}>
-        <input type="radio" {...pick(restProps, inputPropKeys)} ref={ref} />
+        <input type="radio" {...pickInputProps(restProps)} ref={ref} />
         <FauxRadio />
       </div>
     )

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -74,10 +74,6 @@ export interface SelectBaseProps
    * defaults to false for <100 options, true for >=100 options
    */
   windowedOptions?: boolean
-  /**
-   * Sets initial focus when inside a Dialog or Popover
-   */
-  'data-autofocus'?: string
 }
 
 export interface SelectProps
@@ -108,7 +104,6 @@ const SelectComponent = forwardRef(
       options,
       disabled,
       autoFocus,
-      'data-autofocus': dataAutofocus,
       isFilterable,
       isClearable,
       placeholder,
@@ -169,7 +164,6 @@ const SelectComponent = forwardRef(
           before={<SelectInputIcon options={options} />}
           disabled={disabled}
           autoFocus={autoFocus}
-          data-autofocus={dataAutofocus}
           placeholder={placeholder}
           name={name}
           validationType={props.validationType}

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -74,6 +74,10 @@ export interface SelectBaseProps
    * defaults to false for <100 options, true for >=100 options
    */
   windowedOptions?: boolean
+  /**
+   * Sets initial focus when inside a Dialog or Popover
+   */
+  'data-autofocus'?: string
 }
 
 export interface SelectProps
@@ -103,6 +107,8 @@ const SelectComponent = forwardRef(
     {
       options,
       disabled,
+      autoFocus,
+      'data-autofocus': dataAutofocus,
       isFilterable,
       isClearable,
       placeholder,
@@ -162,6 +168,8 @@ const SelectComponent = forwardRef(
           {...ariaProps}
           before={<SelectInputIcon options={options} />}
           disabled={disabled}
+          autoFocus={autoFocus}
+          data-autofocus={dataAutofocus}
           placeholder={placeholder}
           name={name}
           validationType={props.validationType}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -73,6 +73,8 @@ const SelectMultiComponent = forwardRef(
     {
       options,
       disabled,
+      autoFocus,
+      'data-autofocus': dataAutofocus,
       isFilterable = false,
       placeholder,
       onFilter,
@@ -124,6 +126,8 @@ const SelectMultiComponent = forwardRef(
         <ComboboxMultiInput
           {...ariaProps}
           disabled={disabled}
+          autoFocus={autoFocus}
+          data-autofocus={dataAutofocus}
           placeholder={placeholder}
           removeOnBackspace={removeOnBackspace}
           validationType={props.validationType}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -74,7 +74,6 @@ const SelectMultiComponent = forwardRef(
       options,
       disabled,
       autoFocus,
-      'data-autofocus': dataAutofocus,
       isFilterable = false,
       placeholder,
       onFilter,
@@ -127,7 +126,6 @@ const SelectMultiComponent = forwardRef(
           {...ariaProps}
           disabled={disabled}
           autoFocus={autoFocus}
-          data-autofocus={dataAutofocus}
           placeholder={placeholder}
           removeOnBackspace={removeOnBackspace}
           validationType={props.validationType}

--- a/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
+++ b/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import pick from 'lodash/pick'
 import React, { FC } from 'react'
 import styled from 'styled-components'
 import { CompatibleHTMLProps } from '@looker/design-tokens'
@@ -41,7 +40,7 @@ import {
   simpleLayoutCSS,
   SimpleLayoutProps,
 } from '../../../Layout/utils/simple'
-import { inputPropKeys } from '../InputProps'
+import { pickInputProps } from '../InputProps'
 
 type TextAreaResize = 'vertical' | 'none' | boolean
 
@@ -60,7 +59,7 @@ const TextAreaLayout: FC<TextAreaProps> = ({
   validationType,
   ...props
 }) => {
-  const textareaProps = pick(props, inputPropKeys)
+  const textareaProps = pickInputProps(props)
 
   return (
     <div className={className}>

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
@@ -30,10 +30,9 @@ import {
   SpaceProps,
   toggleSwitchShadowColor,
 } from '@looker/design-tokens'
-import pick from 'lodash/pick'
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { InputProps, inputPropKeys } from '../InputProps'
+import { InputProps, pickInputProps } from '../InputProps'
 import { KnobContainer, KnobProps } from './Knob'
 
 export interface ToggleSwitchProps
@@ -71,7 +70,7 @@ export const ToggleSwitchLayout = forwardRef(
           aria-checked={on}
           aria-invalid={validationType === 'error' ? 'true' : undefined}
           ref={ref}
-          {...pick(props, inputPropKeys)}
+          {...pickInputProps(props)}
         />
         <KnobContainer on={on} disabled={disabled} />
         {disabled && <DisabledKnob />}

--- a/storybook/src/Forms/Time.stories.tsx
+++ b/storybook/src/Forms/Time.stories.tsx
@@ -52,6 +52,7 @@ export const Required = () => (
 
 export const ValidationError = () => (
   <FieldTime
+    autoFocus
     defaultValue="14:34"
     description="this is the description is a very long one"
     detail="detail"


### PR DESCRIPTION
### :sparkles: Changes

- Apply `autoFocus` and `data-autofocus` props to the `ComboboxInput` in all `Combobox`-based components

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
