### PR TITLE
Fix Combobox jumpy scrolling

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Tree / TreeItem` disabled and selected states
 
+### Fixed
+
+- Erratic scrolling after dynamic list resize in all `Combobox`-based components
+
 ## [0.9.29]
 
 ### Fixed

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -41,6 +41,7 @@ import {
 import React, {
   forwardRef,
   Ref,
+  useCallback,
   useContext,
   useLayoutEffect,
   useEffect,
@@ -49,6 +50,7 @@ import styled, { css } from 'styled-components'
 import once from 'lodash/once'
 import throttle from 'lodash/throttle'
 import { usePopover } from '../../../Popover'
+import { useResize } from '../../../utils'
 import { ComboboxOptionIndicatorProps } from './ComboboxOptionIndicator'
 import { ComboboxContext, ComboboxMultiContext } from './ComboboxContext'
 import { useBlur } from './utils/useBlur'
@@ -212,6 +214,12 @@ const ComboboxListInternal = forwardRef(
       popperInstanceRef.current && popperInstanceRef.current.update()
     }, [popperInstanceRef, valueLength])
 
+    const resizeListener = useCallback(() => {
+      setListClientRect?.(contentContainer?.getBoundingClientRect())
+    }, [setListClientRect, contentContainer])
+
+    useResize(contentContainer, resizeListener)
+
     useEffect(() => {
       // track scroll position and menu dom rectangle, and bubble up to context.
       // used in InputTimeSelect for managing very long lists
@@ -229,22 +237,14 @@ const ComboboxListInternal = forwardRef(
         }
       }, 50)
 
-      const resizeListener = throttle(() => {
-        if (contentContainer && setListClientRect) {
-          setListClientRect(contentContainer.getBoundingClientRect())
-        }
-      }, 50)
-
       if (contentContainer) {
         contentContainer.addEventListener('scroll', scrollListener)
         scrollListener()
-        window.addEventListener('resize', resizeListener)
       }
 
       return () => {
         contentContainer &&
           contentContainer.removeEventListener('scroll', scrollListener)
-        window.removeEventListener('resize', resizeListener)
 
         setListScrollPosition && setListScrollPosition(0)
         setListClientRect && setListClientRect(undefined)
@@ -268,6 +268,7 @@ const ComboboxUl = styled.ul.withConfig({
   margin: 0;
   max-height: 30rem;
   outline: none;
+  position: relative;
   ${layout}
 `
 

--- a/packages/components/src/Form/Inputs/Combobox/stories/Combobox.story.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/stories/Combobox.story.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import {
   Combobox,
   ComboboxMulti,
@@ -47,6 +47,16 @@ const CustomIndicator: FC<OptionIndicatorProps> = ({
 }
 
 export const ComboboxDemo = () => {
+  const [loading, setLoading] = useState(true)
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      setLoading(false)
+    }, 4000)
+    return () => {
+      window.clearTimeout(t)
+    }
+  }, [])
+
   const [option, setOption] = useState({ value: 'Bananas' })
   const handleChange = (newOption: any) => {
     setOption(newOption)
@@ -63,11 +73,32 @@ export const ComboboxDemo = () => {
         <Combobox width={300} value={option} onChange={handleChange}>
           <ComboboxInput />
           <ComboboxList>
-            <ComboboxOption value="Apples" />
-            <ComboboxOption value="Oranges" />
-            <ComboboxOption value="Grapes" />
-            <ComboboxOption value="Bananas" />
-            <ComboboxOption value="Pineapples" />
+            {loading ? (
+              <ComboboxOption value="Loading..." />
+            ) : (
+              <>
+                <ComboboxOption value="Apples" />
+                <ComboboxOption value="Oranges" />
+                <ComboboxOption value="Grapes" />
+                <ComboboxOption value="Bananas" />
+                <ComboboxOption value="Pineapples" />
+                <ComboboxOption value="Apples2" />
+                <ComboboxOption value="Oranges2" />
+                <ComboboxOption value="Grapes2" />
+                <ComboboxOption value="Bananas2" />
+                <ComboboxOption value="Pineapples2" />
+                <ComboboxOption value="Apples3" />
+                <ComboboxOption value="Oranges3" />
+                <ComboboxOption value="Grapes3" />
+                <ComboboxOption value="Bananas3" />
+                <ComboboxOption value="Pineapples3" />
+                <ComboboxOption value="Apples4" />
+                <ComboboxOption value="Oranges4" />
+                <ComboboxOption value="Grapes4" />
+                <ComboboxOption value="Bananas4" />
+                <ComboboxOption value="Pineapples4" />
+              </>
+            )}
           </ComboboxList>
         </Combobox>
         <ComboboxMulti


### PR DESCRIPTION
### :sparkles: Changes

- When the user hovers over or keyboard navigates to an option, it becomes the "navigated-to" option in Combobox state.
- If the navigated-to option is outside of the scroll window, it is auto-scrolled into view at either the top or bottom of the list, as appropriate.
- This logic is meant for keyboard nav, but targets the navigated-to state, and thus is run for hovering as well.
- If the list is smaller when it first opens and grows as options are added, the height is not getting appropriately updated, so the check for being outside of the scroll window can be incorrectly true.
- As the user scrolls, and the mouseenter event fires when scrolling pauses, the hovered option is unnecessarily auto-scrolled to the top or bottom of the list.
- Fixing the logic that keeps track of the list's height fixes the issue.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
Updated Combobox story shows the issue, pre-fix:
![9f75b794-b4a7-41ed-9542-5d3ce9812840](https://user-images.githubusercontent.com/53451193/102857365-1ee3a180-43dd-11eb-869a-b6c60e4bf65a.gif)
