### PR TITLE
chore: Tag canary release properly

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -32,7 +32,7 @@ jobs:
           yarn build
       - name: Create canary release
         run: |
-          npx lerna version premajor --no-git-tag-version --no-push --preid canary.$(git rev-parse --short HEAD) --yes --exact
+          npx lerna version prerelease --conventional-commits --no-git-tag-version --no-push --preid canary --yes --exact
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -am "chore: Publish"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
             - stylelint-config
             - app:www
             - app:storybook
+            - deps
           # Configure that a scope must always be provided.
           requireScope: true
   lint:


### PR DESCRIPTION
Previous configuration was inaccurately bumping version (`1.0.0`) instead of using conventional-commit scheme + `canary-x`

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [ ] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
