### PR TITLE
DataTable supports onClick of Link/Anchor as text inside rows and does not select the row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ NOTE: This is the CHANGELOG for the @looker/components MONOREPO. Each package ha
 
 ### Fixed
 
-- update DataTable to support onClick of `Link/a tag` as text inside rows.
+- update DataTable to support onClick of `Link/Anchor` as text inside rows.
 
 ## [0.9.23]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ NOTE: This is the CHANGELOG for the @looker/components MONOREPO. Each package ha
 - [Design Tokens](./packages/design-tokens/CHANGELOG.md)
 - [Icons](./packages/icons/CHANGELOG.md)
 
+## [UNRELEASED]
+
+### Fixed
+
+- update DataTable to support onClick of `Link/a tag` as text inside rows.
+
 ## [0.9.23]
 
 ### Added

--- a/packages/components/src/DataTable/Column/DataTableCell.tsx
+++ b/packages/components/src/DataTable/Column/DataTableCell.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, ReactNode } from 'react'
+import React, { FC, ReactNode, cloneElement } from 'react'
 import styled from 'styled-components'
 import { Space, SpaceVertical } from '../../Layout'
 import { Link } from '../../Link'
@@ -47,8 +47,21 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
   indicator,
   size,
 }) => {
+  const handleOnClick = (event: MouseEvent | KeyboardEvent) =>
+    event.stopPropagation()
+
+  const newChild =
+    (children && children.type === 'a') ||
+    (children && children.type && children.type.displayName === 'link')
+      ? cloneElement(children, {
+          onClick: handleOnClick,
+        })
+      : children
+
+  console.log(children.type)
+
   let content =
-    size && size !== 'nowrap' ? <Truncate>{children}</Truncate> : children
+    size && size !== 'nowrap' ? <Truncate>{newChild}</Truncate> : newChild
 
   if (detail) {
     content = (

--- a/packages/components/src/DataTable/Column/DataTableCell.tsx
+++ b/packages/components/src/DataTable/Column/DataTableCell.tsx
@@ -24,9 +24,8 @@
 
  */
 
-import React, { FC, ReactNode, cloneElement, ReactElement } from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled from 'styled-components'
-import { has } from 'lodash'
 import { Space, SpaceVertical } from '../../Layout'
 import { Link } from '../../Link'
 import { Paragraph } from '../../Text'
@@ -48,18 +47,8 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
   indicator,
   size,
 }) => {
-  const handleOnClick = (event: MouseEvent | KeyboardEvent) =>
-    event.stopPropagation()
-
-  const newChild =
-    has(children, 'props') && (children as ReactElement).props.href
-      ? cloneElement(children as ReactElement, {
-          onClick: handleOnClick,
-        })
-      : children
-
   let content =
-    size && size !== 'nowrap' ? <Truncate>{newChild}</Truncate> : newChild
+    size && size !== 'nowrap' ? <Truncate>{children}</Truncate> : children
 
   if (detail) {
     content = (

--- a/packages/components/src/DataTable/Column/DataTableCell.tsx
+++ b/packages/components/src/DataTable/Column/DataTableCell.tsx
@@ -47,18 +47,6 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
   indicator,
   size,
 }) => {
-  const handleChildClick = (event) => event.stopPropagation()
-  console.log('children-type: ', children.type)
-
-  console.log(
-    'children-type.displayName: ',
-    children && children.type && children.type.displayName
-  )
-
-  const link =
-    (children && children.type && children.type === 'a') ||
-    (children && children.type && children.type.displayName === 'Link')
-
   let content =
     size && size !== 'nowrap' ? <Truncate>{children}</Truncate> : children
 
@@ -91,11 +79,7 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
     )
   }
 
-  return (
-    <td className={className} onClick={link && handleChildClick}>
-      {content}
-    </td>
-  )
+  return <td className={className}>{content}</td>
 }
 
 export const DataTableCell = styled(DataTableCellLayout)`

--- a/packages/components/src/DataTable/Column/DataTableCell.tsx
+++ b/packages/components/src/DataTable/Column/DataTableCell.tsx
@@ -24,8 +24,9 @@
 
  */
 
-import React, { FC, ReactNode, cloneElement } from 'react'
+import React, { FC, ReactNode, cloneElement, ReactElement } from 'react'
 import styled from 'styled-components'
+import { has } from 'lodash'
 import { Space, SpaceVertical } from '../../Layout'
 import { Link } from '../../Link'
 import { Paragraph } from '../../Text'
@@ -51,14 +52,11 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
     event.stopPropagation()
 
   const newChild =
-    (children && children.type === 'a') ||
-    (children && children.type && children.type.displayName === 'link')
-      ? cloneElement(children, {
+    has(children, 'props') && (children as ReactElement).props.href
+      ? cloneElement(children as ReactElement, {
           onClick: handleOnClick,
         })
       : children
-
-  console.log(children.type)
 
   let content =
     size && size !== 'nowrap' ? <Truncate>{newChild}</Truncate> : newChild

--- a/packages/components/src/DataTable/Column/DataTableCell.tsx
+++ b/packages/components/src/DataTable/Column/DataTableCell.tsx
@@ -47,6 +47,18 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
   indicator,
   size,
 }) => {
+  const handleChildClick = (event) => event.stopPropagation()
+  console.log('children-type: ', children.type)
+
+  console.log(
+    'children-type.displayName: ',
+    children && children.type && children.type.displayName
+  )
+
+  const link =
+    (children && children.type && children.type === 'a') ||
+    (children && children.type && children.type.displayName === 'Link')
+
   let content =
     size && size !== 'nowrap' ? <Truncate>{children}</Truncate> : children
 
@@ -79,7 +91,11 @@ const DataTableCellLayout: FC<DataTableCellProps> = ({
     )
   }
 
-  return <td className={className}>{content}</td>
+  return (
+    <td className={className} onClick={link && handleChildClick}>
+      {content}
+    </td>
+  )
 }
 
 export const DataTableCell = styled(DataTableCellLayout)`

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -27,6 +27,7 @@
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { fireEvent } from '@testing-library/react'
+import { Link } from '../Link'
 import {
   DataTable,
   DataTableAction,
@@ -64,6 +65,28 @@ const data = [
     id: 2,
     name: 'John Carmack',
     type: 'Programmer',
+  },
+  {
+    id: 3,
+    name: (
+      <a href="https://components.looker.com/" target="_blank" rel="noreferrer">
+        Gouda
+      </a>
+    ),
+    type: 'semi-hard, artisan, brined, processed',
+  },
+  {
+    id: 4,
+    name: (
+      <Link
+        href="https://components.looker.com/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        American
+      </Link>
+    ),
+    type: 'semi-soft, processed',
   },
 ]
 
