### PR TITLE
Update Accordion space props

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Accordion` no longer accepts `SimpleLayoutProps`
+- `AccordionContent` accepts `SimpleLayoutProps`
 - `IconPlaceholder` moved to `Icon`
 - `Menu` structure now follows `Popover` structure: `content` prop accepts the items and `children` is the trigger element
 - `Tree` now uses the same `selected` color as `TreeItem`
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `TreeStyle` bug where `TreeGroup` would increase / decrease indent based on currently hovered parent `Tree`
 - `DataTable` overflow shadow now works properly in Safari
 - `TooltipContent` default width is back to `'auto'`
 - Erratic scrolling after dynamic list resize in all `Combobox`-based components

--- a/packages/components/src/Accordion/Accordion.story.tsx
+++ b/packages/components/src/Accordion/Accordion.story.tsx
@@ -44,9 +44,9 @@ export default {
 const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
 
 export const Basic = () => (
-  <Accordion id="basic-accordion" px="large">
-    <AccordionDisclosure> See more...</AccordionDisclosure>
-    <AccordionContent>{lorem}</AccordionContent>
+  <Accordion id="basic-accordion">
+    <AccordionDisclosure px="large">See more...</AccordionDisclosure>
+    <AccordionContent px="large">{lorem}</AccordionContent>
   </Accordion>
 )
 
@@ -112,9 +112,11 @@ Controlled.parameters = {
 }
 
 export const Nested = () => (
-  <Accordion m="xlarge" pl="xlarge" indicatorPosition="left" defaultOpen>
-    <AccordionDisclosure>Hello World</AccordionDisclosure>
-    <AccordionContent>
+  <Accordion indicatorPosition="left" defaultOpen>
+    <AccordionDisclosure m="xlarge" pl="xlarge">
+      Hello World
+    </AccordionDisclosure>
+    <AccordionContent m="xlarge" pl="xlarge">
       <UnorderedList>
         <li>Cheddar</li>
         <li>Cheddar</li>

--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -28,11 +28,8 @@ import React, { FC, useState, ReactNode } from 'react'
 import styled from 'styled-components'
 import { SpacingSizes } from '@looker/design-tokens'
 import { IconNames, IconSize } from '../Icon'
-import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
 import { useID } from '../utils'
 import { AccordionContext, accordionContextDefaults } from './AccordionContext'
-import { AccordionContent } from './AccordionContent'
-import { AccordionDisclosure } from './AccordionDisclosure'
 
 export type IndicatorIcons = {
   close: IconNames
@@ -112,8 +109,7 @@ export const AccordionControlPropKeys = [
 
 export interface AccordionProps
   extends AccordionControlProps,
-    AccordionIndicatorProps,
-    SimpleLayoutProps {
+    AccordionIndicatorProps {
   children: ReactNode
   className?: string
   /**
@@ -175,15 +171,9 @@ export const Accordion = styled(AccordionLayout).attrs<AccordionProps>(
     indicatorGap = accordionContextDefaults.indicatorGap,
     indicatorPosition = accordionContextDefaults.indicatorPosition,
     indicatorSize = accordionContextDefaults.indicatorSize,
-    width = '100%',
   }) => ({
     indicatorGap,
     indicatorPosition,
     indicatorSize,
-    width,
   })
-)<AccordionProps>`
-  ${AccordionDisclosure}, ${AccordionContent} {
-    ${simpleLayoutCSS}
-  }
-`
+)<AccordionProps>``

--- a/packages/components/src/Accordion/AccordionContent.tsx
+++ b/packages/components/src/Accordion/AccordionContent.tsx
@@ -26,10 +26,10 @@
 
 import React, { useContext, FC } from 'react'
 import styled from 'styled-components'
-
+import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
 import { AccordionContext } from './AccordionContext'
 
-export interface AccordionContentProps {
+export interface AccordionContentProps extends SimpleLayoutProps {
   className?: string
 }
 
@@ -53,4 +53,6 @@ const AccordionContentLayout: FC<AccordionContentProps> = ({
   ) : null
 }
 
-export const AccordionContent = styled(AccordionContentLayout)``
+export const AccordionContent = styled(AccordionContentLayout)`
+  ${simpleLayoutCSS}
+`

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -37,8 +37,6 @@ import {
   TypographyProps,
   typography,
   CompatibleHTMLProps,
-  padding,
-  PaddingProps,
   pickStyledProps,
   shouldForwardProp,
   TextColorProps,
@@ -124,16 +122,13 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
 
 AccordionDisclosureInternal.displayName = 'AccordionDisclosureInternal'
 
-interface AccordionDisclosureStyleProps extends TextColorProps, PaddingProps {
+interface AccordionDisclosureStyleProps extends TextColorProps {
   focusVisible: boolean
 }
 
-export const AccordionDisclosureStyle = styled.div
-  .withConfig({ shouldForwardProp })
-  .attrs<AccordionDisclosureProps>(({ px = 'none', py = 'xsmall' }) => ({
-    px,
-    py,
-  }))<AccordionDisclosureStyleProps>`
+export const AccordionDisclosureStyle = styled.div.withConfig({
+  shouldForwardProp,
+})<AccordionDisclosureStyleProps>`
   align-items: center;
   background-color: transparent;
   ${({ color }) => (color ? colorStyleFn : 'color: currentColor;')}
@@ -142,15 +137,16 @@ export const AccordionDisclosureStyle = styled.div
   outline: 1px solid transparent;
   outline-color: ${({ focusVisible, theme }) =>
     focusVisible && theme.colors.keyFocus};
-  ${padding}
   text-align: left;
   width: 100%;
 `
 
 export const AccordionDisclosure = styled(AccordionDisclosureInternal).attrs(
-  (props) => ({
+  ({ px = 'none', py = 'xsmall', ...props }) => ({
     fontSize: 'small',
     fontWeight: 'semiBold',
+    px,
+    py,
     ...props,
   })
 )`

--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -32,7 +32,7 @@ import {
 } from '../Accordion'
 import { TreeBackgroundStyleProps } from './Tree'
 import { TreeItem, TreeItemLabel } from './TreeItem'
-import { TreeGroupLabel } from './TreeGroup'
+import { TreeGroup, TreeGroupLabel } from './TreeGroup'
 import {
   generateIndent,
   generateTreeBorder,
@@ -89,9 +89,17 @@ export const TreeStyle = styled.div<TreeStyleProps>`
     }
   }
 
