### PR TITLE
fix: Select group heading styles

### DIFF
--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -143,23 +143,14 @@ export function SelectOptionWithDescription({
   )
 }
 
-const SelectOptionGroupTitle = styled(Heading).attrs<HeadingProps>(
-  ({
-    color = 'subdued',
-    fontFamily = 'body',
-    fontSize = 'xxsmall',
-    fontWeight = 'semiBold',
-    px = 'xsmall',
-    py = 'xxsmall',
-  }) => ({
-    color,
-    fontFamily,
-    fontSize,
-    fontWeight,
-    px,
-    py,
-  })
-)<{ isMulti?: boolean }>`
+const SelectOptionGroupTitle = styled(Heading).attrs<HeadingProps>(() => ({
+  color: 'subdued',
+  fontFamily: 'body',
+  fontSize: 'xxsmall',
+  fontWeight: 'semiBold',
+  px: 'xsmall',
+  py: 'xxsmall',
+}))<{ isMulti?: boolean }>`
   display: flex;
   padding-top: ${({ theme }) => theme.space.xxsmall};
 `


### PR DESCRIPTION
During the `defaultProps` refactor, `.attrs()` on `SelectOptionGroupTitle` was incorrectly applied.
![image](https://user-images.githubusercontent.com/53451193/105774134-c2aef880-5f19-11eb-8661-1a2f8d442e68.png)

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [x] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
