### PR TITLE
fix: Focusing hidden input element

### DIFF
--- a/packages/components-providers/src/FocusTrap/utils.ts
+++ b/packages/components-providers/src/FocusTrap/utils.ts
@@ -31,7 +31,7 @@
 // 2. No need for most of the configurable features
 // 3. The text of an input should not be selected on focus if it is readonly
 
-import { tabbable, isFocusable, FocusableElement } from 'tabbable'
+import { tabbable, isFocusable, FocusableElement, isTabbable } from 'tabbable'
 import { Trap } from '../TrapStack/types'
 import { FocusTrapOptions } from './types'
 
@@ -84,9 +84,14 @@ export const activateFocusTrap = ({
     }
 
     // Without autofocus, fallback to a tabbable node by priority, if one exists.
-    const firstInputElement = element.querySelector('input, textarea, select')
-    if (firstInputElement) {
-      return firstInputElement
+    const inputElements = Array.from(
+      element.querySelectorAll('input, textarea, select')
+    )
+    const tabbableInputElement = inputElements.find((inputElement) =>
+      isTabbable(inputElement)
+    )
+    if (tabbableInputElement) {
+      return tabbableInputElement
     }
 
     const footerElement = element.querySelector('footer')

--- a/packages/components/src/utils/useFocusTrap.test.tsx
+++ b/packages/components/src/utils/useFocusTrap.test.tsx
@@ -109,7 +109,13 @@ describe('useFocusTrap', () => {
     })
 
     describe('focus starts on tabbable element by priority', async () => {
-      const inputElement = <FieldText label="Text field" />
+      const inputElements = (
+        <>
+          <input type="hidden" />
+          <FieldText label="Hidden text field" style={{ display: 'none' }} />
+          <FieldText label="Text field" />
+        </>
+      )
       const footerElement = (
         <footer>
           <button>Footer button</button>
@@ -123,7 +129,7 @@ describe('useFocusTrap', () => {
             <Surface>
               {firstTabbableElement}
               {footerElement}
-              {inputElement}
+              {inputElements}
             </Surface>
           </FocusTrapComponent>
         )


### PR DESCRIPTION
Fixes the `web/components/SessionTimeoutModal/SessionTimeoutModal.spec.tsx` test failure from the integration PR. The test was failing, because the focus logic is targeting a [hidden input](https://github.com/looker/helltool/blob/master/web/components/SessionTimeoutModal/components/DataMethodForm.tsx#L27).

![image](https://user-images.githubusercontent.com/24406097/108784675-c63b9c80-7524-11eb-894d-f9469b9a9c9c.png)


### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