-  ${TreeGroupLabel},
-  ${TreeItemLabel},
-  & > ${Accordion} > ${AccordionContent} > ${TreeItem} > ${TreeItemLabel} {
+  &
+    > ${Accordion}
+    > ${AccordionContent}
+    > ${TreeGroup}
+    > ${TreeGroupLabel},
+    ${TreeItemLabel},
+    &
+    > ${Accordion}
+    > ${AccordionContent}
+    > ${TreeItem}
+    > ${TreeItemLabel} {
     ${({ depth, theme }) => generateIndent(depth + 2, theme)}
   }
 `


### PR DESCRIPTION
### :sparkles: Changes

- `Accordion` no longer accepts `SimpleLayoutProps`
- `AccordionContent` accepts `SimpleLayoutProps` 
  - Note:`AccordionDisclosure` already accepted `SimpleLayoutPropts` 

These changes are primarily being made to fix a CSS reset-related problem we're hitting in HT with `FieldTree`:
```
      {/**
       * @COMPONENTS-TODO Remove ` pl="xxsmall"` when Accordion reset fixed
       **/}
      {tree.map((view: ExploreView, index: number) => {
        const fieldCount = activeFieldsByView[view.name] || 0
        const viewLabel = (
          <Space between pl="xxsmall">
            <Truncate>
              <strong>{view.name}</strong>
            </Truncate>
            {fieldCount > 0 && (
              <Badge size="small" intent="key">
                {fieldCount}
              </Badge>
            )}
          </Space>
        )
```

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC
