### PR TITLE
fix(ListItem): Set background of disabled ListItemWrapper to transparent

### DIFF
--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -77,9 +77,6 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
   min-height: ${({ height }) => height}px;
   outline: none;
   text-decoration: none;
-  transition: ${({ theme: { easings, transitions } }) =>
-    `background ${transitions.quick}ms ${easings.ease},
-  color ${transitions.quick}ms ${easings.ease}`};
 
   & > button,
   & > a {
@@ -96,9 +93,11 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
     font-weight: inherit;
     min-width: 0;
     outline: none;
-
     text-align: left;
     text-decoration: none;
+    transition: ${({ theme: { easings, transitions } }) =>
+      `background ${transitions.quick}ms ${easings.ease},
+  color ${transitions.quick}ms ${easings.ease}`};
     width: 100%;
 
     &:hover,
@@ -157,7 +156,6 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
     }
 
     &:hover {
-      background: transparent;
       color: ${({ theme: { colors } }) => colors.text1};
     }
   }

--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -157,7 +157,7 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
     }
 
     &:hover {
-      background: ${({ theme: { colors } }) => colors.background};
+      background: transparent;
       color: ${({ theme: { colors } }) => colors.text1};
     }
   }

--- a/packages/components/src/List/utils/listItemBackgroundColor.ts
+++ b/packages/components/src/List/utils/listItemBackgroundColor.ts
@@ -56,6 +56,6 @@ export const listItemBackgroundColor = ({
   else renderedColor = 'transparent'
 
   return css`
-    background-color: ${renderedColor};
+    background: ${renderedColor};
   `
 }


### PR DESCRIPTION
In the even that `theme.colors.background` does not match the actual background color of a ListItem's container (like with the "Copy my dash" modal), hovering over a disabled item produces a hover background:
![Screen Shot 2021-02-18 at 7 03 01 PM](https://user-images.githubusercontent.com/16812885/108451586-ed8c2400-721b-11eb-94b5-d3bcb0867629.png)

Setting the `background-color` to "transparent" when a `ListItem` is disabled and hovered should get the look we want (i.e. no hover background when an item is disabled).

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [ ] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [ ] not applicable
