### PR TITLE
add outline warning icon

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Aded
+- `WarningOutline`
+
 ## [0.9.26]
 
 ## Added

--- a/packages/icons/src/svg/WarningOutline.svg
+++ b/packages/icons/src/svg/WarningOutline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 5.99L19.53 19H4.47L12 5.99ZM12 2L1 21H23L12 2ZM13 16H11V18H13V16ZM13 10H11V14H13V10Z" fill="#1C2125"/>
+</svg>


### PR DESCRIPTION
### :sparkles: Changes

Add `WarningOutline` icon 

![image](https://user-images.githubusercontent.com/170681/104068370-a2f99f80-51b9-11eb-8f2c-1ec040b6731a.png)


### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
