### PR TITLE
Fix link on home page

### DIFF
--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -98,7 +98,7 @@ const Intro = () => {
                 Install
               </Heading>
               <Paragraph fontSize="small">
-                Visit <Link href="/getting-started/">Getting Started</Link> for
+                Visit <Link href="/develop/">Getting Started</Link> for
                 instructions on installing{' '}
                 <Code fontSize="small">@looker/components</Code>
               </Paragraph>


### PR DESCRIPTION
### :sparkles: Changes

Fix link to "Get Started" on home page to point at /develop

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [ ] Build and tests are passing
- [ ] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [ ] PR is ideally < ~400LOC

### :camera: Screenshots
