### PR TITLE
fix(deps): Downgrade react-hotkeys-hook to resolve hotkey breakages

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,7 @@
     "hotkeys-js": "^3.8.1",
     "lodash": "^4.17.20",
     "react-day-picker": "^7.4.8",
-    "react-hotkeys-hook": "^3.0.3",
+    "react-hotkeys-hook": "2.3.1",
     "react-resize-detector": "^5.2.0",
     "resize-observer-polyfill": "^1.5.1",
     "styled-system": "^5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18358,10 +18358,10 @@ react-hot-loader@^4.12.21:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
-react-hotkeys-hook@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.0.3.tgz#5967486a4f569eb7045d2384ed0c35687ac7bdfa"
-  integrity sha512-kbnb820AUITXxK3qRHq612ivoNvMidIEaVAG7rUDuJMBTlJdSniJjjFl0jddL4iSKJK1d0Vqgn80uPW+spq6yQ==
+react-hotkeys-hook@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-2.3.1.tgz#ab4964fba4a06e25ef31e0a084771303e28e6dd0"
+  integrity sha512-5zutx5e7LuVcSlYTCSOu+WKuvRHiIRc4VJKUzQ+caqn4ibveLtN3MdaIear6I3BAdUeAkOw2uwp8r3OyrSAbqw==
   dependencies:
     hotkeys-js "3.8.1"
 


### PR DESCRIPTION

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [ ] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
