### PR TITLE
docs: Correct useDrawer example and properly document Drawer placement

### DIFF
--- a/packages/components/src/Dialog/stories/Dialog.story.tsx
+++ b/packages/components/src/Dialog/stories/Dialog.story.tsx
@@ -56,18 +56,21 @@ Open.args = {
   ...Basic.args,
   defaultOpen: true,
 }
+Open.parameters = { docs: { disable: true } }
 
 export const MediumContent = Template.bind({})
 MediumContent.args = {
   content: <DialogMediumContent />,
   defaultOpen: true,
 }
+MediumContent.parameters = { docs: { disable: true } }
 
 export const Height = Template.bind({})
 Height.args = {
   ...MediumContent.args,
   height: '1000rem',
 }
+Height.parameters = { docs: { disable: true } }
 
 export const PlacementTop = Template.bind({})
 PlacementTop.args = {
@@ -75,6 +78,7 @@ PlacementTop.args = {
   defaultOpen: true,
   placement: 'top',
 }
+PlacementTop.parameters = { docs: { disable: true } }
 
 export const PlacementCover = Template.bind({})
 PlacementCover.args = {
@@ -82,12 +86,14 @@ PlacementCover.args = {
   defaultOpen: true,
   placement: 'cover',
 }
+PlacementCover.parameters = { docs: { disable: true } }
 
 export const LongContent = Template.bind({})
 LongContent.args = {
   content: <DialogLongContent />,
   defaultOpen: true,
 }
+LongContent.parameters = { docs: { disable: true } }
 
 export const withCheckbox = Template.bind({})
 withCheckbox.args = {
@@ -99,6 +105,7 @@ withCheckbox.args = {
   ),
 }
 withCheckbox.parameters = {
+  docs: { disable: true },
   storyshots: { disable: true },
 }
 
@@ -129,6 +136,7 @@ export const ClickOutside = () => {
 }
 
 ClickOutside.parameters = {
+  docs: { disable: true },
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Drawer/stories/Drawer.story.tsx
+++ b/packages/components/src/Drawer/stories/Drawer.story.tsx
@@ -49,18 +49,21 @@ export const Open = Template.bind({})
 Open.args = {
   defaultOpen: true,
 }
+Open.parameters = { docs: { disable: true } }
 
 export const PlacementLeft = Template.bind({})
 PlacementLeft.args = {
   defaultOpen: true,
   placement: 'left',
 }
+PlacementLeft.parameters = { docs: { disable: true } }
 
 export const Width = Template.bind({})
 Width.args = {
   ...Open.args,
   width: '50rem',
 }
+Width.parameters = { docs: { disable: true } }
 
 export default {
   argTypes: {

--- a/www/src/documentation/components/dialogs/drawer.mdx
+++ b/www/src/documentation/components/dialogs/drawer.mdx
@@ -5,8 +5,6 @@ storybook: true
 
 Drawer is a specialized form of `Dialog` that is attached to the edge of the viewport.
 
-NOTE: Currently `Drawer` only supports attachement to the right side of the viewport. Support for additional `placement` options is planned in the future.
-
 # Standard Use
 
 ```jsx
@@ -21,14 +19,14 @@ We provide a custom hook that returns the opener function and rendered drawer.
 
 ```jsx
 ;() => {
-  const { drawer, open } = useDrawer({
+  const { dialog, setOpen } = useDrawer({
     content: 'Drawer Content',
   })
 
   return (
     <>
-      {drawer}
-      <ButtonOutline onClick={open}>Open Drawer</ButtonOutline>
+      {dialog}
+      <ButtonOutline onClick={() => setOpen(true)}>Open Drawer</ButtonOutline>
     </>
   )
 }
@@ -50,3 +48,35 @@ Determines how surface is positioned in the the viewport.
   - _height_: fits content unless it's explicitly specified with `minHeight` prop
 - `left` - positioned to cover nearly the entire window.
   - _mobile & tablet_: cover the entire window.
+
+```jsx
+;() => {
+  const [placement, setPlacement] = useState('right')
+  const options = [
+    {
+      label: 'Left',
+      value: 'left',
+    },
+    {
+      label: 'Right',
+      value: 'right',
+      detail: 'default',
+    },
+  ]
+
+  return (
+    <Space>
+      <Drawer placement={placement} content="Drawer content">
+        <ButtonOutline>Open Drawer</ButtonOutline>
+      </Drawer>
+      <FieldRadioGroup
+        label="Placement"
+        inputsInline
+        options={options}
+        value={placement}
+        onChange={setPlacement}
+      />
+    </Space>
+  )
+}
+```


### PR DESCRIPTION
Also hide "open" drawers and dialogs from Storybook docs to improve
usability of embedded Storybook examples

Addresses #1779

### :white_check_mark: Requirements

- [ ] Includes test coverage for all changes
- [x] Build and tests are passing
- [x] Update documentation
- [ ] Updated CHANGELOG
- [ ] Checked for i18n impacts
- [ ] Checked for a11y impacts
- [ ] Check for image-snapshot changes (run `yarn image-snapshots` locally)
- [x] PR is ideally < ~400LOC

### :camera: Screenshots
