### PR TITLE
chore: Use Codecov for test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -32,6 +32,9 @@ jobs:
       - uses: c-hive/gha-yarn-cache@v1
       - run : yarn --silent
       - run: yarn test
+      - uses: codecov/codecov-action@v1.2.1
+        with:
+          fail_ci_if_error: false # optional (default = false)
     env:
       CI: true
   build:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Test Suite](https://github.com/looker-open-source/components/workflows/Test/badge.svg?branch=main)
+[![codecov](https://codecov.io/gh/looker-open-source/components/branch/main/graph/badge.svg?token=22OOBW8Q7G)](https://codecov.io/gh/looker-open-source/components)
 
 This repository hosts the Looker UI Components library and the platform needed to generate our style guide. If you're looking for documentation for using Looker UI Components within your own application, you can view the documentation online on our web site.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,6 @@ process.env.TZ = 'UTC'
 module.exports = {
   automock: false,
   collectCoverage: true,
-  coverageDirectory: 'coverage',
   coverageReporters: ['json', 'html'],
   moduleDirectories: ['./node_modules', './packages'],
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 
     "pretest": "yarn prebuild",
     "test": "yarn jest",
-    "coverage": "yarn jest --coverage",
 
     "storybook": "yarn workspace storybook develop",
     "storybook-docs": "yarn workspace storybook develop-docs",


### PR DESCRIPTION
Coverage step caused problems when running against `main` (can't diff the same branch to itself)

Introduced codecov for coverage analysis: 

![image](https://user-images.githubusercontent.com/34253496/106049167-b43c1a80-609a-11eb-9048-78fa94aa7dc8.png)


![image](https://user-images.githubusercontent.com/34253496/106038174-70421900-608c-11eb-994d-aee9bd65bbcb.png)


### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [ ] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
