### PR TITLE
TooltipContent width fix

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `TooltipContent` default width is back to `'auto'`
 - Erratic scrolling after dynamic list resize in all `Combobox`-based components
 
 ## [0.9.29]

--- a/packages/components/src/Tooltip/TooltipContent.tsx
+++ b/packages/components/src/Tooltip/TooltipContent.tsx
@@ -33,10 +33,10 @@ export const TooltipContent = styled(Paragraph).attrs<TooltipProps>(
     fontSize: 'xsmall',
     lineHeight: 'xsmall',
     m: 'none',
-    maxWidth: width,
+    maxWidth: width || '16rem',
     p: 'xsmall',
     textAlign,
-    width: width || '16rem',
+    width: 'auto',
   })
 )<ParagraphProps>`
   hyphens: auto;


### PR DESCRIPTION
### :sparkles: Changes

- Reverts a change from the deprecate defaultProps PR, see comment here: https://github.com/looker-open-source/components/pull/1716/files#r549421281

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Broken:
![image](https://user-images.githubusercontent.com/53451193/103231547-e5cf9380-48ec-11eb-9d20-e95adfccc980.png)
#### Fixed:
![image](https://user-images.githubusercontent.com/53451193/103232769-2da3ea00-48f0-11eb-9d5a-2d70cbae7f77.png)
