### PR TITLE
MenuList windowing fixes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `MenuList` unnecessary windowing
+- `MenuGroup` sticky group label stacking on top of items
 - `Tooltip` shows on an input with `autoFocus` on first mount
 - `FieldInline` positioning correction correction. Affects:
   - `FieldCheckbox`

--- a/packages/components/src/Button/IconButton.story.tsx
+++ b/packages/components/src/Button/IconButton.story.tsx
@@ -24,12 +24,8 @@
 
  */
 
-import React, { FormEvent, useState } from 'react'
+import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
-import { iconNameList, IconNames } from '@looker/icons'
-import { FieldToggleSwitch, InputText } from '../Form'
-import { Icon } from '../Icon'
-import { Space, SpaceVertical } from '../Layout'
 import { IconButton, IconButtonProps } from './IconButton'
 
 export default {
@@ -107,34 +103,4 @@ export const ToggleOff = Template.bind({})
 ToggleOff.args = {
   ...Basic.args,
   toggle: false,
-}
-
-export const PerformanceTest = () => {
-  const [show, setShow] = useState(0)
-  const handleChange = (e: FormEvent<HTMLInputElement>) => {
-    setShow(e.currentTarget.value.length % 2)
-  }
-
-  const [buttons, setButtons] = useState(true)
-  const handleToggle = (e: FormEvent<HTMLInputElement>) => {
-    setButtons(e.currentTarget.checked)
-  }
-  return (
-    <SpaceVertical p="large" align="start">
-      <FieldToggleSwitch on={buttons} onChange={handleToggle} label="Buttons" />
-      <InputText onChange={handleChange} width={200} />
-      <Space flexWrap="wrap">
-        {iconNameList.map((name: string, index: number) => {
-          if (index % 2 === show) {
-            return buttons ? (
-              <IconButton key={name} icon={name as IconNames} label="Test" />
-            ) : (
-              <Icon name={name as IconNames} />
-            )
-          }
-          return null
-        })}
-      </Space>
-    </SpaceVertical>
-  )
 }

--- a/packages/components/src/Button/IconButton.story.tsx
+++ b/packages/components/src/Button/IconButton.story.tsx
@@ -24,8 +24,12 @@
 
  */
 
-import React from 'react'
+import React, { FormEvent, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
+import { iconNameList, IconNames } from '@looker/icons'
+import { FieldToggleSwitch, InputText } from '../Form'
+import { Icon } from '../Icon'
+import { Space, SpaceVertical } from '../Layout'
 import { IconButton, IconButtonProps } from './IconButton'
 
 export default {
@@ -103,4 +107,34 @@ export const ToggleOff = Template.bind({})
 ToggleOff.args = {
   ...Basic.args,
   toggle: false,
+}
+
+export const PerformanceTest = () => {
+  const [show, setShow] = useState(0)
+  const handleChange = (e: FormEvent<HTMLInputElement>) => {
+    setShow(e.currentTarget.value.length % 2)
+  }
+
+  const [buttons, setButtons] = useState(true)
+  const handleToggle = (e: FormEvent<HTMLInputElement>) => {
+    setButtons(e.currentTarget.checked)
+  }
+  return (
+    <SpaceVertical p="large" align="start">
+      <FieldToggleSwitch on={buttons} onChange={handleToggle} label="Buttons" />
+      <InputText onChange={handleChange} width={200} />
+      <Space flexWrap="wrap">
+        {iconNameList.map((name: string, index: number) => {
+          if (index % 2 === show) {
+            return buttons ? (
+              <IconButton key={name} icon={name as IconNames} label="Test" />
+            ) : (
+              <Icon name={name as IconNames} />
+            )
+          }
+          return null
+        })}
+      </Space>
+    </SpaceVertical>
+  )
 }

--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -448,6 +448,22 @@ export const LongMenus = () => {
         </Menu>
         <Menu>
           <MenuDisclosure>
+            <Button>No windowing (groups)</Button>
+          </MenuDisclosure>
+          <MenuList width={100}>
+            {groups.slice(0, 5).map(({ label, items }, index) => (
+              <MenuGroup key={`${label}-${index}`} label={label}>
+                {items.map((item, index2) => (
+                  <MenuItem key={`${item.label}-${index2}`}>
+                    {item.label}
+                  </MenuItem>
+                ))}
+              </MenuGroup>
+            ))}
+          </MenuList>
+        </Menu>
+        <Menu>
+          <MenuDisclosure>
             <Button>Fixed Windowing (3k)</Button>
           </MenuDisclosure>
           <MenuList width={100} windowing={!value ? 'none' : undefined}>
@@ -472,7 +488,7 @@ export const LongMenus = () => {
           <MenuDisclosure>
             <Button>Variable Windowing (groups)</Button>
           </MenuDisclosure>
-          <MenuList width={300} windowing={!value ? 'none' : undefined}>
+          <MenuList width={300} windowing={!value ? 'none' : 'variable'}>
             {groups.map(({ label, items }, index) => (
               <MenuGroup key={`${label}-${index}`} label={label}>
                 {items.map((item, index2) => (

--- a/packages/components/src/Menu/MenuItemLayout.tsx
+++ b/packages/components/src/Menu/MenuItemLayout.tsx
@@ -85,7 +85,6 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
         space: { xxsmall, xsmall, medium },
       },
     }) => (compact ? `${xxsmall} ${medium}` : `${xsmall} ${medium}`)};
-    position: relative;
     text-align: left;
     text-decoration: none;
     width: 100%;
@@ -93,6 +92,7 @@ export const MenuItemLayout = styled(MenuItemWrapper)`
     &:hover,
     &:focus {
       color: inherit;
+      position: relative;
       text-decoration: none;
     }
   }

--- a/packages/components/src/Menu/MenuList.test.tsx
+++ b/packages/components/src/Menu/MenuList.test.tsx
@@ -95,7 +95,7 @@ describe('MenuList', () => {
     test('variable', () => {
       const arr200 = Array.from(Array(200), (_, i) => i)
       renderWithTheme(
-        <MenuList>
+        <MenuList windowing="variable">
           {arr200.map((num) => (
             <MenuGroup key={num}>
               {Array.from(Array((num + 1) % 15), (_, i) => (

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -62,7 +62,6 @@ import { moveFocus, useForkedRef, useWindow } from '../utils'
 import { usePopover } from '../Popover'
 import { MenuContext, MenuItemContext } from './MenuContext'
 import { MenuGroup } from './MenuGroup'
-import { MenuItem } from './MenuItem'
 
 export interface MenuListProps
   extends CompatibleHTMLProps<HTMLUListElement>,
@@ -109,26 +108,22 @@ export interface MenuListProps
   windowing?: 'fixed' | 'variable' | 'none'
 }
 
-const isMenuGroup = (child: ReactChild) => {
-  return isValidElement(child) && child.type === MenuGroup
-}
-const isMenuItem = (child: ReactChild) => {
-  return isValidElement(child) && child.type === MenuItem
+const getMenuItemHeight = (child: ReactChild, compact?: boolean) => {
+  const baseHeight = compact ? 32 : 40
+  if (isValidElement(child) && child.props.description) {
+    return baseHeight + 12
+  }
+  return baseHeight
 }
 
-const getMenuChildHeight = (child: ReactChild, compact?: boolean) => {
+const getMenuGroupHeight = (child: ReactChild, compact?: boolean) => {
   const baseHeight = compact ? 32 : 40
-  if (isValidElement(child)) {
-    if (child.props.description) {
-      return baseHeight + 12
-    }
-    if (isMenuGroup(child) && child.props.children) {
-      // Get height of group items combined
-      const subListHeight =
-        Children.toArray(child.props.children).length * baseHeight
-      // Add group heading, padding and divider
-      return subListHeight + 24 + 16 + 1
-    }
+  if (isValidElement(child) && child.props.children) {
+    // Get height of group items combined
+    const subListHeight =
+      Children.toArray(child.props.children).length * baseHeight
+    // Add group heading, padding and divider
+    return subListHeight + 24 + 16 + 1
   }
   return baseHeight
 }
@@ -151,11 +146,9 @@ export const MenuListInternal = forwardRef(
     const [renderIconPlaceholder, setRenderIconPlaceholder] = useState(false)
 
     const childArray = useMemo(() => Children.toArray(children), [children])
-    if (childArray.length > 100 && windowing === undefined) {
-      const firstChild = childArray[0]
-      if (isMenuGroup(firstChild as ReactChild)) {
-        windowing = 'variable'
-      } else if (isMenuItem(firstChild as ReactChild)) {
+
+    if (windowing === undefined) {
+      if (childArray.length > 100) {
         windowing = 'fixed'
       } else {
         windowing = 'none'
@@ -182,10 +175,10 @@ export const MenuListInternal = forwardRef(
     const childHeight = useMemo(() => {
       if (windowing === 'fixed') {
         return childArray[0]
-          ? getMenuChildHeight(childArray[0] as ReactChild, compact)
+          ? getMenuItemHeight(childArray[0] as ReactChild, compact)
           : 0
       }
-      return (child: ReactChild) => getMenuChildHeight(child, compact)
+      return (child: ReactChild) => getMenuGroupHeight(child, compact)
     }, [windowing, childArray, compact])
 
     const { content, containerElement, ref } = useWindow({

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -108,8 +108,10 @@ export interface MenuListProps
   windowing?: 'fixed' | 'variable' | 'none'
 }
 
+const getBaseHeight = (compact?: boolean) => (compact ? 32 : 40)
+
 const getMenuItemHeight = (child: ReactChild, compact?: boolean) => {
-  const baseHeight = compact ? 32 : 40
+  const baseHeight = getBaseHeight(compact)
   if (isValidElement(child) && child.props.description) {
     return baseHeight + 12
   }
@@ -117,7 +119,7 @@ const getMenuItemHeight = (child: ReactChild, compact?: boolean) => {
 }
 
 const getMenuGroupHeight = (child: ReactChild, compact?: boolean) => {
-  const baseHeight = compact ? 32 : 40
+  const baseHeight = getBaseHeight(compact)
   if (isValidElement(child) && child.props.children) {
     // Get height of group items combined
     const subListHeight =

--- a/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/MenuGroup.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`MenuGroup - JSX label 1`] = `
   min-height: 40px;
   outline: none;
   padding: 0.5rem 1rem;
-  position: relative;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -89,6 +88,7 @@ exports[`MenuGroup - JSX label 1`] = `
 .c6 button:focus,
 .c6 a:focus {
   color: inherit;
+  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -276,7 +276,6 @@ exports[`MenuGroup - label 1`] = `
   min-height: 40px;
   outline: none;
   padding: 0.5rem 1rem;
-  position: relative;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -288,6 +287,7 @@ exports[`MenuGroup - label 1`] = `
 .c5 button:focus,
 .c5 a:focus {
   color: inherit;
+  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -449,7 +449,6 @@ exports[`MenuGroup 1`] = `
   min-height: 40px;
   outline: none;
   padding: 0.5rem 1rem;
-  position: relative;
   text-align: left;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -461,6 +460,7 @@ exports[`MenuGroup 1`] = `
 .c2 button:focus,
 .c2 a:focus {
   color: inherit;
+  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/www/src/documentation/components/overlays/menu.mdx
+++ b/www/src/documentation/components/overlays/menu.mdx
@@ -139,7 +139,7 @@ positioning for natural scrolling behavior.
 
 The windowing mode defaults to `fixed`, meaning all children are assumed to have a fixed height.
 This is the most efficient mode, but scrolling will be distorted if the list is grouped.
-When a `MenuList` contains over 100 `MenuGroup`, manually setting `windowing` to `variable`
+When a `MenuList` contains over 100 `MenuGroup`s, manually setting `windowing` to `variable`
 will allow the height to be derived for each group and scrolling will be smooth.
 
 ## MenuItem

--- a/www/src/documentation/components/overlays/menu.mdx
+++ b/www/src/documentation/components/overlays/menu.mdx
@@ -135,10 +135,12 @@ A `MenuList` accepts a `compact` prop that will make the spacing between the `Me
 
 If a `MenuList` contains more than 100 children it will use windowing to display
 only the visible items for performance reasons. Windowing uses the item height to calculate
-positioning for natural scrolling behavior. If the first child is a `MenuItem`,
-all items will be assumed to have the same height (`fixed`), for optimal performance.
-If the first child is a `MenuGroup`, the height of each child will be derived based on
-its props and children (`variable`). These defaults can be overriden via the `windowing` prop.
+positioning for natural scrolling behavior.
+
+The windowing mode defaults to `fixed`, meaning all children are assumed to have a fixed height.
+This is the most efficient mode, but scrolling will be distorted if the list is grouped.
+When a `MenuList` contains over 100 `MenuGroup`, manually setting `windowing` to `variable`
+will allow the height to be derived for each group and scrolling will be smooth.
 
 ## MenuItem
 


### PR DESCRIPTION
### :sparkles: Changes

- Fixed: `variable` windowing was being incorrectly applied to any `MenuList` where the first item was not exactly `MenuItem`, even with <100 children. Now `variable` must be explicitly set – the detection logic for `MenuGroup` vs `MenuItem` was faulty – these components are often wrapped, which would fail a check like `child.type === MenuGroup`.
- Fixed: sticky `MenuGroup` label stacking under item labels. A later change for the focus ring style added `position: relative` to the button, which makes it win the stacking order against the `position: sticky` group label. Moving `position: relative` inside `:focus` where it's needed fixes this. (It would still stack on top of the group label if it has focus, but I think that's ok)

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
