### PR TITLE
feat: Add label to Dialog

### DIFF
--- a/packages/components/src/Dialog/Dialog.test.tsx
+++ b/packages/components/src/Dialog/Dialog.test.tsx
@@ -48,11 +48,12 @@ describe('Dialog', () => {
   })
 
   test('defaultOpen', async () => {
-    renderWithTheme(<Dialog defaultOpen content={<SimpleContent />} />)
-    expect(screen.queryByText('Dialog content')).toBeInTheDocument()
-    const doneButton = screen.getByText('Done')
+    renderWithTheme(<Dialog defaultOpen content={<DialogMediumContent />} />)
+    expect(screen.queryByText(/We the People/)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/The Constitution/)).toBeInTheDocument()
+    const doneButton = screen.getByText('Done Reading')
     fireEvent.click(doneButton)
-    await waitForElementToBeRemoved(() => screen.getByText('Dialog content'))
+    await waitForElementToBeRemoved(() => screen.getByText(/We the People/))
   })
 
   test('Dialog can be opened & closed', async () => {

--- a/packages/components/src/Dialog/Dialog.test.tsx
+++ b/packages/components/src/Dialog/Dialog.test.tsx
@@ -50,7 +50,11 @@ describe('Dialog', () => {
   test('defaultOpen', async () => {
     renderWithTheme(<Dialog defaultOpen content={<DialogMediumContent />} />)
     expect(screen.queryByText(/We the People/)).toBeInTheDocument()
-    expect(screen.queryByLabelText(/The Constitution/)).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/The Constitution/, {
+        selector: '[role="dialog"]',
+      })
+    ).toBeInTheDocument()
     const doneButton = screen.getByText('Done Reading')
     fireEvent.click(doneButton)
     await waitForElementToBeRemoved(() => screen.getByText(/We the People/))

--- a/packages/components/src/Dialog/DialogContext.ts
+++ b/packages/components/src/Dialog/DialogContext.ts
@@ -29,10 +29,12 @@ import noop from 'lodash/noop'
 
 export interface DialogContextProps {
   closeModal: () => void
+  dialogId: string
 }
 
 const dialogContext: DialogContextProps = {
   closeModal: () => noop,
+  dialogId: '',
 }
 
 export const DialogContext = createContext(dialogContext)

--- a/packages/components/src/Dialog/DialogContext.ts
+++ b/packages/components/src/Dialog/DialogContext.ts
@@ -29,12 +29,16 @@ import noop from 'lodash/noop'
 
 export interface DialogContextProps {
   closeModal: () => void
-  dialogId: string
+  /**
+   * Used to connect the DialogHeader's title to the Dialog's `aria-labelledby`
+   * @private
+   */
+  id: string
 }
 
 const dialogContext: DialogContextProps = {
   closeModal: () => noop,
-  dialogId: '',
+  id: '',
 }
 
 export const DialogContext = createContext(dialogContext)

--- a/packages/components/src/Dialog/Layout/DialogHeader.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader.tsx
@@ -66,12 +66,13 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
   ...props
 }) => {
   const { t } = useTranslation('DialogHeader')
-  const { closeModal } = useContext(DialogContext)
+  const { closeModal, dialogId } = useContext(DialogContext)
   const { id } = props
 
   return (
-    <header {...omitStyledProps(props)}>
+    <div {...omitStyledProps(props)}>
       <Heading
+        id={dialogId ? `${dialogId}-heading` : undefined}
         as="h3"
         mr="xlarge"
         fontSize={fontSize}
@@ -97,7 +98,7 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
           </Detail>
         )
       )}
-    </header>
+    </div>
   )
 }
 

--- a/packages/components/src/Dialog/Layout/DialogHeader.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader.tsx
@@ -68,11 +68,12 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
   const { t } = useTranslation('DialogHeader')
   const { closeModal, dialogId } = useContext(DialogContext)
   const { id } = props
+  const headingId = dialogId ? `${dialogId}-heading` : undefined
 
   return (
-    <div {...omitStyledProps(props)}>
+    <header aria-labelledby={headingId} {...omitStyledProps(props)}>
       <Heading
-        id={dialogId ? `${dialogId}-heading` : undefined}
+        id={headingId}
         as="h3"
         mr="xlarge"
         fontSize={fontSize}
@@ -98,7 +99,7 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
           </Detail>
         )
       )}
-    </div>
+    </header>
   )
 }
 

