### PR TITLE
update InputDate and InputDateRange to support disabled and readOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ NOTE: This is the CHANGELOG for the @looker/components MONOREPO. Each package ha
 
 ## [UNRELEASED]
 
+### Added
+
+- update InputDate and InputDateRange to support disabled and readOnly
+
 ### Fixed
 
 - update DataTable to support onClick of `Link/Anchor` as text inside rows.

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -37,50 +37,52 @@ import { dayPickerCss } from './dayPickerCss'
 import { CalendarNavDisabled } from './CalendarNavDisabled'
 
 export interface CalendarLocalization {
+  firstDayOfWeek: number
   months: string[]
   weekdaysShort: string[]
-  firstDayOfWeek: number
 }
 
 interface CalendarProps {
-  localization?: CalendarLocalization
-  selectedDates?: Date | Date[] | RangeModifier
-  onDayClick?: (day: Date) => void
   className?: string
-  size?: CalendarSize
-  showNextButton?: boolean
-  showPreviousButton?: boolean
+  disabled?: boolean
+  localization?: CalendarLocalization
+  onDayClick?: (day: Date) => void
+  onMonthChange?: (month: Date) => void
   onNextClick?: (date: Date) => void
   onNowClick?: (date: Date) => void
   onPrevClick?: (date: Date) => void
-  onMonthChange?: (month: Date) => void
+  readOnly?: boolean
+  selectedDates?: Date | Date[] | RangeModifier
+  showNextButton?: boolean
+  showPreviousButton?: boolean
+  size?: CalendarSize
   viewMonth?: Date
-  disabled?: boolean
 }
 
 const NoopComponent: FC = () => null
 
 const InternalCalendar: FC<CalendarProps> = ({
+  className,
+  disabled,
   localization = {},
   onDayClick,
-  className,
-  size,
-  showNextButton = true,
-  showPreviousButton = true,
   onMonthChange,
   onNextClick,
   onNowClick,
   onPrevClick,
-  viewMonth,
+  readOnly,
   selectedDates,
-  disabled,
+  showNextButton = true,
+  showPreviousButton = true,
+  size,
+  viewMonth,
 }) => {
   const renderDateRange = selectedDates && has(selectedDates, 'from')
   const modifiers = renderDateRange ? selectedDates : {}
 
   const disableCallback = (cb: Function = noop) => {
-    // allows provided callback to be circumvented by disabled prop
-    return (...args: any[]) => (disabled ? noop() : cb(...args)) // eslint-disable-line standard/no-callback-literal
+    // allows provided callback to be circumvented by disabled or readOnly prop
+    return (...args: any[]) => (disabled || readOnly ? noop() : cb(...args)) // eslint-disable-line standard/no-callback-literal
   }
 
   const formatMonthTitle = (month: Date) => {
@@ -97,8 +99,8 @@ const InternalCalendar: FC<CalendarProps> = ({
         onNextClick: disableCallback(onNextClick),
         onNowClick: disableCallback(onNowClick),
         onPrevClick: disableCallback(onPrevClick),
-        showNextButton: !disabled && showNextButton,
-        showPreviousButton: !disabled && showPreviousButton,
+        showNextButton: (!disabled || !readOnly) && showNextButton,
+        showPreviousButton: (!disabled || !readOnly) && showPreviousButton,
         size,
       }}
     >
@@ -172,19 +174,21 @@ export const Calendar = styled<FC<CalendarProps>>(InternalCalendar)`
     }
 
     &--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-      background-color: ${({ theme: { colors }, disabled }) =>
-        disabled ? colors.neutral : colors.key};
+      background-color: ${({ theme: { colors }, disabled, readOnly }) =>
+        disabled || readOnly ? colors.neutral : colors.key};
       position: static;
 
       &:hover {
-        background-color: ${({ theme: { colors }, disabled }) =>
-          disabled ? colors.neutralInteractive : colors.keyInteractive};
+        background-color: ${({ theme: { colors }, disabled, readOnly }) =>
+          disabled || readOnly
+            ? colors.neutralInteractive
+            : colors.keyInteractive};
       }
     }
 
     &:focus {
-      border-color: ${({ theme: { colors }, disabled }) =>
-        disabled ? 'transparent' : colors.keyBorder};
+      border-color: ${({ theme: { colors }, disabled, readOnly }) =>
+        disabled || readOnly ? 'transparent' : colors.keyBorder};
       border-width: 2px;
       outline: none;
     }

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -34,6 +34,7 @@ import { CalendarSize, calendarSize, calendarSpacing } from './calendar-size'
 import { CalendarContext } from './CalendarContext'
 import { CalendarNav } from './CalendarNav'
 import { dayPickerCss } from './dayPickerCss'
+import { CalendarNavDisabled } from './CalendarNavDisabled'
 
 export interface CalendarLocalization {
   months: string[]
@@ -109,7 +110,7 @@ const InternalCalendar: FC<CalendarProps> = ({
         month={viewMonth}
         showOutsideDays={true}
         onDayClick={disableCallback(onDayClick)}
-        navbarElement={CalendarNav}
+        navbarElement={disabled ? CalendarNavDisabled : CalendarNav}
         captionElement={NoopComponent}
         modifiers={modifiers}
         onMonthChange={onMonthChange}
@@ -183,7 +184,7 @@ export const Calendar = styled<FC<CalendarProps>>(InternalCalendar)`
 
     &:focus {
       border-color: ${({ theme: { colors }, disabled }) =>
-        disabled ? colors.neutralBorder : colors.keyBorder};
+        disabled ? 'transparent' : colors.keyBorder};
       border-width: 2px;
       outline: none;
     }

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -174,8 +174,8 @@ export const Calendar = styled<FC<CalendarProps>>(InternalCalendar)`
     }
 
     &--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-      background-color: ${({ theme: { colors }, disabled, readOnly }) =>
-        disabled || readOnly ? colors.neutral : colors.key};
+      background-color: ${({ theme: { colors }, disabled }) =>
+        disabled ? colors.neutral : colors.key};
       position: static;
 
       &:hover {

--- a/packages/components/src/Calendar/CalendarNav.tsx
+++ b/packages/components/src/Calendar/CalendarNav.tsx
@@ -33,7 +33,7 @@ import { Heading } from '../Text'
 import { CalendarSize } from './calendar-size'
 import { CalendarContext } from './CalendarContext'
 
-const headingSizeMap = (size?: CalendarSize) => {
+export const headingSizeMap = (size?: CalendarSize) => {
   switch (size) {
     case 'small':
       return 'h6'

--- a/packages/components/src/Calendar/CalendarNavDisabled.tsx
+++ b/packages/components/src/Calendar/CalendarNavDisabled.tsx
@@ -44,6 +44,7 @@ export const CalendarNavDisabled: FC<NavbarElementDisabledProps> = ({
     fontWeight="semiBold"
     fontFamily="body"
     textAlign="center"
+    py="xsmall"
   >
     {localeUtils.formatMonthTitle(month)}
   </Heading>

--- a/packages/components/src/Calendar/CalendarNavDisabled.tsx
+++ b/packages/components/src/Calendar/CalendarNavDisabled.tsx
@@ -1,0 +1,52 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React, { FC } from 'react'
+import { LocaleUtils } from 'react-day-picker'
+import { Heading } from '../Text'
+import { headingSizeMap } from './CalendarNav'
+import { CalendarSize } from './calendar-size'
+
+interface NavbarElementDisabledProps {
+  localeUtils: LocaleUtils
+  month: Date
+  size?: CalendarSize
+}
+export const CalendarNavDisabled: FC<NavbarElementDisabledProps> = ({
+  localeUtils,
+  month,
+  size,
+}) => (
+  <Heading
+    as={headingSizeMap(size)}
+    fontWeight="semiBold"
+    fontFamily="body"
+    textAlign="center"
+  >
+    {localeUtils.formatMonthTitle(month)}
+  </Heading>
+)
+
+CalendarNavDisabled.displayName = 'CalendarNavDisabled'

--- a/packages/components/src/InputDate/InputDate.story.tsx
+++ b/packages/components/src/InputDate/InputDate.story.tsx
@@ -1,0 +1,79 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React, { useState, ReactNode } from 'react'
+import { Story } from '@storybook/react/types-6-0'
+import { DateFormat } from '../DateFormat'
+import { Space } from '../Layout/Space'
+import { Box } from '../Layout/Box'
+import { Heading, Text } from '../Text'
+import { InputDate, InputDateProps } from './'
+
+export default {
+  component: InputDate,
+  title: 'InputDate',
+}
+
+const Template: Story<InputDateProps> = (args) => <InputDate {...args} />
+
+export const Basic = Template.bind({})
+Basic.args = {}
+
+export const Value = Template.bind({})
+Value.args = {
+  value: new Date('February 3, 2009'),
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  disabled: true,
+}
+
+export const ReadOnly = Template.bind({})
+ReadOnly.args = {
+  readOnly: true,
+}
+
+export const Controlled = () => {
+  const [selectedDate, setSelectedDate] = useState(new Date())
+  const handleChange = (date: Date) => {
+    setSelectedDate(date)
+  }
+  return (
+    <Space gap="xxlarge">
+      <InputDate defaultValue={selectedDate} onChange={handleChange} />
+      <Box p="large" height="100%" borderLeft="1px solid #ccc">
+        <Heading>Selected:</Heading>
+        <Text variant="secondary">
+          <DateFormat>{selectedDate}</DateFormat>
+        </Text>
+      </Box>
+    </Space>
+  )
+}
+
+Controlled.parameters = {
+  storyshots: { disable: true },
+}

--- a/packages/components/src/InputDate/InputDate.story.tsx
+++ b/packages/components/src/InputDate/InputDate.story.tsx
@@ -23,7 +23,7 @@
  SOFTWARE.
 
  */
-import React, { useState, ReactNode } from 'react'
+import React, { useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { DateFormat } from '../DateFormat'
 import { Space } from '../Layout/Space'
@@ -51,11 +51,22 @@ Disabled.args = {
   disabled: true,
 }
 
+export const DisabledWithValue = Template.bind({})
+DisabledWithValue.args = {
+  disabled: true,
+  value: new Date('February 3, 2009'),
+}
+
 export const ReadOnly = Template.bind({})
 ReadOnly.args = {
   readOnly: true,
 }
 
+export const ReadOnlyWithValue = Template.bind({})
+ReadOnlyWithValue.args = {
+  readOnly: true,
+  value: new Date('March 3, 2009'),
+}
 export const Controlled = () => {
   const [selectedDate, setSelectedDate] = useState(new Date())
   const handleChange = (date: Date) => {

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -42,16 +42,17 @@ import { Locales, formatDateString, parseDateFromString } from '../utils/i18n'
 import { useReadOnlyWarn } from '../utils/useReadOnlyWarn'
 
 export interface InputDateProps extends SpaceProps, BorderProps {
-  defaultValue?: Date
-  value?: Date
-  onChange?: (date?: Date) => void
-  validationType?: ValidationType
-  onValidationFail?: (value: string) => void
-  localization?: CalendarLocalization
   dateStringLocale?: Locales
-  id?: string
-  ref?: Ref<HTMLInputElement>
+  defaultValue?: Date
   disabled?: boolean
+  id?: string
+  localization?: CalendarLocalization
+  onChange?: (date?: Date) => void
+  onValidationFail?: (value: string) => void
+  readOnly?: boolean
+  ref?: Ref<HTMLInputElement>
+  validationType?: ValidationType
+  value?: Date
 }
 
 const isDateInView = (value: Date, viewMonth: Date) => {
@@ -72,15 +73,16 @@ const isDateInView = (value: Date, viewMonth: Date) => {
 export const InputDate: FC<InputDateProps> = forwardRef(
   (
     {
-      onChange,
-      defaultValue,
-      localization,
       dateStringLocale,
-      validationType,
-      onValidationFail,
-      value,
-      id,
+      defaultValue,
       disabled,
+      localization,
+      id,
+      onChange,
+      onValidationFail,
+      readOnly,
+      validationType,
+      value,
     },
     ref: Ref<HTMLInputElement>
   ) => {
@@ -174,6 +176,7 @@ export const InputDate: FC<InputDateProps> = forwardRef(
           id={id}
           ref={ref}
           disabled={disabled}
+          readOnly={readOnly}
           my="xxsmall"
         />
         <CalendarWrapper>
@@ -186,6 +189,7 @@ export const InputDate: FC<InputDateProps> = forwardRef(
             onNextClick={handleNavClick}
             onPrevClick={handleNavClick}
             disabled={disabled}
+            readOnly={readOnly}
           />
         </CalendarWrapper>
       </InputDateWrapper>

--- a/packages/components/src/InputDateRange/InputDateRange.story.tsx
+++ b/packages/components/src/InputDateRange/InputDateRange.story.tsx
@@ -46,6 +46,7 @@ Basic.args = {
     to: new Date('August 5, 2020'),
   },
 }
+
 export const Disabled = Template.bind({})
 Disabled.args = {
   defaultValue: {
@@ -53,6 +54,15 @@ Disabled.args = {
     to: new Date('Jun 19, 2000'),
   },
   disabled: true,
+}
+
+export const ReadOnly = Template.bind({})
+ReadOnly.args = {
+  defaultValue: {
+    from: new Date('Jun 7, 2000'),
+    to: new Date('Jun 19, 2000'),
+  },
+  readOnly: true,
 }
 
 export const Controlled = () => {

--- a/packages/components/src/InputDateRange/InputDateRange.tsx
+++ b/packages/components/src/InputDateRange/InputDateRange.tsx
@@ -56,16 +56,17 @@ import { useID } from '../utils/useID'
 import { useReadOnlyWarn } from '../utils/useReadOnlyWarn'
 
 export interface InputDateRangeProps {
-  value?: RangeModifier
+  disabled?: boolean
+  dateStringLocale?: Locales
   defaultValue?: RangeModifier
+  id?: string
+  localization?: CalendarLocalization
   onChange?: (range?: Partial<RangeModifier>) => void
   onValidationFail?: (value: string) => void
-  localization?: CalendarLocalization
-  dateStringLocale?: Locales
-  validationType?: ValidationType
-  id?: string
+  readOnly?: boolean
   ref?: Ref<HTMLDivElement>
-  disabled?: boolean
+  validationType?: ValidationType
+  value?: RangeModifier
 }
 
 type Endpoint = 'to' | 'from'
@@ -128,15 +129,16 @@ const isDateRangeInView = (
 export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
   (
     {
-      defaultValue = {},
-      localization,
       dateStringLocale,
+      defaultValue = {},
+      disabled,
+      id,
+      localization,
       onChange,
       onValidationFail,
+      readOnly,
       validationType,
       value,
-      id,
-      disabled,
     },
     ref: Ref<HTMLDivElement>
   ) => {
@@ -352,14 +354,15 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
                 new Date(Date.now()),
                 dateStringLocale
               )})`}
