### PR TITLE
fix: DataTable browser sticky cells

### DIFF
--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -171,12 +171,8 @@ const stickyColumns = css<TableProps>`
 `
 
 export const Table = styled(TableLayout)`
-  /* the * is set so the border-bottom displays correctly on Firefox on sticky items */
-  *border-collapse: collapse;
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
-  /* stylelint-disable-next-line value-no-vendor-prefix */
-  height: -webkit-fill-available;
   line-height: 1;
   width: 100%;
   td,

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -175,6 +175,9 @@ export const Table = styled(TableLayout)`
   *border-collapse: collapse;
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
+  /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
+  height: -webkit-fill-available;
+  /* stylelint-enable */
   line-height: 1;
   width: 100%;
   td,

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -171,12 +171,12 @@ const stickyColumns = css<TableProps>`
 `
 
 export const Table = styled(TableLayout)`
-  border-collapse: collapse;
+  /* the * is set so the border-bottom displays correctly on Firefox on sticky items */
+  *border-collapse: collapse;
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
   line-height: 1;
   width: 100%;
-
   td,
   th {
     height: ${densityTarget}; /* acts like min-height */

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -175,9 +175,8 @@ export const Table = styled(TableLayout)`
   *border-collapse: collapse;
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
-  /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
+  /* stylelint-disable-next-line value-no-vendor-prefix */
   height: -webkit-fill-available;
-  /* stylelint-enable */
   line-height: 1;
   width: 100%;
   td,

--- a/packages/components/src/DataTable/stories/items.tsx
+++ b/packages/components/src/DataTable/stories/items.tsx
@@ -28,7 +28,6 @@ import React, { ReactNode } from 'react'
 import { data as mockData, CheeseData } from '../../__mocks__/DataTable/data'
 import { Link } from '../../Link'
 import { Status } from '../../Status'
-import { Span } from '../../Text/Span'
 import { Tooltip } from '../../Tooltip'
 import { DataTableCell } from '../Column'
 import { DataTableItem, DataTableAction } from '../Item'
@@ -99,7 +98,6 @@ export const itemBuilder = (
               size="xsmall"
             />
           </Tooltip>
-          <Span fontSize="xsmall">{status}</Span>
         </DataTableCell>
         <DataTableCell>{inventory}</DataTableCell>
         <DataTableCell>{color}</DataTableCell>

--- a/packages/components/src/DataTable/stories/items.tsx
+++ b/packages/components/src/DataTable/stories/items.tsx
@@ -28,6 +28,7 @@ import React, { ReactNode } from 'react'
 import { data as mockData, CheeseData } from '../../__mocks__/DataTable/data'
 import { Link } from '../../Link'
 import { Status } from '../../Status'
+import { Span } from '../../Text/Span'
 import { Tooltip } from '../../Tooltip'
 import { DataTableCell } from '../Column'
 import { DataTableItem, DataTableAction } from '../Item'
@@ -98,6 +99,7 @@ export const itemBuilder = (
               size="xsmall"
             />
           </Tooltip>
+          <Span fontSize="xsmall">{status}</Span>
         </DataTableCell>
         <DataTableCell>{inventory}</DataTableCell>
         <DataTableCell>{color}</DataTableCell>


### PR DESCRIPTION

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [ ] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
