### PR TITLE
fix: `RangeSlider` & `Slider` properly display on inverted themes

### DIFF
--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -428,8 +428,7 @@ interface ThumbLabelProps extends TypographyProps {
 }
 
 const ThumbLabel = styled.div<ThumbLabelProps>`
-  background: ${({ theme, focus }) =>
-    focus ? theme.colors.keyAccent : `rgba(255, 255, 255, 0.8)`};
+  background: ${({ theme, focus }) => focus && theme.colors.keyAccent};
   border-radius: 1rem;
   color: ${({ theme: { colors }, disabled }) =>
     disabled ? colors.neutral : colors.key};

--- a/packages/components/src/Form/Inputs/Slider/Slider.tsx
+++ b/packages/components/src/Form/Inputs/Slider/Slider.tsx
@@ -248,8 +248,7 @@ interface SliderValueProps extends SliderInputProps {
 }
 
 const SliderValue = styled.div<SliderValueProps>`
-  background: ${({ theme, isFocused }) =>
-    isFocused ? theme.colors.keyAccent : theme.colors.keyText};
+  background: ${({ theme, isFocused }) => isFocused && theme.colors.keyAccent};
   border-radius: 1rem;
   color: ${({ theme: { colors }, disabled }) =>
     disabled ? colors.neutral : colors.key};


### PR DESCRIPTION


### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
