### PR TITLE
Tooltip: support nesting inside Popover

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Tooltip` can now be nested directly inside a `Popover`
 - `AccordionDisclosure` now supports `SimpleLayoutProps`
 - `Tree` uses text5 as text color
 

--- a/packages/components/src/Popover/stories/Popover.story.tsx
+++ b/packages/components/src/Popover/stories/Popover.story.tsx
@@ -50,7 +50,6 @@ import {
 import { Popover } from '../Popover'
 import { PopoverContent } from '../PopoverContent'
 import { usePopover } from '../usePopover'
-import { Tooltip } from '../../Tooltip'
 
 export * from './OverflowExamples'
 
@@ -66,18 +65,6 @@ export const Basic = () => (
 )
 
 Basic.parameters = {
-  storyshots: { disable: true },
-}
-
-export const NestedTooltip = () => (
-  <Popover content={<PopoverContent>Some content</PopoverContent>}>
-    <Tooltip content="Some tooltip">
-      <Button>Open</Button>
-    </Tooltip>
-  </Popover>
-)
-
-NestedTooltip.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Popover/stories/Popover.story.tsx
+++ b/packages/components/src/Popover/stories/Popover.story.tsx
@@ -50,6 +50,7 @@ import {
 import { Popover } from '../Popover'
 import { PopoverContent } from '../PopoverContent'
 import { usePopover } from '../usePopover'
+import { Tooltip } from '../../Tooltip'
 
 export * from './OverflowExamples'
 
@@ -65,6 +66,18 @@ export const Basic = () => (
 )
 
 Basic.parameters = {
+  storyshots: { disable: true },
+}
+
+export const NestedTooltip = () => (
+  <Popover content={<PopoverContent>Some content</PopoverContent>}>
+    <Tooltip content="Some tooltip">
+      <Button>Open</Button>
+    </Tooltip>
+  </Popover>
+)
+
+NestedTooltip.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Tooltip/Tooltip.story.tsx
+++ b/packages/components/src/Tooltip/Tooltip.story.tsx
@@ -24,10 +24,13 @@
 
  */
 
-import React from 'react'
+import React, { FormEvent, SyntheticEvent, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { Button } from '../Button'
 import { Card } from '../Card'
+import { FieldToggleSwitch } from '../Form'
+import { Space, SpaceVertical } from '../Layout'
+import { Text } from '../Text'
 import { Popover, PopoverContent } from '../Popover'
 import { Tooltip, TooltipProps } from './Tooltip'
 
@@ -126,13 +129,46 @@ LargeTrigger.parameters = {
   storyshots: { disable: true },
 }
 
-export const NestedInPopover = () => (
-  <Popover content={<PopoverContent>Some content</PopoverContent>}>
-    <Tooltip content="Some tooltip">
-      <Button>Open</Button>
-    </Tooltip>
-  </Popover>
-)
+export const NestedInPopover = () => {
+  const [prevent, setPrevent] = useState(false)
+  function handleChange(e: FormEvent<HTMLInputElement>) {
+    setPrevent(e.currentTarget.checked)
+  }
+
+  const [lastEvent, setLastEvent] = useState('N/A')
+  const getHandler = (text: string) => (e: SyntheticEvent) => {
+    setLastEvent(text)
+    if (prevent) {
+      e.preventDefault()
+    }
+  }
+
+  const handlers = {
+    onBlur: getHandler('blur'),
+    onClick: getHandler('click'),
+    onFocus: getHandler('focus'),
+    onMouseOut: getHandler('mouse out'),
+    onMouseOver: getHandler('mouse over'),
+  }
+
+  return (
+    <SpaceVertical p="large">
+      <Text>Last event: {lastEvent}</Text>
+      <Space>
+        <Popover content={<PopoverContent>Some content</PopoverContent>}>
+          <Tooltip content="Some tooltip">
+            <Button {...handlers}>Open</Button>
+          </Tooltip>
+        </Popover>
+        <FieldToggleSwitch
+          on={prevent}
+          onChange={handleChange}
+          label="Prevent default"
+        />
+      </Space>
+    </SpaceVertical>
+  )
+}
 
 NestedInPopover.parameters = {
   storyshots: { disable: true },

--- a/packages/components/src/Tooltip/Tooltip.story.tsx
+++ b/packages/components/src/Tooltip/Tooltip.story.tsx
@@ -28,6 +28,7 @@ import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { Button } from '../Button'
 import { Card } from '../Card'
+import { Popover, PopoverContent } from '../Popover'
 import { Tooltip, TooltipProps } from './Tooltip'
 
 const Template: Story<TooltipProps> = (args) => (
@@ -122,6 +123,18 @@ export const LargeTrigger = () => (
 )
 
 LargeTrigger.parameters = {
+  storyshots: { disable: true },
+}
+
+export const NestedInPopover = () => (
+  <Popover content={<PopoverContent>Some content</PopoverContent>}>
+    <Tooltip content="Some tooltip">
+      <Button>Open</Button>
+    </Tooltip>
+  </Popover>
+)
+
+NestedInPopover.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -29,6 +29,7 @@ import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { act, fireEvent, screen } from '@testing-library/react'
 import { Button } from '../Button'
+import { Popover } from '../Popover'
 import { Tooltip } from './Tooltip'
 
 describe('Tooltip', () => {
@@ -169,5 +170,47 @@ describe('Tooltip', () => {
 
     runTimers()
     expect(tooltip).not.toBeInTheDocument()
+  })
+
+  test('nested in a Popover', () => {
+    const mockHandlers = {
+      onBlur: jest.fn(),
+      onClick: jest.fn(),
+      onFocus: jest.fn(),
+      onMouseOut: jest.fn(),
+      onMouseOver: jest.fn(),
+    }
+
+    renderWithTheme(
+      <Popover content="Some popover">
+        <Tooltip content="Some tooltip">
+          <Button {...mockHandlers}>Open</Button>
+        </Tooltip>
+      </Popover>
+    )
+
+    const button = screen.getByText('Open')
+
+    fireEvent.focus(button)
+    expect(mockHandlers.onFocus).toHaveBeenCalled()
+
+    runTimers()
+    expect(screen.getByText('Some tooltip')).toBeVisible()
+
+    fireEvent.click(button)
+    expect(screen.getByText('Some popover')).toBeVisible()
+    expect(screen.queryByText('Some tooltip')).not.toBeInTheDocument()
+    expect(mockHandlers.onClick).toHaveBeenCalled()
+
+    fireEvent.mouseOut(button)
+    expect(mockHandlers.onMouseOut).toHaveBeenCalled()
+    fireEvent.mouseOver(button)
+    expect(mockHandlers.onMouseOver).toHaveBeenCalled()
+    expect(screen.queryByText('Some tooltip')).not.toBeInTheDocument()
+
+    fireEvent.blur(button)
+    expect(mockHandlers.onBlur).toHaveBeenCalled()
+
+    fireEvent.click(document)
   })
 })

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -28,6 +28,7 @@ import React, {
   cloneElement,
   forwardRef,
   isValidElement,
+  MouseEvent,
   ReactNode,
   Ref,
 } from 'react'
@@ -41,7 +42,9 @@ import {
 
 type TooltipRenderProp = (props: UseTooltipResponseDom) => ReactNode
 
-export interface TooltipProps extends UseTooltipProps, UsePopoverResponseDom {
+export interface TooltipProps
+  extends UseTooltipProps,
+    Partial<UsePopoverResponseDom> {
   content: ReactNode
   /**
    * Component to wrap. The HOC will listen for mouse events on this component, maintain the
@@ -85,7 +88,11 @@ export const Tooltip = forwardRef(
       target = cloneElement(children, {
         'aria-expanded': ariaExpanded,
         'aria-haspopup': ariaHaspopup,
-        onClick,
+        onClick: (e: MouseEvent<HTMLElement>) => {
+          // Popover onClick will be rare – don't clobber child's onClick
+          onClick?.(e)
+          children.props.onClick?.(e)
+        },
         ref,
         ...restDomProps,
         className:

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -101,6 +101,7 @@ export const Tooltip = forwardRef(
       ref: tooltipRef,
       ...restDomProps
     } = domProps
+
     const ref = useForkedRef(tooltipRef, forwardedRef)
 
     let target: ReactNode = children

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -28,6 +28,7 @@ import React, {
   cloneElement,
   forwardRef,
   isValidElement,
+  ReactElement,
   ReactNode,
   Ref,
   SyntheticEvent,
@@ -47,10 +48,12 @@ export interface TooltipProps
     Partial<UsePopoverResponseDom> {
   content: ReactNode
   /**
-   * Component to wrap. The HOC will listen for mouse events on this component, maintain the
-   * state of isOpen accordingly, and pass that state into the children or "trigger" element
+   * Component to receive tooltip behavior or render prop function that
+   * receives tooltip props and returns a component
    */
-  children: ReactNode | TooltipRenderProp
+  children:
+    | ReactElement<UseTooltipResponseDom & UsePopoverResponseDom>
+    | TooltipRenderProp
 }
 
 const mergeHandlers = <E extends SyntheticEvent>(
@@ -100,7 +103,7 @@ export const Tooltip = forwardRef(
     } = domProps
     const ref = useForkedRef(tooltipRef, forwardedRef)
 
-    let target = children
+    let target: ReactNode = children
 
     if (isValidElement(children)) {
       const handlers = {

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -103,18 +103,32 @@ export const Tooltip = forwardRef(
     let target = children
 
     if (isValidElement(children)) {
+      const handlers = {
+        onBlur,
+        onClick,
+        onFocus,
+        onMouseOut,
+        onMouseOver,
+      }
+
+      const mergedHandlers = Object.keys(handlers).reduce(
+        (acc: Partial<typeof handlers>, key) => {
+          return {
+            ...acc,
+            [key]: mergeHandlers(handlers[key], children.props[key]),
+          }
+        },
+        {}
+      )
+
       target = cloneElement(children, {
+        ...mergedHandlers,
+        ...restDomProps,
         'aria-expanded': ariaExpanded,
         'aria-haspopup': ariaHaspopup,
-        onBlur: mergeHandlers(onBlur, children.props.onBlur),
-        onClick: mergeHandlers(onClick, children.props.onClick),
-        onFocus: mergeHandlers(onFocus, children.props.onFocus),
-        onMouseOut: mergeHandlers(onMouseOut, children.props.onMouseOut),
-        onMouseOver: mergeHandlers(onMouseOver, children.props.onMouseOver),
-        ref,
-        ...restDomProps,
         className:
           `${children.props.className || ''} ${className}`.trim() || undefined,
+        ref,
       })
     } else if (isRenderProp(children)) {
       target = children(domProps)


### PR DESCRIPTION
### :sparkles: Changes

- Allows a `Tooltip` to be nested directly inside a `Popover`
- Previously, `Tooltip` would not forward on the props that `Popover` spreads onto its children, and the React `Function components cannot be given refs` error would be triggered.
- This changes `Tooltip` to accept the `domProps` from `Popover` and pass them down, along with those generated internally, to its child.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC
