### PR TITLE
fix(components): Unable to filter SelectMulti with 1 or more controlled values

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/utils/getComboboxText.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/getComboboxText.ts
@@ -34,7 +34,9 @@ export function getComboboxText(
   if (typeof value === 'string') {
     if (options && options.length > 0) {
       const currentOption = options.find((option) => option.value === value)
-      return getComboboxText(currentOption)
+      if (currentOption) {
+        return getComboboxText(currentOption)
+      }
     }
     return value
   }

--- a/packages/components/src/Form/Inputs/Combobox/utils/state.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/state.ts
@@ -362,7 +362,6 @@ export const reducerMulti: Reducer<
     case ComboboxActionType.SELECT_SILENT:
       return {
         ...nextState,
-        inputValue: '',
         navigationOption: undefined,
         options: action.options || [],
       }


### PR DESCRIPTION
Issue repros: 
1. Unnecessary `SELECT_SILENT` due to filtering: https://codesandbox.io/s/wispy-wildflower-p2kn3
2. Legit `SELECT_SILENT` due to external state change: https://codesandbox.io/s/zealous-jepsen-jjiyh

This issue (2 issues really) was exposed by this fix https://github.com/looker-open-source/components/pull/1433/files#r491123741 for a different issue, but there were actually 2 separate underlying causes:
1. The `SELECT_SILENT` action exists for controlled use cases in order to sync up the `values` prop with the values in context, if they are found to me out of sync (for example the values are updated externally via an API call response). But the logic that mapped `SelectMulti` values (strings) to `ComboboxMulti` values (objects) was incorrectly setting the `label` to an empty string when there were no matching options (see `getComboboxText`). So in the 1st example above, the context has `[{ label: 'Cheddar', value: 'Cheddar' }]` as the current values, but once Cheddar gets filtered out, the `values` prop is coming in as `[{ label: '', value: 'Cheddar' }]`. The mismatch (now "better" detected after the change in #1433 above) was triggering `SELECT_SILENT`, which then was resetting the `inputValue` to `''`.
2. Event for a legit `SELECT_SILENT`, there's no need to reset the `inputValue`. I don't think I did that intentionally, just copied from `SELECT_WITH_CLICK` without too much thought.

So this issue should be double fixed now. 🙃

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
