### PR TITLE
chore(List): Exported listItemDimensions util function

### DIFF
--- a/packages/components/src/List/index.ts
+++ b/packages/components/src/List/index.ts
@@ -26,3 +26,4 @@
 
 export * from './List'
 export * from './ListItem'
+export { listItemDimensions } from './utils'

--- a/packages/components/src/List/utils/listItemDimensions.ts
+++ b/packages/components/src/List/utils/listItemDimensions.ts
@@ -80,5 +80,9 @@ export const densities = {
   '1': densityPositive1,
 }
 
+/**
+ * Returns an object with size and spacing scaled to "density" parameter value
+ * @param density Accepts values from -3 (smallest) to 1 (largest)
+ */
 export const listItemDimensions = (density: DensityRamp): ListItemDimensions =>
   densities[density]


### PR DESCRIPTION
If your `ListItem` / `TreeItem` / `MenuItem` has string children, those strings are automatically be styled according to our density dimensions objects. However, if a non-string ReactNode is passed in, those stylings don't take affect (since we don't wrap non-string ReactNode children in a Truncate + Text wrapper).

Exposing the `listItemDimensions` function provides a way for non-string ReactNode children to stay consistent with a given density's intended dimensions.