### PR TITLE
InputChip supports disabled and readOnly

### DIFF
--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -51,6 +51,7 @@ export interface ChipProps
   onDelete?: (
     e?: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>
   ) => void
+  readOnly?: boolean
 }
 
 const ChipStyle = styled.span<FocusVisibleProps>`
@@ -88,7 +89,8 @@ const ChipStyle = styled.span<FocusVisibleProps>`
 
   &[disabled] {
     background: ${({ theme }) => theme.colors.neutralAccent};
-    color: ${({ theme }) => theme.colors.neutral};
+    border-color: ${({ theme }) => theme.colors.ui2};
+    color: ${({ theme }) => theme.colors.text1};
 
     &:hover {
       background: ${({ theme }) => theme.colors.neutralAccent};
@@ -111,6 +113,7 @@ const ChipJSX = forwardRef(
       onKeyUp,
       onKeyDown,
       prefix,
+      readOnly = false,
       truncate = true,
       ...props
     }: ChipProps,
@@ -142,16 +145,17 @@ const ChipJSX = forwardRef(
           {prefix && <ChipLabel fontWeight="normal">{prefix}: </ChipLabel>}
           {children}
         </ChipLabel>
-        {onDelete && !disabled && (
-          <IconButton
-            disabled={disabled}
-            icon="Close"
-            label="Delete"
-            ml="xsmall"
-            onClick={handleDelete}
-            size="xxsmall"
-          />
-        )}
+        {readOnly ||
+          (!disabled && onDelete && (
+            <IconButton
+              disabled={disabled}
+              icon="Close"
+              label="Delete"
+              ml="xsmall"
+              onClick={handleDelete}
+              size="xxsmall"
+            />
+          ))}
       </ChipStyle>
     )
   }

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -89,7 +89,7 @@ const ChipStyle = styled.span<FocusVisibleProps>`
 
   &[disabled] {
     background: ${({ theme }) => theme.colors.neutralAccent};
-    border-color: ${({ theme }) => theme.colors.ui2};
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.ui2};
     color: ${({ theme }) => theme.colors.text1};
 
     &:hover {
@@ -146,7 +146,8 @@ const ChipJSX = forwardRef(
           {children}
         </ChipLabel>
         {readOnly ||
-          (!disabled && onDelete && (
+          disabled ||
+          (onDelete && (
             <IconButton
               disabled={disabled}
               icon="Close"

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
@@ -1,0 +1,96 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, { useState } from 'react'
+import { Story } from '@storybook/react/types-6-0'
+import { InputChips, InputChipsProps } from './InputChips'
+
+const chipValues = ['Looker', 'Google']
+
+const Template: Story<InputChipsProps> = ({ values = [], ...args }) => {
+  const [controlledChips, setControlledChips] = useState(values)
+  return (
+    <InputChips
+      {...args}
+      values={controlledChips}
+      onChange={setControlledChips}
+    />
+  )
+}
+
+export const Basic = Template.bind({})
+Basic.args = {}
+
+export const Values = Template.bind({})
+Values.args = {
+  values: chipValues,
+}
+
+export const Placeholder = Template.bind({})
+Placeholder.args = {
+  ...Values.args,
+  placeholder: 'Enter more chips here',
+}
+
+export const Summary = Template.bind({})
+Summary.args = {
+  ...Values.args,
+  summary: 'some more info here',
+}
+
+export const AutoResize = Template.bind({})
+AutoResize.args = {
+  ...Values.args,
+  autoResize: true,
+  height: 36,
+  maxWidth: 250,
+}
+
+export const DisabledWithValues = Template.bind({})
+DisabledWithValues.args = {
+  ...Values.args,
+  disabled: true,
+}
+
+export const DisabledWithOutValues = Template.bind({})
+DisabledWithOutValues.args = {
+  ...Basic.args,
+  disabled: true,
+}
+
+export const ReadOnly = Template.bind({})
+ReadOnly.args = {
+  ...Values.args,
+  readOnly: true,
+}
+ReadOnly.parameters = {
+  storyshots: { disable: true },
+}
+
+export default {
+  component: InputChips,
+  title: 'InputChips',
+}

--- a/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
@@ -129,6 +129,7 @@ export const InputChipsBaseInternal = forwardRef(
       summary,
       removeOnBackspace = true,
       formatChip,
+      readOnly,
       ...props
     }: InputChipsBaseProps & InputChipsInputControlProps,
     forwardedRef: Ref<HTMLInputElement>
@@ -322,13 +323,14 @@ export const InputChipsBaseInternal = forwardRef(
 
       return (
         <Chip
+          aria-selected={isSelected}
           disabled={disabled}
+          key={value}
+          onClick={handleChipClick(value)}
           onDelete={onChipDelete}
           onMouseDown={stopPropagation}
-          onClick={handleChipClick(value)}
-          key={value}
+          readOnly={readOnly}
           role="option"
-          aria-selected={isSelected}
           // Prevent the chip from receiving focus for better keyboard behavior
           tabIndex={disabled ? undefined : -1}
         >
@@ -347,11 +349,14 @@ export const InputChipsBaseInternal = forwardRef(
     return (
       <InputText
         disabled={disabled}
+        readOnly={readOnly}
         after={
           <AdvancedInputControls
             isVisibleOptions={isVisibleOptions}
             onClear={handleClear}
-            showClear={isClearable && values.length > 0}
+            showClear={
+              isClearable && values.length > 0 && !disabled && !readOnly
+            }
             validationType={validationType}
             disabled={disabled}
             summary={summary}


### PR DESCRIPTION
### :sparkles: Changes

- InputChip supports disabled and readOnly

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
