### PR TITLE
refactor: Remove react-resize-detector dependency

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,6 @@
     "react-day-picker": "^7.4.8",
     "react-hotkeys-hook": "2.3.1",
     "react-i18next": "^11.8.5",
-    "react-resize-detector": "^5.2.0",
     "resize-observer-polyfill": "^1.5.1",
     "styled-system": "^5.1.5",
     "uuid": "^8.3.2"

--- a/packages/components/src/Dialog/Layout/DialogContent.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.test.tsx
@@ -29,6 +29,32 @@ import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
 import { DialogContent } from './DialogContent'
 
+const originalScrollHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'scrollHeight'
+)
+
+const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'offsetHeight'
+)
+
+afterAll(() => {
+  originalScrollHeight &&
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'scrollHeight',
+      originalScrollHeight
+    )
+
+  originalOffsetHeight &&
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetHeight',
+      originalOffsetHeight
+    )
+})
+
 describe('DialogContent', () => {
   test('basic', () => {
     renderWithTheme(<DialogContent>Stuff</DialogContent>)
@@ -42,5 +68,51 @@ describe('DialogContent', () => {
       </DialogContent>
     )
     expect(screen.getByText('Stuff')).toBeInTheDocument()
+  })
+
+  test('content does not have a box shadow when content does not overflow', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 0,
+    })
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 500,
+    })
+    renderWithTheme(
+      <DialogContent hasHeader hasFooter>
+        Stuff
+      </DialogContent>
+    )
+
+    expect(
+      getComputedStyle(screen.getByTestId('dialog-content')).getPropertyValue(
+        'box-shadow'
+      )
+    ).toEqual('')
+  })
+
+  test('content has a box shadow when content overflows', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 500,
+    })
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 0,
+    })
+
+    renderWithTheme(
+      <DialogContent hasHeader hasFooter>
+        Stuff
+      </DialogContent>
+    )
+
+    expect(
+      getComputedStyle(screen.getByTestId('dialog-content')).getPropertyValue(
+        'box-shadow'
+      )
+    ).toMatchInlineSnapshot(`"inset 0 -4px 4px -4px #DEE1E5"`)
   })
 })

--- a/packages/components/src/Dialog/Layout/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.tsx
@@ -31,16 +31,17 @@ import {
   reset,
   LayoutProps,
   layout,
-  omitStyledProps,
   pickStyledProps,
 } from '@looker/design-tokens'
 import React, { FC, useRef, useState, useEffect } from 'react'
 import styled, { css } from 'styled-components'
 import { useResize } from '../../utils'
 
-export interface DialogContentProps
+interface DialogStyleProps
   extends LayoutProps,
