### PR TITLE
test: InputDate code coverage

### DIFF
--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -58,10 +58,6 @@ export interface InputDateProps extends SpaceProps, BorderProps {
 }
 
 const isDateInView = (value: Date, viewMonth: Date) => {
-  if (!value) {
-    return false
-  }
-
   if (
     value.getFullYear() === viewMonth.getFullYear() &&
     value.getMonth() === viewMonth.getMonth()


### PR DESCRIPTION
100% test coverage on InputDate

<img width="730" alt="Screen Shot 2021-02-08 at 3 40 54 PM" src="https://user-images.githubusercontent.com/238293/107295967-4fcb7480-6a25-11eb-9929-7dbcf4af83ef.png">

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
