### PR TITLE
Fix InputText mousedown issue

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InputText` issue moving cursor and selecting text when input is already focused
 - `TooltipContent` default width is back to `'auto'`
 - Erratic scrolling after dynamic list resize in all `Combobox`-based components
 

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -126,7 +126,8 @@ const InputTextLayout = forwardRef(
       // Avoid moving focus if the mousedown was inside a button
       // because it will interrupt any onclick behavior
       // (the button click handler should be responsible for moving focus)
-      if (!targetIsButton(e)) {
+      // Also no need to do anything if mousedown was on the input itself
+      if (!targetIsButton(e) && e.target !== internalRef.current) {
         // set focus to input on mousedown of container to mimic natural input behavior
         // need requestAnimationFrame here due to browser updating focus _after_ mousedown is called
         if (document.activeElement === internalRef.current) {


### PR DESCRIPTION
### :sparkles: Changes

- A recent change in https://github.com/looker-open-source/components/pull/1692 added a `preventDefault()` on `InputText`'s wrapper `<div>` mousedown event if the internal input was already focused. That change fixed a bug in `Select`, where `InputText` is an underlying component.
- The aim was to avoid triggering a blur and having to re-focus the input when the caret icon (or summary text, etc) is clicked.
- The unintended side effect was that it broke moving the cursor the input and selecting text with the mouse.
- This PR checks if the mousedown originated in the input and doesn't do anything if so.
- I tried to add a test to guard against this issue but apparently jsdom doesn't simulate moving the cursor around or selecting text on mousedown.

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
#### Issue:
![391519f0-44fe-41b1-87bd-4688bd8a3da4](https://user-images.githubusercontent.com/53451193/103384910-08100f80-4aad-11eb-8604-0c8260a1b932.gif)

#### Fixed:
![fd05e100-0236-4690-910b-364c498ad1e4](https://user-images.githubusercontent.com/53451193/103384915-0c3c2d00-4aad-11eb-9a12-e15e481c8966.gif)
