### PR TITLE
fix: tabbing in & out of the table

### DIFF
--- a/packages/components/src/DataTable/DataTable.tsx
+++ b/packages/components/src/DataTable/DataTable.tsx
@@ -28,13 +28,11 @@ import styled from 'styled-components'
 import { reset } from '@looker/design-tokens'
 import React, { FC, useState } from 'react'
 import { MixedBoolean } from '../Form'
-import { useArrowKeyNav } from '../utils'
 import { BulkActions } from './BulkActions'
 import { DataTableContext } from './DataTableContext'
 import { DataTableFilters } from './Filters/DataTableFilters'
 import { Table } from './Table'
 import { DataTableProps } from './types'
-import { getNextFocus } from './getNextFocus'
 
 export const DataTableLayout: FC<DataTableProps> = (props) => {
   const {
@@ -108,14 +106,9 @@ export const DataTableLayout: FC<DataTableProps> = (props) => {
     />
   )
 
-  const navProps = useArrowKeyNav({
-    axis: 'both',
-    getNextFocus: getNextFocus,
-  })
-
   return (
     <DataTableContext.Provider value={context}>
-      <div className={className} {...navProps}>
+      <div className={className}>
         {filters}
         {bulk && select && select.selectedItems.length > 0 && (
           <BulkActions {...bulk} />

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -108,7 +108,7 @@ const DataTableRowLayout = forwardRef(
             <DataTableCheckbox {...pick(props, checkListProps)} />
           </ColumnType>
         ) : (
-          <ColumnType aria-hidden="true" tabIndex={-1} />
+          <ColumnType aria-hidden="true" />
         )}
         {sizedChildren}
         <ColumnType onClick={suppressClickPropagation} tabIndex={-1}>

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -29,7 +29,7 @@ import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
 import { Spinner } from '../Spinner'
 import { Heading } from '../Text'
-import { useCallbackRef, useIsTruncated } from '../utils'
+import { useArrowKeyNav, useCallbackRef, useIsTruncated } from '../utils'
 import {
   getNumericColumnIndices,
   numericColumnCSS,
@@ -37,6 +37,7 @@ import {
 import { DataTableProps } from './types'
 import { DataTableHeader } from './Header/DataTableHeader'
 import { edgeShadow } from './utils/edgeShadow'
+import { getNextFocus } from './getNextFocus'
 
 export interface TableProps extends DataTableProps {
   caption: string
@@ -68,12 +69,18 @@ export const TableLayout: FC<TableProps> = ({
     </InterimState>
   )
 
+  const navProps = useArrowKeyNav({
+    axis: 'both',
+    getNextFocus: getNextFocus,
+  })
+
   return (
     <>
       <TableScroll ref={ref}>
         <table
           aria-label={caption}
           className={overflow ? `${className} overflow` : className}
+          {...navProps}
         >
           <thead>
             <DataTableHeader id={headerRowId} />

--- a/packages/components/src/DataTable/getNextFocus.ts
+++ b/packages/components/src/DataTable/getNextFocus.ts
@@ -24,10 +24,7 @@
 
  */
 
-export const getTabStops = (ref: HTMLElement): HTMLElement[] =>
-  Array.from(
-    ref.querySelectorAll('td[tabindex="-1"],th[tabindex="-1"],a,button,input')
-  )
+import { getTabStops } from '../utils'
 
 const isTableCell = (
   element: Element
@@ -51,34 +48,36 @@ export const getNextFocus = (
   vertical?: boolean
 ) => {
   const tabStops = getTabStops(element)
-
-  if (
-    document.activeElement &&
-    tabStops.includes(document.activeElement as HTMLElement)
-  ) {
-    const element = document.activeElement
-    if (vertical && isTableCell(element)) {
-      const cellIndex = element.cellIndex
-      if (direction === -1) {
-        // Up Arrow
-        const rowAbove =
-          element &&
-          element.parentElement &&
-          element.parentElement.previousElementSibling
-        return isTableRow(rowAbove) ? rowAbove.cells[cellIndex] : cellIndex
-      } else if (direction === 1) {
-        // Down Arrow
-        const rowBelow =
-          element &&
-          element.parentElement &&
-          element.parentElement.nextElementSibling
-        return isTableRow(rowBelow) ? rowBelow.cells[cellIndex] : cellIndex
+  if (tabStops.length > 0) {
+    if (
+      document.activeElement &&
+      tabStops.includes(document.activeElement as HTMLElement)
+    ) {
+      const element = document.activeElement
+      if (vertical && isTableCell(element)) {
+        const cellIndex = element.cellIndex
+        if (direction === -1) {
+          // Up Arrow
+          const rowAbove =
+            element &&
+            element.parentElement &&
+            element.parentElement.previousElementSibling
+          return isTableRow(rowAbove) ? rowAbove.cells[cellIndex] : null
+        } else if (direction === 1) {
+          // Down Arrow
+          const rowBelow =
+            element &&
+            element.parentElement &&
+            element.parentElement.nextElementSibling
+          return isTableRow(rowBelow) ? rowBelow.cells[cellIndex] : null
+        }
       }
-    }
-    const next =
-      tabStops.findIndex((el) => el === document.activeElement) + direction
+      const next =
+        tabStops.findIndex((el) => el === document.activeElement) + direction
 
-    return tabStops[next]
+      return tabStops[next]
+    }
+    return tabStops[0]
   }
   return null
 }


### PR DESCRIPTION
- Moves `useArrowKeyNav` from `DataTable` to `Table` – the bulk actions & filtering components at the top of `DataTable` should have "normal" tabbing.
- Removes `tabIndex={-1}` from the hidden column
- Uses the `getTabStops` from `../utils` (since everything we want to get focus should now be `[tabindex="-1"]` no need to use a custom one anymore)