### PR TITLE
fix: Pagination component now enables first and last page of results at same thresholds for previous and next

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DialogHeader` uses responsive padding values
 - `CardMedia` supports background color props
 - `InputDate` & `InputDateRange` vertial margin removed to be consistent with other inputs
+- `Pagination` component now enables first and last page of results at same thresholds for previous and next
 
 ### Fixed
 

--- a/packages/components/src/Pagination/Pagination.test.tsx
+++ b/packages/components/src/Pagination/Pagination.test.tsx
@@ -69,24 +69,24 @@ test('First page and previous page buttons are disabled when current === 1', () 
   expect(onPageChange).toHaveBeenCalledTimes(2)
 })
 
-test('First page button is disabled when current === 2', () => {
+test('First page button is enabled when current === 2', () => {
   const { getByText } = renderWithTheme(
     <Pagination current={2} pages={10} onChange={onPageChange} />
   )
   fireEvent.click(getByText('First page of results'))
-  expect(onPageChange).toHaveBeenCalledTimes(0)
-
-  fireEvent.click(getByText('Previous page of results'))
   expect(onPageChange).toHaveBeenCalledTimes(1)
 
-  fireEvent.click(getByText('Next page of results'))
+  fireEvent.click(getByText('Previous page of results'))
   expect(onPageChange).toHaveBeenCalledTimes(2)
 
-  fireEvent.click(getByText('Last page of results'))
+  fireEvent.click(getByText('Next page of results'))
   expect(onPageChange).toHaveBeenCalledTimes(3)
+
+  fireEvent.click(getByText('Last page of results'))
+  expect(onPageChange).toHaveBeenCalledTimes(4)
 })
 
-test('Last page button is disabled when current === (pages - 1)', () => {
+test('Last page button is enable when current === (pages - 1)', () => {
   const { getByText } = renderWithTheme(
     <Pagination current={9} pages={10} onChange={onPageChange} />
   )
@@ -100,7 +100,7 @@ test('Last page button is disabled when current === (pages - 1)', () => {
   expect(onPageChange).toHaveBeenCalledTimes(3)
 
   fireEvent.click(getByText('Last page of results'))
-  expect(onPageChange).toHaveBeenCalledTimes(3)
+  expect(onPageChange).toHaveBeenCalledTimes(4)
 })
 
 test('Last page and next page buttons are disabled when current === pages', () => {

--- a/packages/components/src/Pagination/Pagination.tsx
+++ b/packages/components/src/Pagination/Pagination.tsx
@@ -60,7 +60,7 @@ const PaginationLayout: FC<PaginationProps> = ({
         label="First page of results"
         icon="DoubleChevronLeft"
         onClick={first}
-        disabled={current <= 2}
+        disabled={current === 1}
       />
       <PaginationButton
         label="Previous page of results"
@@ -82,7 +82,7 @@ const PaginationLayout: FC<PaginationProps> = ({
         label="Last page of results"
         icon="DoubleChevronRight"
         onClick={last}
-        disabled={pages - current <= 1}
+        disabled={pages - current === 0}
       />
     </Flex>
   )


### PR DESCRIPTION
Addresses feedback from Issue #1775 

### :white_check_mark: Requirements

- [x] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [x] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [x] Checked for a11y impacts
- [x] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
