### PR TITLE
fix: Properly build ems/cjs/ts for easy deep-imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,13 +23,13 @@ storybook-static
 www/public
 
 # lerna
-/packages/*/cjs
-/packages/*/esm
-/packages/*/types
+/packages/*/lib
 
 # deprecated but useful for folks with older builds
 /packages/*/dist
-/packages/*/lib
+/packages/*/esm
+/packages/*/cjs
+/packages/*/types
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "scripts": {
     "prebuild": "yarn clean && yarn lerna run prebuild  --stream",
     "build": "run-p -c build:*",
-    "build:cjs": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name cjs --root-mode upward --out-dir cjs --source-maps --extensions .ts,.tsx --no-comments'",
-    "build:esm": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name esm --root-mode upward --out-dir esm --source-maps --extensions .ts,.tsx --no-comments'",
+    "build:cjs": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name cjs --root-mode upward --out-dir lib/cjs --source-maps --extensions .ts,.tsx --no-comments'",
+    "build:esm": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name esm --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments'",
     "build:ts": "yarn lerna exec --stream --scope '@looker/*' --sort 'tsc -b tsconfig.build.json'",
     "bumpversion": "yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes",
     "clean": "run-p -c clean:*",

--- a/packages/components-providers/package.json
+++ b/packages/components-providers/package.json
@@ -2,9 +2,9 @@
   "name": "@looker/components-providers",
   "license": "MIT",
   "version": "0.10.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "types/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "cjs",
     "esm",

--- a/packages/components-providers/tsconfig.build.json
+++ b/packages/components-providers/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/components-test-utils/package.json
+++ b/packages/components-test-utils/package.json
@@ -2,9 +2,9 @@
   "name": "@looker/components-test-utils",
   "license": "MIT",
   "version": "0.10.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "types/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "cjs",
     "esm",

--- a/packages/components-test-utils/tsconfig.build.json
+++ b/packages/components-test-utils/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/components-theme-editor/package.json
+++ b/packages/components-theme-editor/package.json
@@ -2,9 +2,9 @@
   "name": "@looker/components-theme-editor",
   "license": "MIT",
   "version": "0.10.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "types/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "cjs",
     "esm",

--- a/packages/components-theme-editor/tsconfig.build.json
+++ b/packages/components-theme-editor/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,9 +2,9 @@
   "name": "@looker/components",
   "license": "MIT",
   "version": "0.10.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "types/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "cjs",
     "esm",

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -2,9 +2,9 @@
   "name": "@looker/design-tokens",
   "license": "MIT",
   "version": "0.10.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "types/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "cjs",
     "esm",

--- a/packages/design-tokens/tsconfig.build.json
+++ b/packages/design-tokens/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["./src"]
 }

--- a/packages/eslint-config/tsconfig.build.json
+++ b/packages/eslint-config/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["./"]
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -2,9 +2,9 @@
   "name": "@looker/icons",
   "license": "MIT",
   "version": "0.10.0",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "types/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "cjs",
     "esm",

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/prettier/tsconfig.build.json
+++ b/packages/prettier/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["./"]
 }

--- a/packages/storybook-config/tsconfig.build.json
+++ b/packages/storybook-config/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/stylelint-config/tsconfig.build.json
+++ b/packages/stylelint-config/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./types"
+    "outDir": "./lib"
   },
   "include": ["./"]
 }


### PR DESCRIPTION
Currently build requires that users do deep imports againist a somewhat unconventional path and in so doing they also break TS import checks.

#### Current (broken)

```
import { InputDate } from '@looker/components/esm/InputDate'
```

NOTE: TSC (Typescript compiler) won't match up types in the `types` folder, a double import will fix it but it's super awkward and requires ESLint hijinks to not get errors about duplicate imports

```
import { InputDate } from '@looker/components/esm/InputDate'
import { InputDate } from '@looker/components/types/InputDate'
```

#### Fix

```
import { InputDate } from '@looker/components/lib/InputDate'
```

Typescript automatically finds `@looker/components/lib/InputDate/InputDate.d.ts` to resolve typings