### PR TITLE
Tree: Set children/label to ReactNode type

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Tooltip` can now be nested directly inside a `Popover`
 - `AccordionDisclosure` now supports `SimpleLayoutProps`
-- `Tree` uses text5 as text color
+- `Tree`
+  - Uses text5 as text color
+  - Accepts ReactNode for `label` prop
+- `TreeItem` accepts ReactNode for `children` prop
 
 ### Fixed
 

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -70,7 +70,7 @@ export interface TreeProps
    * Text label of the Tree
    * Note: This is a required prop
    */
-  label: string
+  label: ReactNode
   /**
    * If true, the internal AccordionDisclosure will have fontWeight = 'Normal'
    * @default false

--- a/packages/components/src/Tree/TreeItem.tsx
+++ b/packages/components/src/Tree/TreeItem.tsx
@@ -58,7 +58,7 @@ import { TreeContext } from './TreeContext'
 export interface TreeItemProps
   extends Omit<CompatibleHTMLProps<HTMLDivElement>, 'color'>,
     TextColorProps {
-  children: string
+  children: ReactNode
   className?: string
   /**
    * Supplementary element that appears right of the TreeItem's label


### PR DESCRIPTION
### :sparkles: Changes

- Set `TreeItem`'s `children` prop and `Tree`'s `label` prop to "ReactNode"
  - Supports "In Use" use case for Explore team

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC
