### PR TITLE
fix(DataTable): "sticky" cell border-bottom now presents properly in Safari

### DIFF
--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -174,6 +174,7 @@ export const Table = styled(TableLayout)`
   border-collapse: collapse;
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
+  height: initial;
   line-height: 1;
   width: 100%;
 

--- a/packages/components/src/DataTable/stories/items.tsx
+++ b/packages/components/src/DataTable/stories/items.tsx
@@ -98,10 +98,6 @@ export const itemBuilder = (
               size="xsmall"
             />
           </Tooltip>
-          <span>some text</span>
-          <p>
-            <a>link here</a>
-          </p>
         </DataTableCell>
         <DataTableCell>{inventory}</DataTableCell>
         <DataTableCell>{color}</DataTableCell>

--- a/packages/components/src/DataTable/stories/items.tsx
+++ b/packages/components/src/DataTable/stories/items.tsx
@@ -98,6 +98,10 @@ export const itemBuilder = (
               size="xsmall"
             />
           </Tooltip>
+          <span>some text</span>
+          <p>
+            <a>link here</a>
+          </p>
         </DataTableCell>
         <DataTableCell>{inventory}</DataTableCell>
         <DataTableCell>{color}</DataTableCell>


### PR DESCRIPTION
Thank so much for contributing to @looker/components!

The CI & [README](https://github.com/looker-open-source/components/blob/main/README.md) should help to make most of our code standards clear

Before requesting review from another developer please delete the lines above and summarize your change.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [ ] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