-    CompatibleHTMLProps<HTMLDivElement> {
+    CompatibleHTMLProps<HTMLDivElement> {}
+
+export interface DialogContentProps extends DialogStyleProps {
   /**
    * If the Dialog does not have a footer use this property to manually render padding
    * at the bottom of the DialogContent. (`hasFooter={false}`)
@@ -63,7 +64,7 @@ export const DialogContent: FC<DialogContentProps> = ({
   ...props
 }) => {
   const internalRef = useRef<HTMLDivElement>(null)
-  const [overflow, setOverflow] = useState(false)
+  const [hasOverflow, setHasOverflow] = useState(false)
   const [height, setHeight] = useState(0)
 
   const handleResize = () => {
@@ -77,40 +78,32 @@ export const DialogContent: FC<DialogContentProps> = ({
   useEffect(() => {
     const container = internalRef.current
     if (container) {
-      setOverflow(container.offsetHeight < container.scrollHeight)
+      setHasOverflow(container.offsetHeight < container.scrollHeight)
     }
   }, [height])
 
   return (
-    <DialogContentWrapper
-      hasOverflow={overflow}
+    <InnerDialogContent
+      hasOverflow={hasOverflow}
       ref={internalRef}
-      {...omitStyledProps(props)}
+      px={['medium', 'xlarge']}
+      pb={hasOverflow || !!hasFooter ? 'large' : 'xxxsmall'}
+      pt={hasOverflow || !!hasHeader ? 'large' : 'xxxsmall'}
+      {...pickStyledProps(props)}
     >
-      <Inner
-        px={['medium', 'xlarge']}
-        pb={overflow || !!hasFooter ? 'large' : 'xxxsmall'}
-        pt={overflow || !!hasHeader ? 'large' : 'xxxsmall'}
-        {...pickStyledProps(props)}
-      >
-        {children}
-      </Inner>
-    </DialogContentWrapper>
+      {children}
+    </InnerDialogContent>
   )
 }
 
-interface InnerProps
-  extends LayoutProps,
-    PaddingProps,
-    CompatibleHTMLProps<HTMLDivElement> {}
+interface InnerDialogContentProps extends DialogStyleProps, PaddingProps {
+  hasOverflow: boolean
+}
 
-const Inner = styled.div<InnerProps>`
+const InnerDialogContent = styled.div<InnerDialogContentProps>`
+  ${reset}
   ${layout}
   ${padding}
-`
-
-const DialogContentWrapper = styled.div<{ hasOverflow: boolean }>`
-  ${reset}
 
   flex: 1 1 auto;
   overflow: auto;

--- a/packages/components/src/Dialog/Layout/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.tsx
@@ -55,7 +55,7 @@ export interface DialogContentProps
   hasHeader?: boolean
 }
 
-const DialogContentLayout: FC<DialogContentProps> = ({
+export const DialogContent: FC<DialogContentProps> = ({
   children,
   className,
   hasFooter,
@@ -83,7 +83,7 @@ const DialogContentLayout: FC<DialogContentProps> = ({
 
   return (
     <DialogContentWrapper
-      overflow={overflow}
+      hasOverflow={overflow}
       ref={internalRef}
       {...omitStyledProps(props)}
     >
@@ -99,19 +99,24 @@ const DialogContentLayout: FC<DialogContentProps> = ({
   )
 }
 
-const Inner = styled.div<PaddingProps>`
+interface InnerProps
+  extends LayoutProps,
+    PaddingProps,
+    CompatibleHTMLProps<HTMLDivElement> {}
+
+const Inner = styled.div<InnerProps>`
+  ${layout}
   ${padding}
 `
 
-const DialogContentWrapper = styled.div<{ overflow: boolean }>`
+const DialogContentWrapper = styled.div<{ hasOverflow: boolean }>`
   ${reset}
-  ${layout}
 
   flex: 1 1 auto;
   overflow: auto;
 
-  ${({ overflow, theme }) =>
-    overflow &&
+  ${({ hasOverflow, theme }) =>
+    hasOverflow &&
     css`
       border-bottom: 1px solid ${theme.colors.ui2};
       border-top: 1px solid ${theme.colors.ui2};

--- a/packages/components/src/Dialog/Layout/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.tsx
@@ -35,7 +35,7 @@ import {
   pickStyledProps,
 } from '@looker/design-tokens'
 import React, { FC, useRef, useState, useEffect } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { useResize } from '../../utils'
 
 export interface DialogContentProps
@@ -82,8 +82,8 @@ const DialogContentLayout: FC<DialogContentProps> = ({
   }, [height])
 
   return (
-    <div
-      className={overflow ? `overflow ${className}` : className}
+    <DialogContentWrapper
+      overflow={overflow}
       ref={internalRef}
       {...omitStyledProps(props)}
     >
@@ -95,7 +95,7 @@ const DialogContentLayout: FC<DialogContentProps> = ({
       >
         {children}
       </Inner>
-    </div>
+    </DialogContentWrapper>
   )
 }
 
@@ -103,16 +103,18 @@ const Inner = styled.div<PaddingProps>`
   ${padding}
 `
 
-export const DialogContent = styled(DialogContentLayout)`
+const DialogContentWrapper = styled.div<{ overflow: boolean }>`
   ${reset}
   ${layout}
 
   flex: 1 1 auto;
   overflow: auto;
 
-  &.overflow {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
-    border-top: 1px solid ${({ theme }) => theme.colors.ui2};
-    box-shadow: inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
-  }
+  ${({ overflow, theme }) =>
+    overflow &&
+    css`
+      border-bottom: 1px solid ${theme.colors.ui2};
+      border-top: 1px solid ${theme.colors.ui2};
+      box-shadow: inset 0 -4px 4px -4px ${theme.colors.ui2};
+    `}
 `

--- a/packages/components/src/Dialog/Layout/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.tsx
@@ -31,9 +31,11 @@ import {
   reset,
   LayoutProps,
   layout,
+  omitStyledProps,
+  pickStyledProps,
 } from '@looker/design-tokens'
 import React, { FC, useRef, useState, useEffect } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { useResize } from '../../utils'
 
 export interface DialogContentProps
@@ -53,7 +55,7 @@ export interface DialogContentProps
   hasHeader?: boolean
 }
 
-export const DialogContent: FC<DialogContentProps> = ({
+const DialogContentLayout: FC<DialogContentProps> = ({
   children,
   className,
   hasFooter,
@@ -80,39 +82,37 @@ export const DialogContent: FC<DialogContentProps> = ({
   }, [height])
 
   return (
-    <DialogContentWrapper
+    <div
+      className={overflow ? `overflow ${className}` : className}
       ref={internalRef}
-      hasOverflow={overflow}
-      px={['medium', 'xlarge']}
-      pb={overflow || !!hasFooter ? 'large' : 'xxxsmall'}
-      pt={overflow || !!hasHeader ? 'large' : 'xxxsmall'}
-      {...props}
+      {...omitStyledProps(props)}
     >
-      {children}
-    </DialogContentWrapper>
+      <Inner
+        px={['medium', 'xlarge']}
+        pb={overflow || !!hasFooter ? 'large' : 'xxxsmall'}
+        pt={overflow || !!hasHeader ? 'large' : 'xxxsmall'}
+        {...pickStyledProps(props)}
+      >
+        {children}
+      </Inner>
+    </div>
   )
 }
 
-interface DialogContentWrapperProps
-  extends LayoutProps,
-    CompatibleHTMLProps<HTMLDivElement>,
-    PaddingProps {
-  hasOverflow: boolean
-}
+const Inner = styled.div<PaddingProps>`
+  ${padding}
+`
 
-const DialogContentWrapper = styled.div<DialogContentWrapperProps>`
+export const DialogContent = styled(DialogContentLayout)`
   ${reset}
   ${layout}
-  ${padding}
 
   flex: 1 1 auto;
   overflow: auto;
 
-  ${({ hasOverflow, theme }) =>
-    hasOverflow &&
-    css`
-      border-bottom: 1px solid ${theme.colors.ui2};
-      border-top: 1px solid ${theme.colors.ui2};
-      box-shadow: inset 0 -4px 4px -4px ${theme.colors.ui2};
-    `}
+  &.overflow {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
+    border-top: 1px solid ${({ theme }) => theme.colors.ui2};
+    box-shadow: inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
+  }
 `

--- a/packages/components/src/Dialog/Layout/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.tsx
@@ -90,6 +90,7 @@ export const DialogContent: FC<DialogContentProps> = ({
       pb={hasOverflow || !!hasFooter ? 'large' : 'xxxsmall'}
       pt={hasOverflow || !!hasHeader ? 'large' : 'xxxsmall'}
       {...pickStyledProps(props)}
+      data-testid="dialog-content"
     >
       {children}
     </InnerDialogContent>

--- a/packages/components/src/Dialog/Layout/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent.tsx
@@ -31,11 +31,9 @@ import {
   reset,
   LayoutProps,
   layout,
-  omitStyledProps,
-  pickStyledProps,
 } from '@looker/design-tokens'
 import React, { FC, useRef, useState, useEffect } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { useResize } from '../../utils'
 
 export interface DialogContentProps
@@ -55,7 +53,7 @@ export interface DialogContentProps
   hasHeader?: boolean
 }
 
-const DialogContentLayout: FC<DialogContentProps> = ({
+export const DialogContent: FC<DialogContentProps> = ({
   children,
   className,
   hasFooter,
@@ -82,37 +80,39 @@ const DialogContentLayout: FC<DialogContentProps> = ({
   }, [height])
 
   return (
-    <div
-      className={overflow ? `overflow ${className}` : className}
+    <DialogContentWrapper
       ref={internalRef}
-      {...omitStyledProps(props)}
+      hasOverflow={overflow}
+      px={['medium', 'xlarge']}
+      pb={overflow || !!hasFooter ? 'large' : 'xxxsmall'}
+      pt={overflow || !!hasHeader ? 'large' : 'xxxsmall'}
+      {...props}
     >
-      <Inner
-        px={['medium', 'xlarge']}
-        pb={overflow || !!hasFooter ? 'large' : 'xxxsmall'}
-        pt={overflow || !!hasHeader ? 'large' : 'xxxsmall'}
-        {...pickStyledProps(props)}
-      >
-        {children}
-      </Inner>
-    </div>
+      {children}
+    </DialogContentWrapper>
   )
 }
 
-const Inner = styled.div<PaddingProps>`
-  ${padding}
-`
+interface DialogContentWrapperProps
+  extends LayoutProps,
+    CompatibleHTMLProps<HTMLDivElement>,
+    PaddingProps {
+  hasOverflow: boolean
+}
 
-export const DialogContent = styled(DialogContentLayout)`
+const DialogContentWrapper = styled.div<DialogContentWrapperProps>`
   ${reset}
   ${layout}
+  ${padding}
 
   flex: 1 1 auto;
   overflow: auto;
 
-  &.overflow {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
-    border-top: 1px solid ${({ theme }) => theme.colors.ui2};
-    box-shadow: inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
-  }
+  ${({ hasOverflow, theme }) =>
+    hasOverflow &&
+    css`
+      border-bottom: 1px solid ${theme.colors.ui2};
+      border-top: 1px solid ${theme.colors.ui2};
+      box-shadow: inset 0 -4px 4px -4px ${theme.colors.ui2};
+    `}
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -18140,11 +18140,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-raf-schd@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
-  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
-
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -18510,16 +18505,6 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
-
-react-resize-detector@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-5.2.0.tgz#992083834432308c551a8251a2c52306d9d16718"
-  integrity sha512-PQAc03J2eyhvaiWgEdQ8+bKbbyGJzLEr70KuivBd1IEmP/iewNakLUMkxm6MWnDqsRPty85pioyg8MvGb0qC8A==
-  dependencies:
-    lodash "^4.17.20"
-    prop-types "^15.7.2"
-    raf-schd "^4.0.2"
-    resize-observer-polyfill "^1.5.1"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"


### PR DESCRIPTION
Use useResize hook to toggle the overflow styling on `DialogContent`, and remove react-resize-detector as a dependency.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
