### PR TITLE
fix: MenuList windowing initial render performance

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `MenuList` windowing initial render performance
 - `DataTable` overflow shadow now works properly in Safari
 - `TooltipContent` default width is back to `'auto'`
 - Erratic scrolling after dynamic list resize in all `Combobox`-based components

--- a/packages/components/src/utils/useWindow.test.tsx
+++ b/packages/components/src/utils/useWindow.test.tsx
@@ -188,10 +188,13 @@ describe('useWindow', () => {
 
   describe('variable', () => {
     test('returns placeholders and children in "window"', () => {
+      const mockRef = jest.fn()
       render(
         <WindowedComponent variable>
           {arr3000.map((num) => (
-            <li key={num}>{num}</li>
+            <li key={num} ref={mockRef}>
+              {num}
+            </li>
           ))}
         </WindowedComponent>
       )
@@ -201,6 +204,10 @@ describe('useWindow', () => {
 
       expect(screen.queryByTestId('before')).not.toBeInTheDocument()
       expect(screen.getByTestId('after')).toHaveStyle('height: 357150px;')
+
+      // Tests for a bug where all list items are initially rendered
+      // before the container is measured and then only the necessary items are rendered
+      expect(mockRef).toHaveBeenCalledTimes(36)
     })
 
     test('updates window on scroll', () => {

--- a/packages/components/src/utils/useWindow.tsx
+++ b/packages/components/src/utils/useWindow.tsx
@@ -55,18 +55,18 @@ interface WindowHeightPayloadObject {
 }
 
 interface WindowHeightAction {
-  type: 'CHANGE' | 'RESET'
-  payload: number | WindowHeightPayloadObject
+  type: 'CHANGE'
+  payload: WindowHeightPayloadObject
 }
 
-const initialState = (length: number) => ({
+const initialState = {
   afterHeight: 0,
   beforeHeight: 0,
-  end: length - 1,
+  end: 0,
   scrollBottom: 0,
   scrollTop: 0,
   start: 0,
-})
+}
 const bufferHeight = 1000
 
 // For windowing lists with variable item height, a reducer that derives
@@ -81,11 +81,6 @@ const reducer: Reducer<WindowHeightState, WindowHeightAction> = (
   state,
   action
 ) => {
-  // RESET (if disabled after being enabled)
-  if (typeof action.payload === 'number') {
-    return initialState(action.payload)
-  }
-
   let { beforeHeight, afterHeight, start, end } = state
   const {
     scrollPosition,
@@ -183,10 +178,7 @@ export const useWindow = <E extends HTMLElement = HTMLElement>({
   const scrollPosition = useScrollPosition(containerElement)
 
   // For variable childHeight
-  const [variable, dispatch] = useReducer(
-    reducer,
-    initialState(childArray.length)
-  )
+  const [variable, dispatch] = useReducer(reducer, initialState)
   useEffect(() => {
     // If using fixed childHeight, totalHeight will be 0
     if (totalHeight > 0) {
@@ -200,8 +192,6 @@ export const useWindow = <E extends HTMLElement = HTMLElement>({
           },
           type: 'CHANGE',
         })
-      } else {
-        dispatch({ payload: childHeightLadder.length, type: 'RESET' })
       }
     }
   }, [enabled, childHeightLadder, height, scrollPosition, totalHeight])
@@ -236,12 +226,14 @@ export const useWindow = <E extends HTMLElement = HTMLElement>({
 
   return {
     containerElement,
-    content: (
+    content: enabled ? (
       <>
         {before}
         {childArray.slice(start, end + 1)}
         {after}
       </>
+    ) : (
+      childArray
     ),
     ref: callbackRef,
   }


### PR DESCRIPTION
### :sparkles: Changes

- Previously the initial state for `useWindow` was to render all items in the list, then the height of the list container element is measured, and the state updates to only render the necessary items.
- This basically defeated the purpose of windowing, making the initial render just as slow as it would have been without `useWindow`.
- This PR updates the initial state to only render the first list item until the correct window size is calculated immediately after.

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [ ] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