@@ -241,6 +264,7 @@ describe('DataTable', () => {
         {items}
       </DataTable>
     )
+
     const dataTableWithOnClickRowSelect = (
       <DataTable
         columns={columns}
@@ -278,6 +302,32 @@ describe('DataTable', () => {
       const { getAllByRole } = renderWithTheme(dataTableWithSelectedItems)
       const checkbox = getAllByRole('checkbox')[1]
       expect((checkbox as HTMLInputElement).checked).toEqual(true)
+    })
+
+    test('selectedItems not selected if clicked on a anchor', () => {
+      const { getAllByRole, getByText } = renderWithTheme(dataTableWithSelect)
+
+      const Anchor = getByText('Gouda')
+
+      expect(Anchor).toBeInTheDocument()
+
+      fireEvent.click(Anchor)
+
+      const checkbox = getAllByRole('checkbox')[3]
+      expect((checkbox as HTMLInputElement).checked).toEqual(false)
+    })
+
+    test('selectedItems not selected if clicked on a link', () => {
+      const { getAllByRole, getByText } = renderWithTheme(dataTableWithSelect)
+
+      const link = getByText('American')
+
+      expect(link).toBeInTheDocument()
+
+      fireEvent.click(link)
+
+      const checkbox = getAllByRole('checkbox')[4]
+      expect((checkbox as HTMLInputElement).checked).toEqual(false)
     })
   })
 

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -87,14 +87,17 @@ const DataTableRowLayout = forwardRef(
     ) : (
       <div />
     )
-
     return (
       <tr
         ref={ref}
         className={className}
         onKeyDown={onKeyDown}
         tabIndex={tabIndex}
-        onClick={onClick}
+        onClick={
+          event && (event.target as HTMLElement).tagName === 'A'
+            ? onClick
+            : undefined
+        }
       >
         <ColumnType>{checkbox}</ColumnType>
         {sizedChildren}

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -82,6 +82,11 @@ const DataTableRowLayout = forwardRef(
       }
     })
 
+    const handleOnClick = (event: React.MouseEvent<HTMLElement>) =>
+      event.target instanceof HTMLAnchorElement
+        ? undefined
+        : onClick && onClick(event)
+
     const checkbox = hasCheckbox ? (
       <DataTableCheckbox {...pick(props, checkListProps)} />
     ) : (
@@ -93,7 +98,7 @@ const DataTableRowLayout = forwardRef(
         className={className}
         onKeyDown={onKeyDown}
         tabIndex={tabIndex}
-        onClick={onClick}
+        onClick={handleOnClick}
       >
         <ColumnType>{checkbox}</ColumnType>
         {sizedChildren}

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -82,18 +82,6 @@ const DataTableRowLayout = forwardRef(
       }
     })
 
-    // (event) => {
-    //   console.log('onClick: ', onClick)
-    //   console.log('tagName: ', (event.target as HTMLElement).tagName)
-    //   console.log(
-    //     'tagName is an a tag: ',
-    //     (event.target as HTMLElement).tagName !== 'A'
-    //   )
-    //   return (event.target as HTMLElement).tagName !== 'A'
-    //     ? onClick
-    //     : undefined
-    // }
-
     const checkbox = hasCheckbox ? (
       <DataTableCheckbox {...pick(props, checkListProps)} />
     ) : (

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -82,6 +82,18 @@ const DataTableRowLayout = forwardRef(
       }
     })
 
+    // (event) => {
+    //   console.log('onClick: ', onClick)
+    //   console.log('tagName: ', (event.target as HTMLElement).tagName)
+    //   console.log(
+    //     'tagName is an a tag: ',
+    //     (event.target as HTMLElement).tagName !== 'A'
+    //   )
+    //   return (event.target as HTMLElement).tagName !== 'A'
+    //     ? onClick
+    //     : undefined
+    // }
+
     const checkbox = hasCheckbox ? (
       <DataTableCheckbox {...pick(props, checkListProps)} />
     ) : (
@@ -93,11 +105,7 @@ const DataTableRowLayout = forwardRef(
         className={className}
         onKeyDown={onKeyDown}
         tabIndex={tabIndex}
-        onClick={
-          event && (event.target as HTMLElement).tagName === 'A'
-            ? onClick
-            : undefined
-        }
+        onClick={onClick}
       >
         <ColumnType>{checkbox}</ColumnType>
         {sizedChildren}


### PR DESCRIPTION
### :sparkles: Changes

- DataTable supports onClick of Link/Anchor as text inside rows and does not select the row

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
