### PR TITLE
fix: Removed 'label' from CompatibleHTMLProps interface

### DIFF
--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -62,6 +62,10 @@ export interface IconProps
    * Used as the aria-label value for the icon
    */
   label?: string
+  /**
+   * Name of the icon type from our components Icon Library:
+   * https://looker-open-source.github.io/components/latest/components/content/icon/
+   */
   name?: IconNames
   /**
    * Explicitly specify a title for the SVG rendered by the icon.

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -58,6 +58,10 @@ export interface IconProps
    */
   artwork?: ReactNode
   color?: string
+  /**
+   * Used as the aria-label value for the icon
+   */
+  label?: string
   name?: IconNames
   /**
    * Explicitly specify a title for the SVG rendered by the icon.

--- a/packages/components/src/Tree/Tree.test.tsx
+++ b/packages/components/src/Tree/Tree.test.tsx
@@ -31,7 +31,7 @@ import { Button } from '../Button'
 import { Tree } from '.'
 
 describe('Tree', () => {
-  test('Renders disclosure label and detail', () => {
+  test('Renders string disclosure label and detail', () => {
     renderWithTheme(
       <Tree label="Tree Label" detail="Tree Detail">
         Hello World
@@ -40,6 +40,16 @@ describe('Tree', () => {
 
     screen.getByText('Tree Label')
     screen.getByText('Tree Detail')
+  })
+
+  test('Renders JSX Element disclosure label', () => {
+    renderWithTheme(
+      <Tree label={<div>Tree JSX Label</div>} detail="Tree Detail">
+        Hello World
+      </Tree>
+    )
+
+    screen.getByText('Tree JSX Label')
   })
 
   test('Renders and hides children on disclosure click', () => {

--- a/packages/components/src/Tree/types.ts
+++ b/packages/components/src/Tree/types.ts
@@ -24,6 +24,7 @@
 
  */
 
+import { ReactNode } from 'react'
 import { AccordionProps } from '../Accordion'
 import { ListItemProps } from '../List'
 
@@ -49,4 +50,8 @@ export interface TreeProps
    * @default false
    */
   dividers?: boolean
+  /**
+   * Label text or element displayed within Tree's internal AccordionDisclosure
+   */
+  label: ReactNode
 }

--- a/packages/design-tokens/src/system/index.ts
+++ b/packages/design-tokens/src/system/index.ts
@@ -61,7 +61,7 @@ export type {
 
 export type CompatibleHTMLProps<T> = Omit<
   HTMLProps<T>,
-  'as' | 'color' | 'height' | 'ref' | 'size' | 'width'
+  'as' | 'color' | 'height' | 'label' | 'ref' | 'size' | 'width'
 >
 
 export { userSelect } from './userSelect'


### PR DESCRIPTION
This also meant adding the label prop to both `Tree` and `Icon` since they can still accept those as props.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [ ] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [ ] not applicable
