### PR TITLE
Remove default exports

### DIFF
--- a/www/src/Layout/Layout.tsx
+++ b/www/src/Layout/Layout.tsx
@@ -35,7 +35,7 @@ import {
 import { ThemeCustomizations } from '@looker/design-tokens'
 import { createGlobalStyle } from 'styled-components'
 import { MDXProvider } from '@mdx-js/react'
-import MDXComponents from '../MDX'
+import { MDXComponents } from '../MDX'
 import { HeaderContent } from '../components/HeaderContent'
 import { Navigation } from '../components/Navigation'
 

--- a/www/src/MDX/Blockquote.tsx
+++ b/www/src/MDX/Blockquote.tsx
@@ -27,7 +27,7 @@
 import styled from 'styled-components'
 import { maxTextWidth } from './styles'
 
-const Blockquote = styled.blockquote`
+export const Blockquote = styled.blockquote`
   font-weight: 300;
   max-width: ${maxTextWidth};
   ${({ theme: { fontSizes, lineHeights, space, colors, radii } }) => `
@@ -43,5 +43,3 @@ const Blockquote = styled.blockquote`
     font-weight: 600;
   }
 `
-
-export default Blockquote

--- a/www/src/MDX/Code.tsx
+++ b/www/src/MDX/Code.tsx
@@ -27,7 +27,7 @@
 import { Box } from '@looker/components'
 import styled from 'styled-components'
 
-export default styled(Box).attrs(() => ({
+export const Code = styled(Box).attrs(() => ({
   as: 'code',
   bg: 'ui1',
   borderRadius: 'small',

--- a/www/src/MDX/Hr.tsx
+++ b/www/src/MDX/Hr.tsx
@@ -27,10 +27,8 @@
 import { Divider } from '@looker/components'
 import styled from 'styled-components'
 
-const Hr = styled(Divider).attrs(() => ({
+export const Hr = styled(Divider).attrs(() => ({
   mx: 'auto',
   my: 'xxlarge',
   width: '50%',
 }))``
-
-export default Hr

--- a/www/src/MDX/Li.tsx
+++ b/www/src/MDX/Li.tsx
@@ -27,8 +27,6 @@
 import React, { FC } from 'react'
 import { ListItem } from '@looker/components'
 
-const Li: FC<{}> = (props) => (
+export const Li: FC<{}> = (props) => (
   <ListItem lineHeight="medium" p="none" pl="xxsmall" {...props} />
 )
-
-export default Li

--- a/www/src/MDX/Link.tsx
+++ b/www/src/MDX/Link.tsx
@@ -27,10 +27,8 @@
 import { Link as LookerLink } from '@looker/components'
 import styled from 'styled-components'
 
-const Link = styled(LookerLink)`
+export const Link = styled(LookerLink)`
   &:visited {
     color: ${(props) => props.theme.colors.keyInteractive};
   }
 `
-
-export default Link

--- a/www/src/MDX/Ol.tsx
+++ b/www/src/MDX/Ol.tsx
@@ -28,7 +28,7 @@ import React, { FC } from 'react'
 import { List } from '@looker/components'
 import { maxTextWidth } from './styles'
 
-const Ol: FC<{}> = (props) => (
+export const Ol: FC<{}> = (props) => (
   <List
     lineHeight="medium"
     mb="medium"
@@ -38,5 +38,3 @@ const Ol: FC<{}> = (props) => (
     {...props}
   />
 )
-
-export default Ol

--- a/www/src/MDX/Paragraph.tsx
+++ b/www/src/MDX/Paragraph.tsx
@@ -28,7 +28,7 @@ import { Paragraph as LookerParagraph } from '@looker/components'
 import React, { FC } from 'react'
 import { maxTextWidth } from './styles'
 
-const Paragraph: FC<{}> = (props) => (
+export const Paragraph: FC<{}> = (props) => (
   <LookerParagraph
     lineHeight="medium"
     mb="medium"
@@ -36,5 +36,3 @@ const Paragraph: FC<{}> = (props) => (
     {...props}
   />
 )
-
-export default Paragraph

--- a/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/www/src/MDX/Pre/CodeSandbox.tsx
@@ -56,7 +56,7 @@ const transformCode = (code: string) => {
   }
 }
 
-const CodeSandbox = ({
+export const CodeSandbox = ({
   code,
   language,
   editorVisible = true,
@@ -126,8 +126,6 @@ const CodeSandbox = ({
     </SandboxWrapper>
   )
 }
-
-export default CodeSandbox
 
 interface LiveProps {
   code: string

--- a/www/src/MDX/Pre/CodeStatic.tsx
+++ b/www/src/MDX/Pre/CodeStatic.tsx
@@ -35,7 +35,11 @@ interface CodeStaticProps {
   className?: string
 }
 
-const CodeStatic: FC<CodeStaticProps> = ({ code, language, ...props }) => {
+export const CodeStatic: FC<CodeStaticProps> = ({
+  code,
+  language,
+  ...props
+}) => {
   const outerClassName = props.className
 
   return (
@@ -59,8 +63,6 @@ const CodeStatic: FC<CodeStaticProps> = ({ code, language, ...props }) => {
     </Highlight>
   )
 }
-
-export default CodeStatic
 
 const PreWrapper = styled.pre`
   border-radius: ${({ theme }) => theme.radii.medium};

--- a/www/src/MDX/Pre/Pre.tsx
+++ b/www/src/MDX/Pre/Pre.tsx
@@ -27,8 +27,8 @@
 import { Language } from 'prism-react-renderer'
 import React from 'react'
 
-import CodeSandbox from './CodeSandbox'
-import CodeStatic from './CodeStatic'
+import { CodeSandbox } from './CodeSandbox'
+import { CodeStatic } from './CodeStatic'
 
 interface PreProps {
   children: {
@@ -43,7 +43,7 @@ interface PreProps {
   }
 }
 
-const Pre = ({ children }: PreProps) => {
+export const Pre = ({ children }: PreProps) => {
   const { className } = children.props
   const trimmedClassName = className
     ? className.replace(/language-/, '')
@@ -58,5 +58,3 @@ const Pre = ({ children }: PreProps) => {
     return <CodeSandbox code={code} language={language} />
   }
 }
-
-export default Pre

--- a/www/src/MDX/Pre/index.ts
+++ b/www/src/MDX/Pre/index.ts
@@ -24,5 +24,4 @@
 
  */
 
-import Pre from './Pre'
-export default Pre
+export { Pre } from './Pre'

--- a/www/src/MDX/Ul.tsx
+++ b/www/src/MDX/Ul.tsx
@@ -28,7 +28,7 @@ import React, { FC } from 'react'
 import { List } from '@looker/components'
 import { maxTextWidth } from './styles'
 
-const Ul: FC<{}> = (props) => (
+export const Ul: FC<{}> = (props) => (
   <List
     lineHeight="medium"
     mb="medium"
@@ -38,5 +38,3 @@ const Ul: FC<{}> = (props) => (
     {...props}
   />
 )
-
-export default Ul

--- a/www/src/MDX/index.ts
+++ b/www/src/MDX/index.ts
@@ -26,17 +26,17 @@
 
 import { MessageBar } from '@looker/components'
 import * as headings from './Headings'
-import Blockquote from './Blockquote'
-import Code from './Code'
-import Hr from './Hr'
-import Li from './Li'
-import Link from './Link'
-import Ol from './Ol'
-import Paragraph from './Paragraph'
-import Pre from './Pre'
-import Ul from './Ul'
+import { Blockquote } from './Blockquote'
+import { Code } from './Code'
+import { Hr } from './Hr'
+import { Li } from './Li'
+import { Link } from './Link'
+import { Ol } from './Ol'
+import { Paragraph } from './Paragraph'
+import { Pre } from './Pre'
+import { Ul } from './Ul'
 
-const MDXComponents = {
+export const MDXComponents = {
   ...headings,
   Code,
   MessageBar,
@@ -50,5 +50,3 @@ const MDXComponents = {
   pre: Pre,
   ul: Ul,
 }
-
-export default MDXComponents


### PR DESCRIPTION
Remove usage of default exports wherever possible. 

Admittedly, none of these use cases affect tree-shaking as they're outside of the library build src but figured I'd remove the pattern as much as possible.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
