### PR TITLE
Fixes Safari bug box-shadow applied to DataTable ::after element

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ProgressCircular` component
 - `UnorderedList`, `OrderedList`
 
-
 ### Changed
 
 - `Tree` now uses the same `selected` color as `TreeItem`
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DataTable` overflow shadow now works properly in Safari
 - `TooltipContent` default width is back to `'auto'`
 - Erratic scrolling after dynamic list resize in all `Combobox`-based components
 

--- a/packages/components/src/DataTable/utils/edgeShadow.ts
+++ b/packages/components/src/DataTable/utils/edgeShadow.ts
@@ -43,15 +43,22 @@ export const edgeShadow = (placement: 'left' | 'right' = 'left', depth = 4) => {
   }
 
   const shadow = `${`${shadowReverse}${depth}px`} 0 ${depth}px -${depth}px rgba( 0, 0, 0, 0.25) inset`
+
+  /**
+   * NOTE: In Safari for reasons we can't entirely explain the `::after`` pseudo element
+   * is obscured by a black area unless it's moved at least 11px
+   **/
+  const position = depth + 7
+
   return css`
     &${pseudo} {
       box-shadow: ${shadow};
       content: ' ';
       height: 100%;
       position: absolute;
-      ${`${relativeTo}: -${depth}px;`}
+      ${`${relativeTo}: -${position}px;`}
       top: 0;
-      width: ${depth}px;
+      width: ${position}px;
     }
   `
 }


### PR DESCRIPTION


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
