### PR TITLE
CopyToClipboardButton

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `FadeIn`
+- CopyToClipboardButton component
 
 ### Changed
 

--- a/packages/components/src/Button/CopyToClipboardButton.story.tsx
+++ b/packages/components/src/Button/CopyToClipboardButton.story.tsx
@@ -24,15 +24,23 @@
 
  */
 
-export * from './Button'
-export * from './ButtonBase'
-export * from './ButtonGroup'
-export * from './ButtonItem'
-export * from './ButtonOutline'
-export * from './ButtonToggle'
-export * from './ButtonTransparent'
-export * from './IconButton'
-export * from './CopyToClipboardButton'
-export * from './iconButtonColor'
+import React, { createRef } from 'react'
+import { Story } from '@storybook/react/types-6-0'
+import { CopyToClipboardButton } from './CopyToClipboardButton'
 
-export type { ButtonSizes } from './size'
+const Template: Story = () => {
+  const ref = createRef<HTMLTextAreaElement>()
+  return (
+    <>
+      <textarea ref={ref} defaultValue={'HI I AM A TEXT AREA'} />
+      <CopyToClipboardButton ref={ref} />
+    </>
+  )
+}
+
+export const Basic = Template.bind({})
+
+export default {
+  component: CopyToClipboardButton,
+  title: 'CopyToClipboardButton',
+}

--- a/packages/components/src/Button/CopyToClipboardButton.test.tsx
+++ b/packages/components/src/Button/CopyToClipboardButton.test.tsx
@@ -1,0 +1,76 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import { act, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { CopyToClipboardButton } from './CopyToClipboardButton'
+
+const getMockedComponent = (propOverride = {}) => {
+  const ref: any = React.createRef()
+
+  const defaultProps = {
+    ref,
+  }
+  const updatedProps = { ...defaultProps, ...propOverride }
+  return (
+    <>
+      <textarea ref={ref} defaultValue={'HI I AM A TEXT AREA'} />
+      <CopyToClipboardButton {...updatedProps} />
+    </>
+  )
+}
+
+describe('CopyToClipboardButton', () => {
+  beforeAll(() => {
+    Object.defineProperty(document, 'execCommand', { value: jest.fn() })
+  })
+
+  it('renders the CopyToClipboardButton', () => {
+    const { getByText } = renderWithTheme(getMockedComponent())
+    expect(getByText('Copy to Clipboard')).toBeVisible()
+  })
+
+  it('transitions from copy to copied state and back when clicked', async () => {
+    jest.useFakeTimers()
+    const { getByText } = renderWithTheme(getMockedComponent())
+    const button = getByText('Copy to Clipboard')
+    fireEvent.click(button)
+    expect(getByText('Copied')).toBeVisible()
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    expect(getByText('Copy to Clipboard')).toBeVisible()
+    jest.useRealTimers()
+  })
+
+  it('copies the refs textarea content on copy click', () => {
+    jest.spyOn(document, 'execCommand')
+    const { getByText } = renderWithTheme(getMockedComponent())
+    const button = getByText('Copy to Clipboard')
+    fireEvent.click(button)
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+  })
+})

--- a/packages/components/src/Button/CopyToClipboardButton.tsx
+++ b/packages/components/src/Button/CopyToClipboardButton.tsx
@@ -1,0 +1,87 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, { forwardRef, Ref, RefObject, useState } from 'react'
+import styled from 'styled-components'
+import { ButtonTransparent } from './ButtonTransparent'
+
+/**
+ * This button allows user to copy contents of the passed in ref to clipboard.
+ */
+
+export const copyToClipboard = (
+  ref: RefObject<HTMLTextAreaElement | HTMLInputElement>
+) => {
+  ref?.current?.select()
+  document.execCommand('copy')
+}
+
+export const CopyToClipboardButton = forwardRef(
+  (_props: any, ref: Ref<HTMLTextAreaElement | HTMLInputElement>) => {
+    const [copied, setCopied] = useState(false)
+
+    const clickCopyButton = () => {
+      if (typeof ref !== 'function') {
+        ref && copyToClipboard(ref)
+      }
+      setCopied(true)
+      setTimeout(() => {
+        setCopied(false)
+      }, 2500)
+    }
+
+    return copied ? (
+      <CopiedButton iconBefore="Check" size="medium">
+        Copied
+      </CopiedButton>
+    ) : (
+      <ButtonTransparent
+        size="medium"
+        iconBefore="Clipboard"
+        onClick={clickCopyButton}
+      >
+        Copy to Clipboard
+      </ButtonTransparent>
+    )
+  }
+)
+
+CopyToClipboardButton.displayName = 'CopyToClipboardButton'
+
+const CopiedButton = styled(ButtonTransparent)`
+  border: none;
+  color: ${({ theme }) => theme.colors.positive};
+  margin: 0;
+
+  &:hover,
+  &:active,
+  &:focus,
+  &:focus-within {
+    background-color: ${({ theme }) => theme.colors.background};
+    border: none;
+    color: ${({ theme }) => theme.colors.positive};
+  }
+`


### PR DESCRIPTION
### :sparkles: Changes

- CopyToClipboardButton component
- tested

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots

<img width="239" alt="Screen Shot 2020-11-24 at 9 34 43 AM" src="https://user-images.githubusercontent.com/23616264/100131145-820f0200-2e38-11eb-9fbc-1b77503435af.png">

<img width="102" alt="Screen Shot 2020-11-24 at 9 36 02 AM" src="https://user-images.githubusercontent.com/23616264/100131150-83402f00-2e38-11eb-82be-0fa6d3af4156.png">