### PR TITLE
fix: Tab no longer spuriously accepts MarginProps

### DIFF
--- a/packages/components/src/Tabs/Tab.tsx
+++ b/packages/components/src/Tabs/Tab.tsx
@@ -31,8 +31,6 @@ import {
   layout,
   LayoutProps,
   reset,
-  space,
-  SpaceProps,
   shouldForwardProp,
   typography,
   TypographyProps,
@@ -42,7 +40,6 @@ import {
 export interface TabProps
   extends Omit<CompatibleHTMLProps<HTMLButtonElement>, 'type'>,
     LayoutProps,
-    SpaceProps,
     TypographyProps {
   disabled?: boolean
   focusVisible?: boolean
@@ -54,7 +51,6 @@ export interface TabProps
 const TabStyle = styled.button.withConfig({ shouldForwardProp })<TabProps>`
   ${reset}
   ${layout}
-  ${space}
   ${typography}
 
   background: transparent;
@@ -70,6 +66,8 @@ const TabStyle = styled.button.withConfig({ shouldForwardProp })<TabProps>`
   font-family: ${({ theme }) => theme.fonts.brand};
   /* Remove default margin button in Safari */
   margin: 0;
+  padding-bottom: small;
+  padding-top: xsmall;
 
   &:active {
     border-bottom-color: ${({ selected, theme }) =>
@@ -153,15 +151,8 @@ const TabJSX = forwardRef((props: TabProps, ref: Ref<HTMLButtonElement>) => {
 TabJSX.displayName = 'TabJSX'
 
 export const Tab = styled(TabJSX).attrs(
-  ({
-    fontSize = 'small',
-    fontWeight = 'medium',
-    pb = 'small',
-    pt = 'xsmall',
-  }) => ({
+  ({ fontSize = 'small', fontWeight = 'medium' }) => ({
     fontSize,
     fontWeight,
-    pb,
-    pt,
   })
 )``

--- a/packages/components/src/Tabs/Tab.tsx
+++ b/packages/components/src/Tabs/Tab.tsx
@@ -31,6 +31,8 @@ import {
   layout,
   LayoutProps,
   reset,
+  padding,
+  PaddingProps,
   shouldForwardProp,
   typography,
   TypographyProps,
@@ -40,6 +42,7 @@ import {
 export interface TabProps
   extends Omit<CompatibleHTMLProps<HTMLButtonElement>, 'type'>,
     LayoutProps,
+    PaddingProps,
     TypographyProps {
   disabled?: boolean
   focusVisible?: boolean
@@ -51,6 +54,7 @@ export interface TabProps
 const TabStyle = styled.button.withConfig({ shouldForwardProp })<TabProps>`
   ${reset}
   ${layout}
+  ${padding}
   ${typography}
 
   background: transparent;
@@ -66,8 +70,6 @@ const TabStyle = styled.button.withConfig({ shouldForwardProp })<TabProps>`
   font-family: ${({ theme }) => theme.fonts.brand};
   /* Remove default margin button in Safari */
   margin: 0;
-  padding-bottom: small;
-  padding-top: xsmall;
 
   &:active {
     border-bottom-color: ${({ selected, theme }) =>
@@ -151,8 +153,15 @@ const TabJSX = forwardRef((props: TabProps, ref: Ref<HTMLButtonElement>) => {
 TabJSX.displayName = 'TabJSX'
 
 export const Tab = styled(TabJSX).attrs(
-  ({ fontSize = 'small', fontWeight = 'medium' }) => ({
+  ({
+    fontSize = 'small',
+    fontWeight = 'medium',
+    pb = 'small',
+    pt = 'xsmall',
+  }) => ({
     fontSize,
     fontWeight,
+    pb,
+    pt,
   })
 )``


### PR DESCRIPTION
Thank so much for contributing to @looker/components!

The CI & [README](https://github.com/looker-open-source/components/blob/main/README.md) should help to make most of our code standards clear

Before requesting review from another developer please delete the lines above and summarize your change.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
- [ ] :rotating_light: Check for image-snapshot changes (run `yarn image-snapshots` locally)
