### PR TITLE
Select: fix click caret to open while focused

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Select` / `SelectMulti` clicking on the caret icon opens the list when focused
 - `Tab` now displays properly in Safari
 - `Truncate` with `Link` inside will properly preserve text color from `Link`
 - update InputText and InlineInputText for disabled color on Safari.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Select` / `SelectMulti` clicking on the caret icon opens the list when focused
+- `Select` / `SelectMulti` / `InputTimeSelect` clicking on the caret icon toggles the list and focuses the field if it was not already focused
 - `Tab` now displays properly in Safari
 - `Truncate` with `Link` inside will properly preserve text color from `Link`
 - update InputText and InlineInputText for disabled color on Safari.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,6 +43,7 @@
     "@storybook/react": "^6.1.1",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
+    "@testing-library/user-event": "^12.5.0",
     "@types/d3-color": "^2.0.1",
     "@types/d3-hsv": "^0.1.4",
     "@types/lodash": "^4.14.165",

--- a/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
+++ b/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
@@ -91,6 +91,7 @@ export const AdvancedInputControls: FC<AdvancedInputControlsProps> = ({
         <CaretIcon
           name={isVisibleOptions ? 'CaretUp' : 'CaretDown'}
           disabled={disabled}
+          data-testid="caret"
         />
       ),
     ])

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.test.tsx
@@ -25,7 +25,7 @@
  */
 
 import { renderWithTheme } from '@looker/components-test-utils'
