### PR TITLE
Revert "Range Slider Touch Support"

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -75,7 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InputSearch` now supports `disabled` and `readOnly`
 - `InputChips` now supports `disabled` and `readOnly`
 - `InputDate` removed stories that did not use `value` prop to avoid daily snapshot discrepancies
-- `RangeSlider` now supports touch events
 
 ### Removed
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.28]
+
+### Removed
+
+- Reverted: `RangeSlider` now supports touch events
+
 ## [0.9.27]
 
 ### Added
@@ -75,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InputSearch` now supports `disabled` and `readOnly`
 - `InputChips` now supports `disabled` and `readOnly`
 - `InputDate` removed stories that did not use `value` prop to avoid daily snapshot discrepancies
+- `RangeSlider` now supports touch events
 
 ### Removed
 

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
@@ -30,7 +30,6 @@ import { renderWithTheme } from '@looker/components-test-utils'
 import { RangeSlider } from './RangeSlider'
 
 const globalConsole = global.console
-const globalRequestAnimationFrame = global.requestAnimationFrame
 /* eslint-disable-next-line @typescript-eslint/unbound-method */
 const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
 
@@ -40,9 +39,6 @@ beforeEach(() => {
     error: jest.fn(),
     warn: jest.fn(),
   }
-  global.requestAnimationFrame = jest
-    .fn()
-    .mockImplementation((cb: Function) => cb())
   /* eslint-disable-next-line @typescript-eslint/unbound-method */
   Element.prototype.getBoundingClientRect = jest.fn(() => {
     return {
@@ -62,7 +58,6 @@ beforeEach(() => {
 afterEach(() => {
   jest.resetAllMocks()
   global.console = globalConsole
-  global.requestAnimationFrame = globalRequestAnimationFrame
   /* eslint-disable-next-line @typescript-eslint/unbound-method */
   Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
 })
@@ -90,7 +85,7 @@ test('warns the developer if value prop falls outside of possible min/max range'
   expect(handleChange).toHaveBeenCalledWith([10, 20])
 })
 
-test('fires onChange callback on mouseMove', () => {
+test('fires onChange callback when on mouseMove', () => {
   const handleChange = jest.fn()
   const { getByTestId } = renderWithTheme(
     <RangeSlider onChange={handleChange} />
@@ -99,20 +94,6 @@ test('fires onChange callback on mouseMove', () => {
   const wrapper = getByTestId('range-slider-wrapper')
   fireEvent.mouseDown(wrapper)
   fireEvent.mouseMove(wrapper, { clientX: 100, clientY: 10 })
-
-  expect(handleChange).toHaveBeenLastCalledWith([3, 10])
-})
-
-test('fires onChange callback on touchMove', () => {
-  const handleChange = jest.fn()
-  const { getByTestId } = renderWithTheme(
-    <RangeSlider onChange={handleChange} />
-  )
-
-  const wrapper = getByTestId('range-slider-wrapper')
-  fireEvent.touchStart(wrapper)
-  fireEvent.touchMove(wrapper, { touches: [{ clientX: 100, clientY: 10 }] })
-
   expect(handleChange).toHaveBeenLastCalledWith([3, 10])
 })
 
@@ -208,22 +189,6 @@ describe('disabled prop', () => {
 
     minThumb.focus()
     fireEvent.keyDown(document.activeElement as Element, { key: 'ArrowUp' })
-    expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
-    expect(handleChange).toHaveBeenCalledTimes(1)
-  })
-
-  test('disabled component does not respond to TOUCH input', () => {
-    const handleChange = jest.fn()
-    const { getByTestId } = renderWithTheme(
-      <RangeSlider onChange={handleChange} disabled />
-    )
-
-    expect(handleChange).toHaveBeenCalledWith([0, 10]) // initial render
-
-    const wrapper = getByTestId('range-slider-wrapper')
-    fireEvent.touchStart(wrapper)
-    fireEvent.touchMove(wrapper, { touches: [{ clientX: 100, clientY: 10 }] })
-
     expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
     expect(handleChange).toHaveBeenCalledTimes(1)
   })

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -47,10 +47,10 @@ import startsWith from 'lodash/startsWith'
 import partial from 'lodash/partial'
 import map from 'lodash/map'
 import isEqual from 'lodash/isEqual'
-
 import {
   useMeasuredElement,
   useMouseDragPosition,
+  usePreviousValue,
   useReadOnlyWarn,
 } from '../../../utils'
 import { ValidationType } from '../../ValidationMessage'
@@ -202,6 +202,7 @@ export const InternalRangeSlider = forwardRef(
     const containerRect = useMeasuredElement(containerRef)
 
     const { mousePos, isMouseDown } = useMouseDragPosition(containerRef)
+    const prevMouseDown = usePreviousValue(isMouseDown)
 
     const minThumbRef = useRef<HTMLDivElement>(null)
     const maxThumbRef = useRef<HTMLDivElement>(null)
@@ -284,7 +285,6 @@ export const InternalRangeSlider = forwardRef(
           newPoint,
           maintainFocus ? focusedThumb : undefined
         )
-
         focusChangedPoint(newValue, newPoint)
         setValue(newValue)
       }
@@ -298,7 +298,7 @@ export const InternalRangeSlider = forwardRef(
      */
     useEffect(
       () => {
-        if (isMouseDown) {
+        if (isMouseDown && prevMouseDown) {
           handleMouseDrag()
         }
       },
@@ -336,8 +336,6 @@ export const InternalRangeSlider = forwardRef(
       <div
         data-testid="range-slider-wrapper"
         onMouseDown={handleMouseDown}
-        onTouchStart={handleMouseDown}
-        onTouchEnd={handleBlur}
         className={className}
         id={id}
         ref={setContainerRef}
@@ -409,8 +407,6 @@ export const RangeSlider = styled(InternalRangeSlider)`
   ${space}
   ${typography}
   padding: 1.5rem 0 0.5rem;
-  touch-action: none;
-  user-select: none;
 `
 
 RangeSlider.defaultProps = { fontSize: 'small', lineHeight: 'xsmall' }

--- a/packages/components/src/utils/useMouseDragPosition.ts
+++ b/packages/components/src/utils/useMouseDragPosition.ts
@@ -26,7 +26,6 @@
 
 import { useState, useEffect } from 'react'
 import throttle from 'lodash/throttle'
-import get from 'lodash/get'
 
 interface MouseState {
   mousePos: { x: number; y: number }
@@ -43,54 +42,43 @@ export function useMouseDragPosition(
   const [isMouseDown, setIsMouseDown] = useState(false)
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
 
-  const updateMousePos = (e: globalThis.TouchEvent | globalThis.MouseEvent) => {
-    // use e.touches[0] for touch events, or simply e for mouse events
-    const event = get(e, 'touches[0]', e)
-    // e.clientX and e.clientY fallbacks are included for testing purposes. jsDOM doesn't support pageX/pageY attributes
-    const { pageX, clientX, pageY, clientY } = event
-    setMousePos({ x: pageX || clientX, y: pageY || clientY })
+  const handleMouseDown = (e: globalThis.MouseEvent) => {
+    setMousePos({ x: e.pageX, y: e.pageY })
+    setIsMouseDown(true)
   }
 
-  const handleStart = (e: globalThis.TouchEvent | globalThis.MouseEvent) => {
-    // update mouse down state AFTER mouse position state is updated
-    requestAnimationFrame(() => {
-      setIsMouseDown(true)
-    })
-    updateMousePos(e)
-  }
-
-  const handleMove = throttle(updateMousePos, 50)
-
-  const handleEnd = () => {
+  const handleMouseUp = () => {
     setIsMouseDown(false)
   }
 
-  useEffect(() => {
-    targetRef && targetRef.addEventListener('mousedown', handleStart)
-    targetRef && targetRef.addEventListener('touchstart', handleStart)
-
+  const handleMouseMove = throttle((e: globalThis.MouseEvent) => {
     if (isMouseDown) {
-      window.addEventListener('touchmove', handleMove)
-      window.addEventListener('touchend', handleEnd)
-      window.addEventListener('mouseup', handleEnd)
-      window.addEventListener('mousemove', handleMove)
-      window.addEventListener('mouseleave', handleEnd)
+      // e.clientX and e.clientY fallbacks are included for testing purposes. jsDOM doesn't support pageX/pageY attributes
+      setMousePos({ x: e.pageX || e.clientX, y: e.pageY || e.clientY })
     }
+  }, 50)
 
-    return () => {
-      targetRef && targetRef.removeEventListener('mousedown', handleStart)
-      targetRef && targetRef.removeEventListener('touchstart', handleStart)
+  const handleMouseLeave = () => {
+    setIsMouseDown(false)
+  }
 
-      if (isMouseDown) {
-        window.removeEventListener('touchmove', handleMove)
-        window.removeEventListener('touchend', handleEnd)
-        window.removeEventListener('mouseup', handleEnd)
-        window.removeEventListener('mousemove', handleMove)
-        window.removeEventListener('mouseleave', handleEnd)
+  useEffect(
+    () => {
+      targetRef && targetRef.addEventListener('mousedown', handleMouseDown)
+      window.addEventListener('mouseup', handleMouseUp)
+      window.addEventListener('mousemove', handleMouseMove)
+      window.addEventListener('handleMouseLeave', handleMouseLeave)
+
+      return () => {
+        targetRef && targetRef.removeEventListener('mousedown', handleMouseDown)
+        window.removeEventListener('mouseup', handleMouseUp)
+        window.removeEventListener('mousemove', handleMouseMove)
+        window.removeEventListener('handleMouseLeave', handleMouseLeave)
       }
-    }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMouseDown, targetRef])
+    [isMouseDown, targetRef]
+  )
 
   return { isMouseDown, mousePos: mousePos }
 }


### PR DESCRIPTION
This reverts commit 1a1c89f7e6c2b698bd91d772e5e60c8f43ef4897.

### :sparkles: Changes

Revert "Range Slider Touch Support"

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
