### PR TITLE
fix(ListItem): Removed reset from ListItemWrapper

### DIFF
--- a/packages/components/src/List/ListItemDetail.tsx
+++ b/packages/components/src/List/ListItemDetail.tsx
@@ -35,6 +35,7 @@ export const ListItemDetail = styled.div.attrs<PaddingProps>((props) => ({
   align-items: center;
   color: ${({ theme: { colors } }) => colors.text1};
   display: flex;
-  font-size: ${({ theme: { fontSizes } }) => fontSizes.xsmall};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.xsmall};
   margin-left: auto;
 `

--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import { CompatibleHTMLProps, reset } from '@looker/design-tokens'
+import { CompatibleHTMLProps } from '@looker/design-tokens'
 import omit from 'lodash/omit'
 import React, { forwardRef, ReactNode, Ref } from 'react'
 import styled from 'styled-components'
@@ -83,7 +83,6 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
 
   & > button,
   & > a {
-    ${reset}
     ${listItemBackgroundColor}
 
     align-items: center;


### PR DESCRIPTION
Currently, the `${reset}` CSS is removing vertical and right padding, which makes the internal button / a element within `ListItem` much shorter than it should be. Removing the `${reset}` from `ListItemWrapper` should resolve this issue and allow us to proceed with the HT upgrade PR.

**Note:** The relevant snapshot changes to `List` and `Menu` have to do with the "detail" string fonts changing in various snapshots from what I can tell.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
