### PR TITLE
SC5 Support: Remove use of attrs({})

### DIFF
--- a/packages/components/src/Badge/Badge.tsx
+++ b/packages/components/src/Badge/Badge.tsx
@@ -106,17 +106,18 @@ const badgeIntent = (intent: BadgeIntent) =>
     color: ${({ theme: { colors } }) => generateIntentShade(colors[intent])};
   `
 
-export const Badge = styled(BadgeLayout).attrs({ fontWeight: 'semiBold' })`
+export const Badge = styled(BadgeLayout)`
   ${reset}
+
+  border-radius:50px;
+  display: inline-flex;
+  font-weight: ${({ theme }) => theme.fontWeights.semiBold};
 
   ${color}
   ${space}
   ${typography}
   ${size}
   ${({ intent }) => badgeIntent(intent || 'key')}
-
-  border-radius:50px;
-  display: inline-flex;
 `
 
 Badge.defaultProps = {

--- a/packages/components/src/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/packages/components/src/Badge/__snapshots__/Badge.test.tsx.snap
@@ -3,6 +3,11 @@
 exports[`Badge renders all intents 1`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -10,16 +15,10 @@ exports[`Badge renders all intents 1`] = `
   padding-right: 0.5rem;
   background: #e4f5eb;
   color: #146536;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="positive"
   size="medium"
 >
@@ -30,6 +29,11 @@ exports[`Badge renders all intents 1`] = `
 exports[`Badge renders all intents 2`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -37,16 +41,10 @@ exports[`Badge renders all intents 2`] = `
   padding-right: 0.5rem;
   background: #e0f0fb;
   color: #0061a1;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="inform"
   size="medium"
 >
@@ -57,6 +55,11 @@ exports[`Badge renders all intents 2`] = `
 exports[`Badge renders all intents 3`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -64,16 +67,10 @@ exports[`Badge renders all intents 3`] = `
   padding-right: 0.5rem;
   background: #edeeef;
   color: #525659;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="neutral"
   size="medium"
 >
@@ -84,6 +81,11 @@ exports[`Badge renders all intents 3`] = `
 exports[`Badge renders all intents 4`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -91,16 +93,10 @@ exports[`Badge renders all intents 4`] = `
   padding-right: 0.5rem;
   background: #fff4e0;
   color: #754d00;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="warn"
   size="medium"
 >
@@ -111,6 +107,11 @@ exports[`Badge renders all intents 4`] = `
 exports[`Badge renders all intents 5`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -118,16 +119,10 @@ exports[`Badge renders all intents 5`] = `
   padding-right: 0.5rem;
   background: #f8e4e6;
   color: #951727;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="critical"
   size="medium"
 >
@@ -138,6 +133,11 @@ exports[`Badge renders all intents 5`] = `
 exports[`Badge renders all sizes 1`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -145,16 +145,10 @@ exports[`Badge renders all sizes 1`] = `
   padding-right: 0.5rem;
   background: #ede8fb;
   color: #4b20c3;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="key"
   size="medium"
 >
@@ -165,6 +159,11 @@ exports[`Badge renders all sizes 1`] = `
 exports[`Badge renders all sizes 2`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.6875rem;
   line-height: 16px;
@@ -172,16 +171,10 @@ exports[`Badge renders all sizes 2`] = `
   padding-right: 0.5rem;
   background: #ede8fb;
   color: #4b20c3;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="key"
   size="small"
 >
@@ -192,6 +185,11 @@ exports[`Badge renders all sizes 2`] = `
 exports[`Badge renders all sizes 3`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 0.75rem;
   line-height: 24px;
@@ -199,16 +197,10 @@ exports[`Badge renders all sizes 3`] = `
   padding-right: 0.5rem;
   background: #ede8fb;
   color: #4b20c3;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="key"
   size="medium"
 >
@@ -219,6 +211,11 @@ exports[`Badge renders all sizes 3`] = `
 exports[`Badge renders all sizes 4`] = `
 .c0 {
   font-family: 'Roboto','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI','Helvetica','Arial',sans-serif;
+  border-radius: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-weight: 600;
   font-size: 1rem;
   line-height: 32px;
@@ -226,16 +223,10 @@ exports[`Badge renders all sizes 4`] = `
   padding-right: 0.75rem;
   background: #ede8fb;
   color: #4b20c3;
-  border-radius: 50px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 <span
   className="c0"
-  fontWeight="semiBold"
   intent="key"
   size="large"
 >

--- a/packages/components/src/ChipButton/ChipButton.tsx
+++ b/packages/components/src/ChipButton/ChipButton.tsx
@@ -36,7 +36,7 @@ import { Chip } from '../Chip/Chip'
    *
 =   */
 
-export const ChipButton = styled(Chip).attrs({ role: 'button' })`
+export const ChipButton = styled(Chip).attrs(() => ({ role: 'button' }))`
   border: 1px solid ${({ theme }) => theme.colors.ui2};
   cursor: pointer;
   font-size: ${({ theme }) => theme.fontSizes.small};

--- a/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
+++ b/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
@@ -114,10 +114,7 @@ const SearchControlDivider = styled.div`
   width: 1px;
 `
 
-const CaretIcon = styled(Icon).attrs({
-  mr: 'xxsmall',
-  size: 20,
-})`
+const CaretIcon = styled(Icon).attrs(() => ({ mr: 'xxsmall', size: 20 }))`
   ${iconButtonColor}
   opacity: ${({ disabled }) => (disabled ? '0.75' : '1')};
 `

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -272,14 +272,14 @@ const isMultiPadding = css<ComboboxListInternalProps>`
   padding: ${({ isMulti, theme }) => (isMulti ? theme.space.xsmall : 0)} 0;
 `
 
-export const ComboboxList = styled(ComboboxListInternal).attrs({
+export const ComboboxList = styled(ComboboxListInternal).attrs(() => ({
   isMulti: false,
-})`
+}))`
   ${isMultiPadding}
 `
 
-export const ComboboxMultiList = styled(ComboboxListInternal).attrs({
+export const ComboboxMultiList = styled(ComboboxListInternal).attrs(() => ({
   isMulti: true,
-})`
+}))`
   ${isMultiPadding}
 `

--- a/packages/components/src/Form/Inputs/InputColor/LuminositySlider/LuminositySlider.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/LuminositySlider/LuminositySlider.tsx
@@ -26,7 +26,7 @@
 
 import styled from 'styled-components'
 
-export const LuminositySlider = styled.input.attrs({ type: 'range' })`
+export const LuminositySlider = styled.input.attrs(() => ({ type: 'range' }))`
   appearance: none;
   background: transparent;
   width: ${({ width }) => width};

--- a/packages/components/src/Form/Inputs/InputHidden/InputHidden.tsx
+++ b/packages/components/src/Form/Inputs/InputHidden/InputHidden.tsx
@@ -27,6 +27,6 @@
 import styled from 'styled-components'
 import { InputProps } from '../InputProps'
 
-export const InputHidden = styled.input.attrs({ type: 'hidden' })<
+export const InputHidden = styled.input.attrs(() => ({ type: 'hidden' }))<
   Omit<InputProps, 'type'>
 >``

--- a/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
+++ b/packages/components/src/Form/Inputs/InputTime/InputTime.tsx
@@ -530,11 +530,11 @@ const InputTimeInternal = forwardRef(
 
 const WarningIcon = styled(Icon)``
 
-const StyledInput = styled.input.attrs({
+const StyledInput = styled.input.attrs(() => ({
   maxLength: 2,
   placeholder: '--',
   type: 'text',
-})`
+}))`
   ${innerInputStyle}
   font-family: inherit;
   font-size: ${(props) => props.theme.fontSizes.small};

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -172,7 +172,9 @@ const SliderThumb = styled.div<SliderInputProps>`
   `}
 `
 
-const SliderInput = styled.input.attrs({ type: 'range' })<SliderInputProps>`
+const SliderInput = styled.input.attrs(() => ({ type: 'range' }))<
+  SliderInputProps
+>`
   background: transparent;
   display: block;
   height: 22px;

--- a/packages/components/src/Sidebar/SidebarGroup.tsx
+++ b/packages/components/src/Sidebar/SidebarGroup.tsx
@@ -66,12 +66,12 @@ const InternalSidebarGroup: FC<SidebarGroupProps> = ({
   )
 }
 
-const SidebarGroupHeading = styled(Heading).attrs({
+const SidebarGroupHeading = styled(Heading).attrs(() => ({
   as: 'h3',
   fontFamily: 'body',
   fontSize: 'small',
   fontWeight: 'semiBold',
-})`
+}))`
   button {
     align-items: center;
     all: inherit;

--- a/packages/components/src/Text/Code.tsx
+++ b/packages/components/src/Text/Code.tsx
@@ -27,6 +27,6 @@
 import styled from 'styled-components'
 import { TextBase } from './TextBase'
 
-export const Code = styled(TextBase).attrs({ as: 'code' })``
+export const Code = styled(TextBase).attrs(() => ({ as: 'code' }))``
 
 Code.defaultProps = { color: 'text', fontFamily: 'code', fontSize: 'medium' }

--- a/packages/components/src/Text/Paragraph.tsx
+++ b/packages/components/src/Text/Paragraph.tsx
@@ -44,7 +44,9 @@ export interface ParagraphProps
     TruncateProps,
     Omit<CompatibleHTMLProps<HTMLParagraphElement>, 'wrap'> {}
 
-export const Paragraph = styled(TextBase).attrs({ as: 'p' })<ParagraphProps>`
+export const Paragraph = styled(TextBase).attrs(() => ({ as: 'p' }))<
+  ParagraphProps
+>`
   ${layout}
   ${textTransform}
   ${textVariant}

--- a/www/src/MDX/Code.tsx
+++ b/www/src/MDX/Code.tsx
@@ -27,7 +27,7 @@
 import { Box } from '@looker/components'
 import styled from 'styled-components'
 
-export default styled(Box).attrs({
+export default styled(Box).attrs(() => ({
   as: 'code',
   bg: 'ui1',
   borderRadius: 'small',
@@ -36,4 +36,4 @@ export default styled(Box).attrs({
   fontSize: 'small',
   lineHeight: 'medium',
   px: 'xxsmall',
-})``
+}))``

--- a/www/src/MDX/Li.tsx
+++ b/www/src/MDX/Li.tsx
@@ -24,13 +24,11 @@
 
  */
 
+import React, { FC } from 'react'
 import { ListItem } from '@looker/components'
-import styled from 'styled-components'
 
-const Li = styled(ListItem).attrs({
-  lineHeight: 'medium',
-  p: 'none',
-  pl: 'xxsmall',
-})``
+const Li: FC<{}> = (props) => (
+  <ListItem lineHeight="medium" p="none" pl="xxsmall" {...props} />
+)
 
 export default Li

--- a/www/src/MDX/Ol.tsx
+++ b/www/src/MDX/Ol.tsx
@@ -24,12 +24,11 @@
 
  */
 
+import React, { FC } from 'react'
 import { List } from '@looker/components'
-import styled from 'styled-components'
 
-export default styled(List).attrs({
-  lineHeight: 'medium',
-  mb: 'medium',
-  ml: 'xxlarge',
-  type: 'number',
-})``
+const Ol: FC<{}> = (props) => (
+  <List lineHeight="medium" mb="medium" ml="large" type="number" {...props} />
+)
+
+export default Ol

--- a/www/src/MDX/Paragraph.tsx
+++ b/www/src/MDX/Paragraph.tsx
@@ -25,11 +25,10 @@
  */
 
 import { Paragraph as LookerParagraph } from '@looker/components'
-import styled from 'styled-components'
+import React, { FC } from 'react'
 
-const Paragraph = styled(LookerParagraph).attrs({
-  lineHeight: 'medium',
-  mb: 'medium',
-})``
+const Paragraph: FC<{}> = (props) => (
+  <LookerParagraph lineHeight="medium" mb="medium" {...props} />
+)
 
 export default Paragraph

--- a/www/src/MDX/Ul.tsx
+++ b/www/src/MDX/Ul.tsx
@@ -24,12 +24,11 @@
 
  */
 
+import React, { FC } from 'react'
 import { List } from '@looker/components'
-import styled from 'styled-components'
 
-export default styled(List).attrs({
-  lineHeight: 'medium',
-  mb: 'medium',
-  ml: 'xxlarge',
-  type: 'bullet',
-})``
+const Ul: FC<{}> = (props) => (
+  <List lineHeight="medium" mb="medium" ml="large" type="bullet" {...props} />
+)
+
+export default Ul

--- a/www/src/Shared/ComponentResources/Resource.tsx
+++ b/www/src/Shared/ComponentResources/Resource.tsx
@@ -30,14 +30,13 @@ import { Link, ListItem } from '@looker/components'
 
 const Resource: FC<{ url: string }> = ({ children, url }) => (
   <Link href={url} target="_blank" rel="noopener noreferrer">
-    <Style>{children}</Style>
+    <Style fontSize="small" py="xsmall">
+      {children}
+    </Style>
   </Link>
 )
 
-const Style = styled(ListItem).attrs({
-  fontSize: 'small',
-  py: 'xsmall',
-})`
+const Style = styled(ListItem)`
   align-items: center;
   color: ${(props) => props.theme.colors.text2};
   display: flex;

--- a/www/src/Shared/ComponentStatus/ComponentStatus.tsx
+++ b/www/src/Shared/ComponentStatus/ComponentStatus.tsx
@@ -49,7 +49,7 @@ const Status: FC<StatusProps> = (props) => {
   const { status } = props
   return (
     <Link href="/principles/support-levels">
-      <StatusFlag fontSize="small" {...props}>
+      <StatusFlag py="xsmall" fontSize="small" {...props}>
         <Box
           as="span"
           textAlign="center"
@@ -81,10 +81,10 @@ const statusBackground = (props: StatusProps) => {
 
 const StyledBox = styled(Box)``
 
-const StatusFlag = styled(Paragraph).attrs({ py: 'xsmall' })<StatusProps>`
+const StatusFlag = styled(Paragraph)<StatusProps>`
   ${statusBackground}
-  text-transform: capitalize;
   color: ${(props) => props.theme.colors.text};
+  text-transform: capitalize;
 
   &:hover {
     color: ${(props) => props.theme.colors.text3};

--- a/www/src/Shared/Props/Props.tsx
+++ b/www/src/Shared/Props/Props.tsx
@@ -35,22 +35,22 @@ interface PropsProps {
 
 const Props = ({ of, interfaceName = `${of}` }: PropsProps) => {
   return (
-    <Layout>
+    <Layout mb="large" mt="small" py="small">
       <FlexItem>
-        Interface of <PropsCode>{interfaceName}</PropsCode>
+        Interface of <PropsCode fontSize="small">{interfaceName}</PropsCode>
       </FlexItem>
       <FlexItem ml="auto">🏗 Coming Soon</FlexItem>
     </Layout>
   )
 }
 
-const PropsCode = styled(Code).attrs({ fontSize: 'small' })`
+const PropsCode = styled(Code)`
   color: ${(props) => props.theme.colors.key};
 `
 
-const Layout = styled(Flex).attrs({ mb: 'large', mt: 'small', py: 'small' })`
-  border-top: 1px solid ${(props) => props.theme.colors.ui2};
+const Layout = styled(Flex)`
   border-bottom: 1px solid ${(props) => props.theme.colors.ui2};
+  border-top: 1px solid ${(props) => props.theme.colors.ui2};
   color: ${(props) => props.theme.colors.text2};
   font-size: ${(props) => props.theme.fontSizes.small};
 `


### PR DESCRIPTION
### :sparkles: Changes

Per Styled Components 5 release removed support for "subfunctions":

![image](https://user-images.githubusercontent.com/34253496/99341894-9d2db080-283f-11eb-91c2-f750a2840db0.png)

Oddly they still seem to work but in the interest of not having ambient breakage later I figured it'd be good to remove these.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
