### PR TITLE
test: Combobox useKeyDown coverage

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMulti.test.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMulti.test.tsx
@@ -92,18 +92,26 @@ describe('<ComboboxMulti/> with values', () => {
     fireEvent.click(document)
   })
 
-  test('Removes existing values via option click', () => {
+  test('Removes existing values via option click or enter key', () => {
     renderComboboxMulti()
     const input = screen.getByPlaceholderText('Type here')
-    fireEvent.mouseDown(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
 
-    const bar = screen.getAllByText('Bar')[0]
-
-    fireEvent.click(bar)
-
-    expect(handleClick).toHaveBeenCalledTimes(1)
     expect(handleChange).toHaveBeenCalledTimes(1)
     expect(handleChange).toHaveBeenCalledWith([{ label: 'Qux', value: '104' }])
+
+    fireEvent.mouseDown(input)
+    const qux = screen.getAllByText('Qux')[0]
+    fireEvent.click(qux)
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+    expect(handleChange).toHaveBeenCalledTimes(2)
+    expect(handleChange).toHaveBeenNthCalledWith(2, [
+      { label: 'Bar', value: '102' },
+    ])
 
     // Close popover to silence act() warning
     fireEvent.click(document)

--- a/packages/components/src/Form/Inputs/Combobox/utils/useKeyDown.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useKeyDown.ts
@@ -56,6 +56,7 @@ export function useKeyDown() {
   function checkOnChange() {
     if (onChange) {
       if (context.transition) {
+        // not Multi
         ;(onChange as ComboboxCallback)(navigationOption)
       } else {
         const newOptions = xorWith(
@@ -131,15 +132,13 @@ export function useKeyDown() {
         // Don't scroll the page
         event.preventDefault()
 
-        // If the developer didn't render any options, there's no point in
-        // trying to navigate--but seriously what the heck? Give us some
-        // options fam.
-        if (options.length === 0) {
-          return
-        }
-
         if (state === ComboboxState.IDLE) {
-          transition && transition(ComboboxActionType.NAVIGATE)
+          // Opening a closed list
+          transition &&
+            transition(ComboboxActionType.NAVIGATE, {
+              persistSelection:
+                persistSelectionPropRef && persistSelectionPropRef.current,
+            })
         } else {
           const index = navigationOption
             ? findIndex(options, ['value', navigationOption.value])


### PR DESCRIPTION
Improves coverage for `Combobox/utils/useKeyDown` via new & updated tests in `Combobox.test.tsx` & `ComboboxMulti.test.tsx`

And, what do you know, because coverage was bad, there was a bug! Arrow Up should open a closed, focused `Combobox`, but it was broken. You can test the issue on a [basic Select here](https://looker-open-source.github.io/components/latest/components/forms/input-select) and the fix on the same page locally. To get a closed, focused `Select`, tab navigate to it or click it then hit Escape.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