-              value={inputs.from.value}
-              onChange={handleTextInputChange}
-              onBlur={handleValidation}
-              data-testid="date-from-text-input"
-              id={fromID}
-              onFocus={partial(handleTextInputFocus, 'from')}
-              fontSize="small"
               disabled={disabled}
+              data-testid="date-from-text-input"
+              fontSize="small"
+              id={fromID}
+              onBlur={handleValidation}
+              onChange={handleTextInputChange}
+              onFocus={partial(handleTextInputFocus, 'from')}
+              readOnly={readOnly}
+              value={inputs.from.value}
             />
           </InputTextWrapper>
           <HyphenWrapper hasInputValues={!isEmpty(dateRange)}>
@@ -371,14 +374,15 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
                 new Date(Date.now()),
                 dateStringLocale
               )})`}
-              value={inputs.to.value}
-              onChange={handleTextInputChange}
-              onBlur={handleValidation}
+              disabled={disabled}
+              fontSize="small"
               data-testid="date-to-text-input"
               id={toID}
+              onBlur={handleValidation}
+              onChange={handleTextInputChange}
               onFocus={partial(handleTextInputFocus, 'to')}
-              fontSize="small"
-              disabled={disabled}
+              readOnly={readOnly}
+              value={inputs.to.value}
             />
           </InputTextWrapper>
           {(inputs.from.isValid && inputs.to.isValid) || (
@@ -396,28 +400,30 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
         <MultiCalendarLayout>
           <CalendarWrapper>
             <Calendar
-              selectedDates={dateRange as RangeModifier}
-              onDayClick={handleCalendarClick}
+              disabled={disabled}
               localization={localization}
-              viewMonth={viewMonth}
+              onDayClick={handleCalendarClick}
+              onMonthChange={partial(handleMonthChange, 0)}
               onNowClick={handleNowClick}
               onPrevClick={handlePrevClick}
+              readOnly={readOnly}
+              selectedDates={dateRange as RangeModifier}
               showNextButton={false}
-              onMonthChange={partial(handleMonthChange, 0)}
-              disabled={disabled}
+              viewMonth={viewMonth}
             />
           </CalendarWrapper>
           <CalendarWrapper>
             <Calendar
-              selectedDates={dateRange as RangeModifier}
-              onDayClick={handleCalendarClick}
-              localization={localization}
-              viewMonth={viewNextMonth}
-              onNowClick={handleNowClick}
-              onNextClick={handleNextClick}
-              showPreviousButton={false}
-              onMonthChange={partial(handleMonthChange, -1)}
               disabled={disabled}
+              localization={localization}
+              onDayClick={handleCalendarClick}
+              onMonthChange={partial(handleMonthChange, -1)}
+              onNextClick={handleNextClick}
+              onNowClick={handleNowClick}
+              readOnly={readOnly}
+              selectedDates={dateRange as RangeModifier}
+              showPreviousButton={false}
+              viewMonth={viewNextMonth}
             />
           </CalendarWrapper>
         </MultiCalendarLayout>


### PR DESCRIPTION
### :sparkles: Changes

- update InputDate to support disabled
- update InputDate to support readOnly
- update InputDateRange to support readOnly

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

- Disabled - with value
<img width="1275" alt="Screen Shot 2020-11-16 at 3 35 13 PM" src="https://user-images.githubusercontent.com/23616264/99321058-cfc8b080-2821-11eb-9360-107084a3208e.png">

- ReadOnly - with value
<img width="1278" alt="Screen Shot 2020-11-16 at 3 35 23 PM" src="https://user-images.githubusercontent.com/23616264/99321062-d1927400-2821-11eb-8083-e9328b112440.png">

- Disabled - no value
<img width="1275" alt="Screen Shot 2020-11-16 at 3 35 41 PM" src="https://user-images.githubusercontent.com/23616264/99321063-d2c3a100-2821-11eb-833c-e6dd560ea148.png">

- ReadOnly - no value
<img width="1273" alt="Screen Shot 2020-11-16 at 3 35 53 PM" src="https://user-images.githubusercontent.com/23616264/99321065-d3f4ce00-2821-11eb-8fe9-0231a947ba14.png">
