### PR TITLE
Deactivate focus trap on click outside

### DIFF
--- a/packages/components-providers/src/FocusTrap/utils.ts
+++ b/packages/components-providers/src/FocusTrap/utils.ts
@@ -105,6 +105,16 @@ export const activateFocusTrap = (container: HTMLElement) => {
       node.select()
     }
   }
+
+  // This needs to be done on mousedown and touchstart instead of click
+  // so that it precedes the focus event.
+  const checkPointerDown = function (e: MouseEvent | TouchEvent) {
+    if (!container.contains(e.target as Node)) {
+      // immediately deactivate the trap
+      deactivate()
+    }
+  }
+
   // In case focus escapes the trap for some strange reason, pull it back in.
   const checkFocusIn = (e: FocusEvent) => {
     // In Firefox when you Tab out of an iframe the Document is briefly focused.
@@ -135,6 +145,14 @@ export const activateFocusTrap = (container: HTMLElement) => {
   }
 
   document.addEventListener('focusin', checkFocusIn, true)
+  document.addEventListener('mousedown', checkPointerDown, {
+    capture: true,
+    passive: false,
+  })
+  document.addEventListener('touchstart', checkPointerDown, {
+    capture: true,
+    passive: false,
+  })
   document.addEventListener('keydown', checkKey, {
     capture: true,
     passive: false,
@@ -145,9 +163,11 @@ export const activateFocusTrap = (container: HTMLElement) => {
   }, 0)
 
   // Deactivate function
-  return () => {
+  const deactivate = () => {
     clearTimeout(t)
     document.removeEventListener('focusin', checkFocusIn, true)
+    document.removeEventListener('mousedown', checkPointerDown, true)
+    document.removeEventListener('touchstart', checkPointerDown, true)
     document.removeEventListener('keydown', checkKey, true)
 
     // If focus lands on the body, move it back to where it was before the trap
@@ -161,4 +181,5 @@ export const activateFocusTrap = (container: HTMLElement) => {
       elementToFocus.removeAttribute('data-notooltip')
     }
   }
+  return deactivate
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.29]
+
+### Fixed
+
+- Clicking outside a focus trap deactivates it
+
 ## [0.9.28]
 
 ### Removed

--- a/packages/components/src/Dialog/stories/Dialog.story.tsx
+++ b/packages/components/src/Dialog/stories/Dialog.story.tsx
@@ -108,6 +108,32 @@ withCheckbox.parameters = {
   storyshots: { disable: true },
 }
 
+export const ClickOutside = () => {
+  return (
+    <>
+      <input
+        type="text"
+        style={{
+          position: 'absolute',
+          right: '0',
+          top: '0',
+          zIndex: 100,
+        }}
+      />
+      <Dialog
+        content={
+          <>
+            <button>button 1</button>
+            <button>button 2</button>
+          </>
+        }
+      >
+        <button>Open Dialog</button>
+      </Dialog>
+    </>
+  )
+}
+
 export default {
   argTypes: {
     placement: {

--- a/packages/components/src/Dialog/stories/Dialog.story.tsx
+++ b/packages/components/src/Dialog/stories/Dialog.story.tsx
@@ -134,6 +134,10 @@ export const ClickOutside = () => {
   )
 }
 
+ClickOutside.arguments = {
+  storyshots: { disable: true },
+}
+
 export default {
   argTypes: {
     placement: {


### PR DESCRIPTION
### :sparkles: Changes

- Pre 0.9.26, a click outside a focus trap deactivated it, but that behavior was lost in the refactor
- This PR re-adds click outside to deactivate to focus trap

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
