### PR TITLE
fix(Select): Text highlighted when focused via keyboard

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  FocusEvent,
   MouseEvent as ReactMouseEvent,
   useRef,
   useContext,
@@ -57,7 +58,7 @@ export function useInputEvents<
     disabled,
     // highlights all the text in the box on click when true
     selectOnClick = false,
-    readOnly = false,
+    inputReadOnly = false,
     // wrapped events
     onClick,
     onMouseDown,
@@ -84,8 +85,16 @@ export function useInputEvents<
 
   const handleBlur = useBlur(context)
 
-  function handleFocus() {
-    if (!readOnly && selectOnClick) {
+  function handleFocus(e: FocusEvent<HTMLInputElement>) {
+    if (inputReadOnly) {
+      // User can't type in the input so deselect the text
+      // if it gets naturally selected from focusing via keyboard
+      const input = e.currentTarget
+      input.selectionStart = input.selectionEnd
+    } else if (selectOnClick) {
+      // If user can type in the input, and selectOnClick is true,
+      // a newly focused input should select the text on next click
+      // because the user is likely to want to replace it
       selectOnClickRef.current = true
     }
 


### PR DESCRIPTION
The text in a `Select` (_without_ `isFilterable`) gets inappropriately highlighted when focused via keyboard, which is default browser behavior for text inputs. This change actively deselects the text when `inputReadOnly` on `ComboboxInput` is true – which corresponds to `isFilterable` on `Select` is undefined or false.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