-import { cleanup, fireEvent } from '@testing-library/react'
+import { cleanup, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -342,6 +342,40 @@ describe('<Combobox/> with children', () => {
 
     getByPlaceholderText('Type here').focus()
     expect(getByRole('listbox')).toBeInTheDocument()
+
+    // Close popover to silence act() warning
+    fireEvent.click(document)
+  })
+
+  test.each([
+    [
+      'Combobox',
+      <Combobox key="combobox">
+        <ComboboxInput placeholder="Type here" />
+        <ComboboxList>
+          <ComboboxOption label="Foo" value="101" />
+          <ComboboxOption label="Bar" value="102" />
+        </ComboboxList>
+      </Combobox>,
+    ],
+    [
+      'ComboboxMulti',
+      <ComboboxMulti key="combobox-multi">
+        <ComboboxMultiInput placeholder="Type here" />
+        <ComboboxMultiList>
+          <ComboboxMultiOption label="Foo" value="101" />
+          <ComboboxMultiOption label="Bar" value="102" />
+        </ComboboxMultiList>
+      </ComboboxMulti>,
+    ],
+  ])('click caret to open', (_, jsx) => {
+    renderWithTheme(jsx)
+
+    screen.getByPlaceholderText('Type here').focus()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+
+    userEvent.click(screen.getByTestId('caret'))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
 
     // Close popover to silence act() warning
     fireEvent.click(document)

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.test.tsx
@@ -26,6 +26,7 @@
 
 import { renderWithTheme } from '@looker/components-test-utils'
 import { cleanup, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 import {

--- a/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useBlur.ts
@@ -61,7 +61,9 @@ export function useBlur<
     if (!e) {
       // handleBlur was called directly (via popover close)
       // only need to close the list
-      closeList(ComboboxActionType.ESCAPE)
+      if (state !== ComboboxState.IDLE) {
+        closeList(ComboboxActionType.ESCAPE)
+      }
       return
     }
     // we on want to close only if focus rests outside the select

--- a/packages/components/src/Form/Inputs/Combobox/utils/useFocusManagement.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useFocusManagement.ts
@@ -38,8 +38,6 @@ export function useFocusManagement(lastActionType?: ComboboxActionType) {
   // of awkwardly at the beginning, unclear to my why ...
   useLayoutEffect(() => {
     if (
-      lastActionType === ComboboxActionType.NAVIGATE ||
-      lastActionType === ComboboxActionType.ESCAPE ||
       lastActionType === ComboboxActionType.SELECT_WITH_CLICK ||
       lastActionType === ComboboxActionType.INTERACT
     ) {

--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
@@ -31,7 +31,11 @@ import {
   useCallback,
   Context,
 } from 'react'
-import { useMouseDownClick, useWrapEvent } from '../../../../utils'
+import {
+  targetIsButton,
+  useMouseDownClick,
+  useWrapEvent,
+} from '../../../../utils'
 import { ComboboxInputProps } from '../ComboboxInput'
 import { ComboboxMultiInputProps } from '../ComboboxMultiInput'
 import {
@@ -41,20 +45,6 @@ import {
 import { ComboboxActionType, ComboboxState } from './state'
 import { useBlur } from './useBlur'
 import { useKeyDown } from './useKeyDown'
-
-// Walks up the dom tree from an element to a containingAncestor checking for a button
-// Used for determining whether a mousedown/click should toggle the option list
-function checkForButton(
-  element: Element,
-  containingAncestor: Element
-): boolean {
-  if (element === containingAncestor) return false
-  if (!element.parentElement) return false
-  if (element.tagName === 'BUTTON') {
-    return true
-  }
-  return checkForButton(element.parentElement, containingAncestor)
-}
 
 export function useInputEvents<
   TProps extends
@@ -129,7 +119,7 @@ export function useInputEvents<
       // Without this, when clicking on a "clear" or "remove value" icon button
       // the list will flash open & closed (if closed)
       // or unnecessarily close (if open)
-      if (checkForButton(e.target as Element, e.currentTarget as Element)) {
+      if (targetIsButton(e)) {
         return
       }
       if (state === ComboboxState.IDLE) {

--- a/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
@@ -188,9 +188,10 @@ export const InputChipsBaseInternal = forwardRef(
       }
     }
 
-    // Prevent the default InputText behavior of moving focus to the internal input just after mousedown
-    // on Chip and clear button and instead focus after onChipDelete / onClear
-    // If mousedown/click is elsewhere on Chip, don't move focus b/c user is trying to select the Chip itself
+    // If mousedown is on the Chip, prevent moving focus to the input
+    // from the mousedown handler in InputChip
+    // The user is either trying to select the Chip itself
+    // or deleting the chip, which would be interrupted by moving focus
     function stopPropagation(e: SyntheticEvent) {
       e.stopPropagation()
     }
@@ -363,7 +364,6 @@ export const InputChipsBaseInternal = forwardRef(
             disabled={disabled}
             summary={summary}
             showCaret={showCaret}
-            onMouseDown={stopPropagation}
           />
         }
         height="auto"

--- a/packages/components/src/Form/Inputs/InputText/InputText.test.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.test.tsx
@@ -48,109 +48,116 @@ afterEach(() => {
   global.console = globalConsole
 })
 
-test('InputText default', () => {
-  assertSnapshot(<InputText />)
-})
+describe('InputText', () => {
+  test('default', () => {
+    assertSnapshot(<InputText />)
+  })
 
-test('InputText with name and id', () => {
-  assertSnapshot(<InputText name="Bob" id="Bobby" />)
-})
+  test('with name and id', () => {
+    assertSnapshot(<InputText name="Bob" id="Bobby" />)
+  })
 
-test('InputText should accept disabled', () => {
-  assertSnapshot(<InputText disabled />)
-})
+  test('should accept disabled', () => {
+    assertSnapshot(<InputText disabled />)
+  })
 
-test('InputText with a placeholder', () => {
-  assertSnapshot(<InputText placeholder="I am a placeholder" />)
-})
+  test('with a placeholder', () => {
+    assertSnapshot(<InputText placeholder="I am a placeholder" />)
+  })
 
-test('InputText should accept readOnly', () => {
-  assertSnapshot(<InputText readOnly />)
-})
+  test('should accept readOnly', () => {
+    assertSnapshot(<InputText readOnly />)
+  })
 
-test('InputText should accept required', () => {
-  assertSnapshot(<InputText required />)
-})
+  test('should accept required', () => {
+    assertSnapshot(<InputText required />)
+  })
 
-test('InputText with a value', () => {
-  assertSnapshot(<InputText value="Some value" />)
-})
+  test('with a value', () => {
+    assertSnapshot(<InputText value="Some value" />)
+  })
 
-test('InputText with aria-describedby', () => {
-  assertSnapshot(<InputText aria-describedby="some-id" />)
-})
+  test('with aria-describedby', () => {
+    assertSnapshot(<InputText aria-describedby="some-id" />)
+  })
+  test('autoResize', () => {
+    const { container, getByPlaceholderText, getByText } = renderWithTheme(
+      <InputText autoResize placeholder="resize me" />
+    )
+    expect(container.firstChild).toHaveStyleRule('width: auto')
+    expect(getByPlaceholderText('resize me')).toHaveStyleRule(
+      'position: absolute'
+    )
+    expect(getByText('resize me')).toBeVisible()
+  })
 
-test('InputText autoResize', () => {
-  const { container, getByPlaceholderText, getByText } = renderWithTheme(
-    <InputText autoResize placeholder="resize me" />
-  )
-  expect(container.firstChild).toHaveStyleRule('width: auto')
-  expect(getByPlaceholderText('resize me')).toHaveStyleRule(
-    'position: absolute'
-  )
-  expect(getByText('resize me')).toBeVisible()
-})
+  test('with an error validation', () => {
+    const { getAllByTitle, getByPlaceholderText } = renderWithTheme(
+      <InputText placeholder="Hello" validationType="error" />
+    )
 
-test('InputText with an error validation', () => {
-  const { getAllByTitle, getByPlaceholderText } = renderWithTheme(
-    <InputText placeholder="Hello" validationType="error" />
-  )
+    expect(getByPlaceholderText('Hello')).toHaveAttribute('aria-invalid')
+    expect(getAllByTitle('Validation Error')).toBeDefined()
+  })
 
-  expect(getByPlaceholderText('Hello')).toHaveAttribute('aria-invalid')
-  expect(getAllByTitle('Validation Error')).toBeDefined()
-})
+  describe('before & after', () => {
+    test('ReactNode', () => {
+      const { getByText } = renderWithTheme(
+        <InputText before={<span>before</span>} after={<span>after</span>} />
+      )
 
-test('InputText with a before & after', () => {
-  const { getByText } = renderWithTheme(
-    <InputText before={<span>before</span>} after={<span>after</span>} />
-  )
+      expect(getByText('before')).toBeVisible()
+      expect(getByText('after')).toBeVisible()
+    })
 
-  expect(getByText('before')).toBeVisible()
-  expect(getByText('after')).toBeVisible()
-})
+    test('icons', () => {
+      const { getByTitle } = renderWithTheme(
+        <InputText
+          iconBefore="Favorite"
+          iconBeforeTitle="Before Title"
+          iconAfter="Account"
+          iconAfterTitle="After Title"
+        />
+      )
 
-test('InputText with an iconBefore & iconAfter', () => {
-  const { getByTitle } = renderWithTheme(
-    <InputText
-      iconBefore="Favorite"
-      iconBeforeTitle="Before Title"
-      iconAfter="Account"
-      iconAfterTitle="After Title"
-    />
-  )
+      expect(getByTitle('Before Title')).toBeInTheDocument()
+      expect(getByTitle('After Title')).toBeInTheDocument()
+    })
 
-  expect(getByTitle('Before Title')).toBeInTheDocument()
-  expect(getByTitle('After Title')).toBeInTheDocument()
-})
+    test('redundant ones should not render', () => {
+      const { queryByPlaceholderText } = renderWithTheme(
+        <>
+          <InputText placeholder="Hello" iconBefore="Favorite" before="$" />
+          <InputText placeholder="Goodbye" iconAfter="Account" after="%" />
+        </>
+      )
 
-test('InputText with redundant before/after props', () => {
-  const { queryByPlaceholderText } = renderWithTheme(
-    <>
-      <InputText placeholder="Hello" iconBefore="Favorite" before="$" />
-      <InputText placeholder="Goodbye" iconAfter="Account" after="%" />
-    </>
-  )
+      expect(queryByPlaceholderText('Hello')).not.toBeInTheDocument()
+      expect(queryByPlaceholderText('Goodbye')).not.toBeInTheDocument()
+      expect(warnMock.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            "Use before or iconBefore, but not both at the same time.",
+          ],
+          Array [
+            "Use after or iconAfter, but not both at the same time.",
+          ],
+        ]
+      `)
+    })
 
-  expect(queryByPlaceholderText('Hello')).not.toBeInTheDocument()
-  expect(queryByPlaceholderText('Goodbye')).not.toBeInTheDocument()
-  expect(warnMock.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        "Use before or iconBefore, but not both at the same time.",
-      ],
-      Array [
-        "Use after or iconAfter, but not both at the same time.",
-      ],
-    ]
-  `)
-})
+    test('focus input on click', () => {
+      //
+    })
+  })
 
-test('Should trigger onChange handler', () => {
-  let counter = 0
-  const handleChange = () => counter++
+  test('Should trigger onChange handler', () => {
+    let counter = 0
+    const handleChange = () => counter++
 
-  const wrapper = mountWithTheme(<InputText onChange={handleChange} />)
+    const wrapper = mountWithTheme(<InputText onChange={handleChange} />)
 
-  wrapper.find('input').simulate('change', { target: { value: '' } })
-  expect(counter).toEqual(1)
+    wrapper.find('input').simulate('change', { target: { value: '' } })
+    expect(counter).toEqual(1)
+  })
 })

--- a/packages/components/src/Form/Inputs/InputText/InputText.test.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.test.tsx
@@ -151,15 +151,7 @@ describe('InputText', () => {
       `)
     })
 
-    test('focus input on click', () => {
-      renderWithTheme(<InputText after={<span>after</span>} />)
-      const after = screen.getByText('after')
-      userEvent.click(after)
-      jest.runOnlyPendingTimers()
-      expect(screen.getByRole('textbox')).toHaveFocus()
-    })
-
-    test('does not blur input on click', () => {
+    test('focus & blur behavior', () => {
       const handleBlur = jest.fn()
       const handleFocus = jest.fn()
       renderWithTheme(

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -122,12 +122,17 @@ const InputTextLayout = forwardRef(
     const internalRef = useRef<null | HTMLInputElement>(null)
     const ref = useForkedRef<HTMLInputElement>(internalRef, forwardedRef)
 
-    const handleMouseDown = () => {
+    const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
       // set focus to input on mousedown of container to mimic natural input behavior
       // need requestAnimationFrame here due to browser updating focus _after_ mousedown is called
+      // if (document.activeElement === internalRef.current) {
+      // Avoid triggering the blur event
+      //   e.preventDefault()
+      // } else {
       window.requestAnimationFrame(() => {
         internalRef.current && internalRef.current.focus()
       })
+      // }
     }
 
     const onMouseDownWrapped = useWrapEvent(handleMouseDown, onMouseDown)

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -45,7 +45,7 @@ import { innerInputStyle } from '../innerInputStyle'
 import { SimpleLayoutProps } from '../../../Layout/utils/simple'
 import { Icon } from '../../../Icon'
 import { Span } from '../../../Text'
-import { useForkedRef, useWrapEvent } from '../../../utils'
+import { targetIsButton, useForkedRef, useWrapEvent } from '../../../utils'
 import { InlineInputTextBase } from '../InlineInputText'
 import { inputHeight } from '../height'
 
@@ -123,15 +123,20 @@ const InputTextLayout = forwardRef(
     const ref = useForkedRef<HTMLInputElement>(internalRef, forwardedRef)
 
     const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
-      // set focus to input on mousedown of container to mimic natural input behavior
-      // need requestAnimationFrame here due to browser updating focus _after_ mousedown is called
-      if (document.activeElement === internalRef.current) {
-        // Avoid triggering the blur event
-        e.preventDefault()
-      } else {
-        setTimeout(() => {
-          internalRef.current && internalRef.current.focus()
-        }, 0)
+      // Avoid moving focus if the mousedown was inside a button
+      // because it will interrupt any onclick behavior
+      // (the button click handler should be responsible for moving focus)
+      if (!targetIsButton(e)) {
+        // set focus to input on mousedown of container to mimic natural input behavior
+        // need requestAnimationFrame here due to browser updating focus _after_ mousedown is called
+        if (document.activeElement === internalRef.current) {
+          // Avoid triggering the blur event
+          e.preventDefault()
+        } else {
+          setTimeout(() => {
+            internalRef.current && internalRef.current.focus()
+          }, 0)
+        }
       }
     }
 

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -125,14 +125,14 @@ const InputTextLayout = forwardRef(
     const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
       // set focus to input on mousedown of container to mimic natural input behavior
       // need requestAnimationFrame here due to browser updating focus _after_ mousedown is called
-      // if (document.activeElement === internalRef.current) {
-      // Avoid triggering the blur event
-      //   e.preventDefault()
-      // } else {
-      window.requestAnimationFrame(() => {
-        internalRef.current && internalRef.current.focus()
-      })
-      // }
+      if (document.activeElement === internalRef.current) {
+        // Avoid triggering the blur event
+        e.preventDefault()
+      } else {
+        setTimeout(() => {
+          internalRef.current && internalRef.current.focus()
+        }, 0)
+      }
     }
 
     const onMouseDownWrapped = useWrapEvent(handleMouseDown, onMouseDown)

--- a/packages/components/src/Form/Inputs/Select/Select.test.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.test.tsx
@@ -719,7 +719,9 @@ describe('Select / SelectMulti', () => {
     renderWithTheme(<Component />)
     const input = screen.getByPlaceholderText('Search')
     fireEvent.mouseDown(input)
-    fireEvent.click(screen.getByText('FOO'))
+    const option = screen.getByText('FOO')
+    fireEvent.blur(input, { relatedTarget: option })
+    fireEvent.click(option)
 
     expect(input).toHaveFocus()
 

--- a/packages/components/src/utils/targetIsButton.ts
+++ b/packages/components/src/utils/targetIsButton.ts
@@ -24,29 +24,24 @@
 
  */
 
-export * from './getNextFocusTarget'
-export * from './getWindowedListBoundaries'
-export * from './HoverDisclosure'
-export * from './moveFocus'
-export * from './targetIsButton'
-export * from './undefinedCoalesce'
-export * from './useAnimationState'
-export * from './useClickable'
-export * from './useControlWarn'
-export * from './useReadOnlyWarn'
-export * from './useCallbackRef'
-export * from './useFocusTrap'
-export * from './useForkedRef'
-export * from './useGlobalHotkeys'
-export * from './useHovered'
-export * from './useID'
-export * from './useIsTruncated'
-export * from './useMouseDownClick'
-export * from './usePopper'
-export * from './useResize'
-export * from './useScrollLock'
-export * from './useToggle'
-export * from './useWrapEvent'
-export * from './useMeasuredElement'
-export * from './useMouseDragPosition'
-export * from './usePreviousValue'
+import { MouseEvent as ReactMouseEvent } from 'react'
+
+const checkForButton = (
+  element: Element,
+  containingAncestor: Element
+): boolean => {
+  if (element === containingAncestor) return false
+  if (!element.parentElement) return false
+  if (element.tagName === 'BUTTON') {
+    return true
+  }
+  return checkForButton(element.parentElement, containingAncestor)
+}
+/**
+ * Walks up the dom tree from an event's target to its currentTarget
+ * to determine whether a mousedown/click was located within a button
+ * @param e mouse event
+ */
+export const targetIsButton = (e: ReactMouseEvent<HTMLElement>) => {
+  return checkForButton(e.target as Element, e.currentTarget as Element)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4754,6 +4754,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^12.5.0":
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.5.0.tgz#7c6f69cee4dbd11037ac9c3f62c5d81b9a4ccf30"
+  integrity sha512-9uXr4+OwjHVUxzdfYZ2yCnF3xlEzr8cZOdqjGnqD8Qb1NoCJrm7UXxG3RUpL2QqcqZ1eqVuxkFJTCky5Yit+XQ==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@tokenizer/token@^0.1.0", "@tokenizer/token@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"


### PR DESCRIPTION
### :sparkles: Changes

#### Issue 1
- **Issue:** Clicking on the caret icon _while_ `Select` is focused fails to open the list.
![9008e81d-603a-48cc-8fde-6a7039f9c9fd](https://user-images.githubusercontent.com/53451193/101684109-be3a8900-3a1a-11eb-89ff-3b2ff9684696.gif)
- **Cause:** The caret click triggered a blur event on the input, which tells `Combobox` to close... _after_ the mousedown event tells it to open. "Blur event -> close" wins.
- **Fix:** `InputText` focuses the input after any mousedown on a non-button element inside the wrapper div – e.g. the caret icon. Adding a check inside the mousedown handler for if the input is already focused and then `e.preventDefault()` avoids the unnecessary blur & refocus, thus fixing the `Select` issue.

#### Issue 2
- **Issue:** The 1st click on the caret icon on a `SelectMulti` doesn't focus the field.
![5c445a8e-f692-4832-b181-324d3ac6e0b5](https://user-images.githubusercontent.com/53451193/101670382-ef5d8e00-3a07-11eb-8db9-4d167075acf6.gif)
- **Cause:** In `InputChipsBase.tsx` there was a `onMouseDown={stopPropagation}` that was put in place to prevent the default behavior from `InputText` of focus moving to the input, because this breaks the Clear button. 
- **Fix:** Adding a check for if the mousedown occurred inside a button to `InputText` and removing `onMouseDown={stopPropagation}` from `InputChipsBase` allows the caret to move focus but the Clear button still works.

#### Issue 3
- **Issue:** The 1st click on the caret icon on a `InputTimeSelect` with no current value fails to open the list.
![e8cef040-2d50-4ba3-8f95-59ed83b70f9d](https://user-images.githubusercontent.com/53451193/101684360-27ba9780-3a1b-11eb-9914-958bcd6dc63b.gif)
- **Cause:** The "scroll current time into view" behavior was triggering a `NAVIGATE` action, which in turn (unnecessarily) re-focused the input, causing a blur event on the caret. (Who knew `.focus()` would trigger a blur even when the element is already focused?)
- **Fix:** Remove behavior that triggers `.focus()` on the input after a `NAVIGATE` action. This was in the original code but I can't figure out why it would be there. `NAVIGATE` is only triggered via `mouseenter` and `keydown` (arrow keys only) events, neither of which move focus. I also removed `ESCAPE` (closes the list in various scenarios) from the same bit of code – it wasn't actually doing anything except breaking my new tests.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue 1 fixed
![dce8387d-94b1-4436-bc2b-893eb5e3dc0a](https://user-images.githubusercontent.com/53451193/101539931-1fe3f000-3954-11eb-9fba-c4c28b8303fb.gif)

#### Issue 2 fixed
![8c9b52d9-9fdc-479f-840f-0645d9cad831](https://user-images.githubusercontent.com/53451193/101687545-841fb600-3a1f-11eb-91db-c1639a6a4028.gif)

#### Issue 3 fixed
![3f922166-18ce-45b6-af7b-32d3035c3631](https://user-images.githubusercontent.com/53451193/101687566-8c77f100-3a1f-11eb-9bc1-520508a0ef3c.gif)
