### PR TITLE
test: Add eslint 'i18next/no-literal-string' rule for automatic i18n checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,12 +24,46 @@
 
  */
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ignoreProps = require('./config/i18nIgnoredProps.js')
+
 module.exports = {
   extends: ['@looker/eslint-config', '@looker/eslint-config/license-header'],
   overrides: [
     {
       files: ['www/**/*.ts', 'www/**/*.tsx'],
       rules: {},
+    },
+    {
+      files: ['packages/*/src/**/*.tsx', 'packages/*/src/**/*.ts'],
+      rules: {
+        'i18next/no-literal-string': [
+          2,
+          {
+            ignoreAttribute: ignoreProps,
+            ignoreComponent: ['HyphenWrapper', 'Icon', 'WarningIcon'],
+            markupOnly: true,
+          },
+        ],
+      },
+    },
+    {
+      files: [
+        '*.test.*',
+        '*.spec.*',
+        '*.story.*',
+        '*.js',
+        '**/__mocks__/**',
+        '**/stories/**',
+        'packages/components-theme-editor/**',
+        'packages/design-tokens/**',
+        'packages/storybook-config/**',
+        'www/**',
+        'www/**',
+      ],
+      rules: {
+        'i18next/no-literal-string': 'off',
+      },
     },
   ],
   rules: {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "flexbox",
     "focusable",
     "frontmatter",
+    "haspopup",
     "labeledby",
     "labelledby",
     "nomarker",

--- a/config/i18nIgnoredProps.js
+++ b/config/i18nIgnoredProps.js
@@ -1,0 +1,176 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+const ours = [
+  'icon',
+  'iconBefore',
+  'iconAfter',
+  'gap',
+  'grid-area',
+  'textDecoration',
+]
+const aria = [
+  'aria-autocomplete',
+  'aria-haspopup',
+  'aria-hidden',
+  'aria-live',
+  'aria-orientation',
+]
+const react = ['data-autofocus', 'data-testid', 'htmlFor']
+const styledComponents = ['as']
+const htmlXml = ['autoComplete', 'fill', 'role', 'xmlns']
+
+const styledSystem = [
+  'alignContent',
+  'alignItems',
+  'alignSelf',
+  'background',
+  'backgroundColor',
+  'backgroundImage',
+  'backgroundPosition',
+  'backgroundRepeat',
+  'backgroundSize',
+  'bg',
+  'bgImage',
+  'bgPosition',
+  'bgRepeat',
+  'bgSize',
+  'border',
+  'borderBottom',
+  'borderBottomColor',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'borderBottomStyle',
+  'borderBottomWidth',
+  'borderColor',
+  'borderLeft',
+  'borderLeftColor',
+  'borderLeftStyle',
+  'borderLeftWidth',
+  'borderRadius',
+  'borderRight',
+  'borderRightColor',
+  'borderRightStyle',
+  'borderRightWidth',
+  'borderStyle',
+  'borderTop',
+  'borderTopColor',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderTopStyle',
+  'borderTopWidth',
+  'borderWidth',
+  'borderX',
+  'borderY',
+  'bottom',
+  'boxShadow',
+  'color',
+  'display',
+  'flex',
+  'flexBasis',
+  'flexDirection',
+  'flexGrow',
+  'flexShrink',
+  'flexWrap',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontWeight',
+  'gridArea',
+  'gridAutoColumns',
+  'gridAutoFlow',
+  'gridAutoRows',
+  'gridColumn',
+  'gridColumnGap',
+  'gridGap',
+  'gridRow',
+  'gridRowGap',
+  'gridTemplateAreas',
+  'gridTemplateColumns',
+  'gridTemplateRows',
+  'height',
+  'justifyContent',
+  'justifyItems',
+  'justifySelf',
+  'left',
+  'letterSpacing',
+  'lineHeight',
+  'm',
+  'margin',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'marginX',
+  'marginY',
+  'maxHeight',
+  'maxWidth',
+  'mb',
+  'minHeight',
+  'minWidth',
+  'ml',
+  'mr',
+  'mt',
+  'mx',
+  'my',
+  'opacity',
+  'order',
+  'overflow',
+  'overflowX',
+  'overflowY',
+  'p',
+  'padding',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'paddingX',
+  'paddingY',
+  'pb',
+  'pl',
+  'position',
+  'pr',
+  'pt',
+  'px',
+  'py',
+  'right',
+  'size',
+  'textAlign',
+  'textShadow',
+  'top',
+  'verticalAlign',
+  'width',
+  'zIndex',
+]
+
+module.exports = [
+  ...aria,
+  ...ours,
+  ...htmlXml,
+  ...react,
+  ...styledComponents,
+  ...styledSystem,
+]

--- a/packages/components/src/Dialog/Confirm/ConfirmationDialog.tsx
+++ b/packages/components/src/Dialog/Confirm/ConfirmationDialog.tsx
@@ -87,12 +87,10 @@ export interface ConfirmationDialogProps extends ConfirmationProps {
 
 export const ConfirmationDialog: FC<ConfirmationDialogProps> = (props) => {
   const { t } = useTranslation('ConfirmationDialog')
-  const cancelLabelText = t('Cancel')
-  const confirmLabelText = t('Confirm')
   const {
-    cancelLabel = cancelLabelText,
+    cancelLabel = t('Cancel'),
     close,
-    confirmLabel = confirmLabelText,
+    confirmLabel = t('Confirm'),
     buttonColor = 'key',
     cancelColor = 'neutral',
     isOpen = false,

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -60,6 +60,7 @@ module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   plugins: [
     '@typescript-eslint',
+    'i18next',
     'jest-dom',
     'prettier',
     'react-hooks',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,6 +32,7 @@
     "eslint-import-resolver-typescript": "^2.3.0",
     "eslint-import-resolver-webpack": "^0.13.0",
     "eslint-plugin-header": "^3.1.0",
+    "eslint-plugin-i18next": "^5.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest-dom": "3.6.5",
     "eslint-plugin-mdx": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9632,6 +9632,13 @@ eslint-plugin-header@^3.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.1.0.tgz#5e6819489a7722ae0c5c237387f78350d755c1d5"
   integrity sha512-jKKcwMsB0/ftBv3UVmuQir1f8AmXzTS9rdzPkileW8/Nz9ivdea8vOU1ZrMbX+WH6CpwnHEo3403baSHk40Mag==
 
+eslint-plugin-i18next@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-i18next/-/eslint-plugin-i18next-5.0.0.tgz#e87cf6a42603ed1513b87a3de91104d55ae5da50"
+  integrity sha512-ixbgSMrSb0dZsO6WPElg4JvPiQKLDA3ZpBuayxToADan1TKcbzKXT2A42Vyc0lEDhJRPL6uZnmm8vPjODDJypg==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-import@^2.22.0, eslint-plugin-import@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
@@ -19397,6 +19404,11 @@ requireindex@^1.2.0, requireindex@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
   integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requirejs-config-file@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Adds in automated linting for i18n

Definitely not perfect but still helpful (I think). Currently flags 12 failures that I think are legitmate.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] Includes test coverage for all changes
- [ ] Documentation updated
- [ ] i18n impacts
- [ ] a11y impacts