--- a/packages/components/src/Dialog/Layout/DialogHeader.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader.tsx
@@ -66,7 +66,7 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
   ...props
 }) => {
   const { t } = useTranslation('DialogHeader')
-  const { closeModal, dialogId } = useContext(DialogContext)
+  const { closeModal, id: dialogId } = useContext(DialogContext)
   const { id } = props
   const headingId = dialogId ? `${dialogId}-heading` : undefined
 

--- a/packages/components/src/Dialog/SurfaceBase.tsx
+++ b/packages/components/src/Dialog/SurfaceBase.tsx
@@ -30,7 +30,7 @@ import styled, { css } from 'styled-components'
 import { useGlobalHotkeys } from '../utils'
 import { DialogContext } from './DialogContext'
 
-const SurfaceLayout: FC<{ className?: string }> = (props) => {
+const SurfaceLayout: FC<{ className?: string; id?: string }> = (props) => {
   const { closeModal } = useContext(DialogContext)
 
   const ref = useRef<null | HTMLDivElement>(null)

--- a/packages/components/src/Dialog/stories/Dialog.story.tsx
+++ b/packages/components/src/Dialog/stories/Dialog.story.tsx
@@ -62,6 +62,7 @@ export const MediumContent = Template.bind({})
 MediumContent.args = {
   content: <DialogMediumContent />,
   defaultOpen: true,
+  id: 'CustomDialogId',
 }
 MediumContent.parameters = { docs: { disable: true } }
 

--- a/packages/components/src/Dialog/useDialog.tsx
+++ b/packages/components/src/Dialog/useDialog.tsx
@@ -31,6 +31,7 @@ import {
   useAnimationState,
   useControlWarn,
   useFocusTrap,
+  useID,
   useScrollLock,
 } from '../utils'
 import { Backdrop } from './Backdrop'
@@ -78,6 +79,11 @@ export interface UseDialogBaseProps {
    * Specify a callback to be called each time this Popover is closed
    */
   canClose?: () => boolean
+
+  /**
+   * The id of the dialog (if absent, a random id will be generated)
+   */
+  id?: string
 }
 
 export interface UseDialogProps extends UseDialogBaseProps, DialogSurfaceProps {
@@ -116,6 +122,7 @@ export const useDialog = ({
   setOpen: controlledSetOpen,
   Surface: CustomSurface,
   placement,
+  id,
   ...surfaceProps
 }: UseDialogPropsInternal): UseDialogResponse => {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(defaultOpen)
@@ -169,15 +176,20 @@ export const useDialog = ({
 
   const RenderSurface = CustomSurface || DialogSurface
 
+  const dialogId = useID(id)
+
   const dialog = renderDOM && (
     <DialogContext.Provider
       value={{
         closeModal: handleClose,
+        dialogId,
       }}
     >
       <Portal ref={portalRef}>
         <Backdrop className={className} onClick={handleClose} />
         <RenderSurface
+          id={dialogId}
+          aria-labelledby={`${dialogId}-heading`}
           aria-busy={busy ? true : undefined}
           className={className}
           placement={placement as DialogPlacements}

--- a/packages/components/src/Dialog/useDialog.tsx
+++ b/packages/components/src/Dialog/useDialog.tsx
@@ -182,7 +182,7 @@ export const useDialog = ({
     <DialogContext.Provider
       value={{
         closeModal: handleClose,
-        dialogId,
+        id: dialogId,
       }}
     >
       <Portal ref={portalRef}>

--- a/packages/components/src/Popover/usePopover.tsx
+++ b/packages/components/src/Popover/usePopover.tsx
@@ -44,6 +44,7 @@ import {
   UsePopperProps,
   useScrollLock,
   useForkedRef,
+  useID,
 } from '../utils'
 import { usePopoverToggle, UsePopoverToggleProps } from './usePopoverToggle'
 import { useVerticalSpace } from './useVerticalSpace'
@@ -102,6 +103,11 @@ export interface UsePopoverProps extends UsePopoverToggleProps {
    * @private
    */
   surface?: typeof OverlaySurface
+
+  /**
+   * The id of the dialog (if absent, a random id will be generated)
+   */
+  id?: string
 }
 
 const useOpenWithoutElement = (
@@ -144,6 +150,7 @@ export const usePopover = ({
   scrollLock = true,
   cancelClickOutside,
   surface,
+  id,
 }: UsePopoverProps) => {
   const [scrollElement, scrollRef] = useScrollLock({ disabled: !scrollLock })
   const [, focusRef] = useFocusTrap({ disabled: !focusTrap })
@@ -226,10 +233,13 @@ export const usePopover = ({
 
   const SurfaceComponent = surface || OverlaySurface
 
+  const dialogId = useID(id)
+
   const popover = content && !openWithoutElem && isOpen && !disabled && (
     <DialogContext.Provider
       value={{
         closeModal: handleClose,
+        dialogId,
       }}
     >
       <Portal ref={scrollRef}>

--- a/packages/components/src/Popover/usePopover.tsx
+++ b/packages/components/src/Popover/usePopover.tsx
@@ -239,7 +239,7 @@ export const usePopover = ({
     <DialogContext.Provider
       value={{
         closeModal: handleClose,
-        dialogId,
+        id: dialogId,
       }}
     >
       <Portal ref={scrollRef}>


### PR DESCRIPTION
### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] Includes test coverage for all changes
- [x] Documentation updated
- [x] i18n impacts
- [x] a11y impacts

Storybook DialogHeader inherits Dialog id:
![image](https://user-images.githubusercontent.com/24406097/108261664-cac51700-7118-11eb-9c5d-f887be434c4f.png)

Screen reader reads labelled Dialog:
![image](https://user-images.githubusercontent.com/24406097/108261630-bf71eb80-7118-11eb-8933-dfac8f42de72.png)