### PR TITLE
removing postbuild task from storybook

### DIFF
--- a/storybook/package.json
+++ b/storybook/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "start": "start-storybook  -c .storybook -p 3333  --host 0.0.0.0",
     "develop": "export storybookBuildMode=develop && yarn start",
-    "build": "build-storybook -c .storybook",
-    "postbuild": "npx sb extract"
+    "build": "build-storybook -c .storybook"
   },
   "dependencies": {
     "@looker/components": "^0.9.22",


### PR DESCRIPTION
Removed storybook postbuild task that uses puppeteer since we're not using it yet and it's causing issues with the storybook build inside docker.

### :sparkles: Changes

- **Thank you for your contribution to Looker Components!**
- To ensure a successful review, please double check our checklist of requirements below.
- Also including a short description of changes and relevant screenshots will help us more quickly understand the ultimate goal of your work (🗑 replace this introduction with your summary of changes).

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
