### PR TITLE
docs: Fix broken link and correct Header presentation when site is deployed to folder

### DIFF
--- a/www/src/components/HeaderContent/HeaderContent.tsx
+++ b/www/src/components/HeaderContent/HeaderContent.tsx
@@ -47,8 +47,9 @@ export const HeaderContentLayout: FC<HeaderProps> = ({
   updateTheme,
   hasCustomTheme,
 }) => {
-  const location = useLocation()
-  const showHamburger = location.pathname.split('/').length < (isDev ? 2 : 4)
+  const { pathname } = useLocation()
+  const showHamburger =
+    pathname.substring(1).split('/').length < (isDev ? 2 : 4)
 
   const data = useStaticQuery(graphql`
     query HeaderNav {

--- a/www/src/components/HeaderContent/HeaderContent.tsx
+++ b/www/src/components/HeaderContent/HeaderContent.tsx
@@ -39,6 +39,8 @@ interface HeaderProps extends ThemeEditorProps {
   toggleNavigation: () => void
 }
 
+const isDev = process.env.NODE_ENV === 'development'
+
 export const HeaderContentLayout: FC<HeaderProps> = ({
   className,
   toggleNavigation,
@@ -46,7 +48,7 @@ export const HeaderContentLayout: FC<HeaderProps> = ({
   hasCustomTheme,
 }) => {
   const location = useLocation()
-  const currentPath = location.pathname
+  const showHamburger = location.pathname.split('/').length < (isDev ? 2 : 4)
 
   const data = useStaticQuery(graphql`
     query HeaderNav {
@@ -73,7 +75,7 @@ export const HeaderContentLayout: FC<HeaderProps> = ({
       height="100%"
     >
       <Space>
-        {currentPath === '/' ? (
+        {showHamburger ? (
           <span />
         ) : (
           <IconButton

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -97,7 +97,7 @@ const Intro = () => {
                 Install
               </Heading>
               <Paragraph fontSize="small">
-                Visit the <Link href="/develop/">Develop</Link> page for
+                Visit the <Link to="develop">Develop</Link> page for
                 instructions on installing{' '}
                 <Code fontSize="small">@looker/components</Code>
               </Paragraph>


### PR DESCRIPTION
- Correctly constructs link to `develop` when running within a folder
- Does not show "Hamburger" menu on home page when deployed within a folder (`/components/latest`)

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
