### PR TITLE
fix(FocusTrap): Return focus behavior on nested focus traps

### DIFF
--- a/packages/components-providers/src/FocusTrap/FocusTrapProvider.tsx
+++ b/packages/components-providers/src/FocusTrap/FocusTrapProvider.tsx
@@ -27,8 +27,11 @@
 import React, { createContext, FC } from 'react'
 import { TrapStackContextProps, TrapStackProvider } from '../TrapStack'
 import { activateFocusTrap } from './utils'
+import { FocusTrapOptions } from './types'
 
-export const FocusTrapContext = createContext<TrapStackContextProps>({})
+export const FocusTrapContext = createContext<
+  TrapStackContextProps<FocusTrapOptions>
+>({})
 FocusTrapContext.displayName = 'FocusTrapContext'
 
 export const FocusTrapProvider: FC = (props) => (

--- a/packages/components-providers/src/FocusTrap/index.ts
+++ b/packages/components-providers/src/FocusTrap/index.ts
@@ -25,3 +25,4 @@
  */
 
 export * from './FocusTrapProvider'
+export * from './types'

--- a/packages/components-providers/src/FocusTrap/types.ts
+++ b/packages/components-providers/src/FocusTrap/types.ts
@@ -27,6 +27,14 @@
 import { MutableRefObject } from 'react'
 
 export interface FocusTrapOptions {
+  /**
+   * A click outside the focus trap element will not be prevented
+   * and will deactivate the trap
+   */
   clickOutsideDeactivates?: boolean
+  /**
+   * A ref to track the last element to have focus before the trap activates
+   * in order to return focus there when it deactivates
+   */
   returnFocusRef: MutableRefObject<Element | null>
 }

--- a/packages/components-providers/src/FocusTrap/types.ts
+++ b/packages/components-providers/src/FocusTrap/types.ts
@@ -24,22 +24,9 @@
 
  */
 
-import { useRef } from 'react'
-import {
-  FocusTrapContext,
-  FocusTrapOptions,
-} from '@looker/components-providers'
-import { useTrapStack, UseTrapStackProps } from './useTrapStack'
+import { MutableRefObject } from 'react'
 
-export const useFocusTrap = <E extends HTMLElement = HTMLElement>({
-  options,
-  ...props
-}: Omit<UseTrapStackProps<E, Partial<FocusTrapOptions>>, 'context'> = {}) => {
-  const returnFocusRef = useRef<Element>(null)
-  return useTrapStack<E, FocusTrapOptions>({
-    context: FocusTrapContext,
-    // If options.returnFocusRef is set, it will override this one
-    options: { returnFocusRef, ...options },
-    ...props,
-  })
+export interface FocusTrapOptions {
+  clickOutsideDeactivates?: boolean
+  returnFocusRef: MutableRefObject<Element | null>
 }

--- a/packages/components-providers/src/FocusTrap/utils.ts
+++ b/packages/components-providers/src/FocusTrap/utils.ts
@@ -33,6 +33,7 @@
 
 import { tabbable, isFocusable, FocusableElement } from 'tabbable'
 import { Trap } from '../TrapStack/types'
+import { FocusTrapOptions } from './types'
 
 const isSelectableInput = (
   node: FocusableElement
@@ -57,8 +58,11 @@ const checkFocusLost = () => {
 export const activateFocusTrap = ({
   element,
   options,
-}: Trap<{ clickOutsideDeactivates?: boolean }>) => {
-  const nodeFocusedBeforeActivation = document.activeElement
+}: Trap<FocusTrapOptions>) => {
+  if (options && !options.returnFocusRef.current) {
+    options.returnFocusRef.current = document.activeElement
+  }
+  const nodeFocusedBeforeActivation = options?.returnFocusRef?.current
   let firstTabbableNode: FocusableElement = element
   let lastTabbableNode: FocusableElement = element
   let mostRecentlyFocusedNode: FocusableElement | null = null

--- a/packages/components-providers/src/FocusTrap/utils.ts
+++ b/packages/components-providers/src/FocusTrap/utils.ts
@@ -60,6 +60,9 @@ export const activateFocusTrap = ({
   options,
 }: Trap<FocusTrapOptions>) => {
   if (options && !options.returnFocusRef.current) {
+    // The return focus element may already have been stored if this is an existing trap
+    // that has been superseded by a new focus trap and is now being re-activated.
+    // If it's empty, store the current focused element
     options.returnFocusRef.current = document.activeElement
   }
   const nodeFocusedBeforeActivation = options?.returnFocusRef?.current

--- a/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
+++ b/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
@@ -25,27 +25,28 @@
  */
 
 import noop from 'lodash/noop'
-import React, { Context, FC, useRef, useMemo } from 'react'
+import React, { Context, ReactNode, useRef, useMemo } from 'react'
 import { Trap, TrapStackContextProps, TrapMap } from './types'
 import { getActiveTrap } from './utils'
 
-export interface TrapStackProviderProps {
-  activate: (trap: Trap) => () => void
-  context: Context<TrapStackContextProps>
+export interface TrapStackProviderProps<O extends {} = {}> {
+  activate: (trap: Trap<O>) => () => void
+  children?: ReactNode
+  context: Context<TrapStackContextProps<O>>
 }
 
 /**
  * Manages "trap" behavior (e.g. scroll lock & focus trap)
  * in a stack of elements (e.g. layered Dialogs & Popovers)
  */
-export const TrapStackProvider: FC<TrapStackProviderProps> = ({
+export const TrapStackProvider = <O,>({
   activate,
   context,
   children,
-}) => {
+}: TrapStackProviderProps<O>) => {
   // Stores all available trap elements
   // (map of ids to elements that have traps)
-  const registeredTrapsRef = useRef<TrapMap>({})
+  const registeredTrapsRef = useRef<TrapMap<O>>({})
   // Stores the current trap (element) where scrolling is allowed
   // null if no trap is active
   const activeTrapRef = useRef<HTMLElement | null>(null)
@@ -54,7 +55,7 @@ export const TrapStackProvider: FC<TrapStackProviderProps> = ({
 
   // Create the context value
   const value = useMemo(() => {
-    const getTrap = (id?: string): Trap | null => {
+    const getTrap = (id?: string): Trap<O> | null => {
       const registeredTraps = registeredTrapsRef.current
       return id ? registeredTraps[id] || null : getActiveTrap(registeredTraps)
     }
@@ -80,7 +81,7 @@ export const TrapStackProvider: FC<TrapStackProviderProps> = ({
       activeTrapRef.current = null
     }
 
-    const addTrap = (id: string, trap: Trap) => {
+    const addTrap = (id: string, trap: Trap<O>) => {
       registeredTrapsRef.current[id] = trap
       enableCurrentTrap()
     }

--- a/packages/components-providers/src/TrapStack/types.ts
+++ b/packages/components-providers/src/TrapStack/types.ts
@@ -26,38 +26,38 @@
 
 import { MutableRefObject } from 'react'
 
-export interface Trap<T extends {} = {}> {
+export interface Trap<O extends {} = {}> {
   element: HTMLElement
-  options?: T
+  options?: O
 }
 
-export interface TrapStackContextProps {
+export interface TrapStackContextProps<O extends {} = {}> {
   /**
-   * Stores the element for the active scroll lock (null if none are active)
+   * Stores the element for the active trap (null if none are active)
    */
   activeTrapRef?: MutableRefObject<HTMLElement | null>
   /**
    * @private
    */
-  addTrap?: (id: string, trap: Trap) => void
+  addTrap?: (id: string, trap: Trap<O>) => void
   /**
-   * Disables the current scroll lock (no scroll lock will be enabled as a result)
+   * Disables the current trap (no trap will be enabled as a result)
    */
   disableCurrentTrap?: () => void
   /**
-   * Enables the scroll lock stacked on top
+   * Enables the trap stacked on top
    */
   enableCurrentTrap?: () => void
   /**
    * @private
    */
-  getTrap?: (id: string) => Trap | null
+  getTrap?: (id: string) => Trap<O> | null
   /**
    * @private
    */
   removeTrap?: (id: string) => void
 }
 
-export interface TrapMap {
-  [key: string]: Trap
+export interface TrapMap<O extends {} = {}> {
+  [key: string]: Trap<O>
 }

--- a/packages/components-providers/src/TrapStack/utils.ts
+++ b/packages/components-providers/src/TrapStack/utils.ts
@@ -25,7 +25,7 @@
  */
 import { TrapMap } from './types'
 
-export const getActiveTrap = (trapMap: TrapMap) => {
+export const getActiveTrap = <O extends {} = {}>(trapMap: TrapMap<O>) => {
   // Sort the trap elements according to dom position and return the last
   // which we assume to be stacked on top since all components using Portal
   // share a single zIndexFloor and use dom order to determine stacking

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -30,6 +30,7 @@ import {
   fireEvent,
   waitForElementToBeRemoved,
   screen,
+  waitFor,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React, { useRef } from 'react'
@@ -274,10 +275,9 @@ describe('<Menu />', () => {
       fireEvent.click(document)
     })
 
-    test('toggle on arrow keys', () => {
+    test('toggle on arrow keys', async () => {
       renderWithTheme(
         <Menu
-          isOpen
           content={
             <MenuItem nestedMenu={<MenuItem>Swiss</MenuItem>}>Gouda</MenuItem>
           }
@@ -285,6 +285,9 @@ describe('<Menu />', () => {
           <Button>Cheese</Button>
         </Menu>
       )
+
+      const button = screen.getByText('Cheese')
+      userEvent.click(button)
 
       const parent = screen.getByText('Gouda')
       fireEvent.keyDown(parent, { key: 'ArrowRight' })
@@ -303,6 +306,8 @@ describe('<Menu />', () => {
       fireEvent.keyDown(child2, { key: 'Escape' })
       expect(screen.queryByText('Swiss')).not.toBeInTheDocument()
       expect(screen.queryByText('Gouda')).not.toBeInTheDocument()
+
+      await waitFor(() => expect(button).toHaveFocus())
     })
 
     test('toggle on click', () => {

--- a/packages/components/src/utils/useFocusTrap.test.tsx
+++ b/packages/components/src/utils/useFocusTrap.test.tsx
@@ -48,7 +48,12 @@ const Inner: FC<{ clickOutsideDeactivates?: boolean }> = ({
   const { value, setOff, toggle } = useToggle()
   return (
     <>
-      {value && <div ref={ref}>{children}</div>}
+      {value && (
+        <div ref={ref}>
+          {children}
+          <button onClick={setOff}>Close</button>
+        </div>
+      )}
       <button onClick={toggle}>toggle</button>
       <button onClick={setOff}>Another button</button>
     </>
@@ -153,6 +158,30 @@ describe('useFocusTrap', () => {
       fireEvent.click(otherButton)
       otherButton.focus()
       expect(otherButton).toHaveFocus()
+    })
+
+    test.only('With nested traps', async () => {
+      render(
+        <FocusTrapComponent>
+          <Surface>
+            <Inner>
+              <Surface />
+            </Inner>
+          </Surface>
+        </FocusTrapComponent>
+      )
+      const toggle = screen.getByText('toggle')
+      toggle.focus()
+      fireEvent.click(toggle)
+
+      const toggleInner = screen.getAllByText('toggle')[0]
+      toggleInner.focus()
+      fireEvent.click(toggleInner)
+
+      const closeButtons = screen.getAllByText('Close')
+      fireEvent.click(closeButtons[0])
+      fireEvent.click(closeButtons[1])
+      await waitFor(() => expect(toggle).toHaveFocus())
     })
   })
 

--- a/packages/components/src/utils/useFocusTrap.test.tsx
+++ b/packages/components/src/utils/useFocusTrap.test.tsx
@@ -160,7 +160,7 @@ describe('useFocusTrap', () => {
       expect(otherButton).toHaveFocus()
     })
 
-    test.only('With nested traps', async () => {
+    test('With nested traps', async () => {
       render(
         <FocusTrapComponent>
           <Surface>

--- a/packages/components/src/utils/useFocusTrap.test.tsx
+++ b/packages/components/src/utils/useFocusTrap.test.tsx
@@ -40,9 +40,15 @@ afterEach(() => {
   jest.useRealTimers()
 })
 
-const Inner: FC<{ clickOutsideDeactivates?: boolean }> = ({
+interface TestProps {
+  clickOutsideDeactivates?: boolean
+  hideClose?: boolean
+}
+
+const Inner: FC<TestProps> = ({
   children,
   clickOutsideDeactivates,
+  hideClose,
 }) => {
   const [, ref] = useFocusTrap({ options: { clickOutsideDeactivates } })
   const { value, setOff, toggle } = useToggle()
@@ -51,7 +57,7 @@ const Inner: FC<{ clickOutsideDeactivates?: boolean }> = ({
       {value && (
         <div ref={ref}>
           {children}
-          <button onClick={setOff}>Close</button>
+          {!hideClose && <button onClick={setOff}>Close</button>}
         </div>
       )}
       <button onClick={toggle}>toggle</button>
@@ -60,15 +66,10 @@ const Inner: FC<{ clickOutsideDeactivates?: boolean }> = ({
   )
 }
 
-const FocusTrapComponent: FC<{ clickOutsideDeactivates?: boolean }> = ({
-  children,
-  clickOutsideDeactivates,
-}) => {
+const FocusTrapComponent: FC<TestProps> = (props) => {
   return (
     <FocusTrapProvider>
-      <Inner clickOutsideDeactivates={clickOutsideDeactivates}>
-        {children}
-      </Inner>
+      <Inner {...props} />
     </FocusTrapProvider>
   )
 }
@@ -187,7 +188,7 @@ describe('useFocusTrap', () => {
 
   describe('cycle focus when tabbing', () => {
     const CycleFocus = () => (
-      <FocusTrapComponent>
+      <FocusTrapComponent hideClose>
         <Surface>
           <button>First</button>
           <input type="text" />

--- a/packages/components/src/utils/useTrapStack.ts
+++ b/packages/components/src/utils/useTrapStack.ts
@@ -33,7 +33,7 @@ export interface UseTrapStackProps<
   E extends HTMLElement = HTMLElement,
   O extends {} = {}
 > {
-  context: Context<TrapStackContextProps>
+  context: Context<TrapStackContextProps<O>>
   /**
    * Turns off functionality completely, for use in components
    * where trap behavior can be optionally disabled


### PR DESCRIPTION
The [Focus Trap refactor](https://github.com/looker-open-source/components/pull/1644) introduced a bug in the "return focus" behavior. When a trap was activated while a another trap was already active – e.g. a nested menu – the reference to original return focus element was lost. When both focus traps were deactivated (pressing the escape key on a nested menu) focus just landed on `<body>` instead of the menu button.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [x] a11y impacts
