### PR TITLE
Fix Tooltip for autoFocus input

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Tooltip` shows on an input with `autoFocus` on first mount
 - `FieldInline` positioning correction correction. Affects:
   - `FieldCheckbox`
   - `FieldCheckboxGroup`

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -25,7 +25,7 @@
  */
 
 import 'jest-styled-components'
-import React from 'react'
+import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { act, fireEvent, screen } from '@testing-library/react'
 import { Button } from '../Button'
@@ -212,5 +212,33 @@ describe('Tooltip', () => {
     expect(mockHandlers.onBlur).toHaveBeenCalled()
 
     fireEvent.click(document)
+  })
+
+  test('with nested autoFocus input', () => {
+    const AutoFocusInput = () => {
+      const [show, setShow] = useState(false)
+      return (
+        <>
+          <Button onClick={() => setShow(true)}>Click</Button>
+          {show && (
+            <Tooltip
+              content="See what happens when you scroll"
+              placement="right"
+            >
+              <div>
+                <input type="text" autoFocus />
+              </div>
+            </Tooltip>
+          )}
+        </>
+      )
+    }
+
+    renderWithTheme(<AutoFocusInput />)
+    fireEvent.click(screen.getByText('Click'))
+    runTimers()
+    expect(screen.getByRole('tooltip')).toBeVisible()
+
+    fireEvent.blur(screen.getByRole('textbox'))
   })
 })

--- a/packages/components/src/Tooltip/useTooltip.tsx
+++ b/packages/components/src/Tooltip/useTooltip.tsx
@@ -144,7 +144,7 @@ export function useTooltip({
     typeof triggerElement === 'undefined' ? newTriggerElement : triggerElement
 
   const handleOpen = () => {
-    if (element && !element.dataset.notooltip) {
+    if (!element || !element.dataset.notooltip) {
       setIsOpen(true)
     }
   }


### PR DESCRIPTION
### :sparkles: Changes

- `Tooltip`'s `onFocus` handler may be triggered before the callback ref on the trigger is updated, for example an `autoFocus` input receiving focus just as it mounts.
- A recent change for the [Focus Trap refactor](https://github.com/looker-open-source/components/pull/1644) added a check if the element exists and does NOT have `data-notooltip`. In the `autoFocus` scenario, the element does not exist yet (it will soon) but the focus event should not be igored.
- The updated check is for _either_ the element has no `data-tooltip` or it doesn't exist (yet, hopefully). 

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
