### PR TITLE
fix(FocusTrap): Overly aggressive return focus behavior

### DIFF
--- a/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
+++ b/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
@@ -48,7 +48,7 @@ export const TrapStackProvider = <O,>({
   const registeredTrapsRef = useRef<TrapMap<O>>({})
   // Stores the current trap (element) where scrolling is allowed
   // null if no trap is active
-  const activeTrapRef = useRef<HTMLElement | null>(null)
+  const activeTrapRef = useRef<HTMLElement>()
   // Stores the callback to remove the trap behavior
   const deactivateRef = useRef<() => void>()
 
@@ -64,7 +64,7 @@ export const TrapStackProvider = <O,>({
       if (newTrap?.element !== activeTrapRef.current) {
         // Disable the existing trap and update the activeTrapRef
         // (whether there's a new trap or not)
-        activeTrapRef.current = newTrap?.element || null
+        activeTrapRef.current = newTrap?.element
         deactivateRef.current?.()
         deactivateRef.current = undefined
         // If there's a new trap, activate it and
@@ -78,7 +78,7 @@ export const TrapStackProvider = <O,>({
     const disableCurrentTrap = () => {
       deactivateRef.current?.()
       deactivateRef.current = undefined
-      activeTrapRef.current = null
+      activeTrapRef.current = undefined
     }
 
     const addTrap = (id: string, trap: Trap<O>) => {

--- a/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
+++ b/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
@@ -47,16 +47,16 @@ export const TrapStackProvider = <O,>({
   // (map of ids to elements that have traps)
   const registeredTrapsRef = useRef<TrapMap<O>>({})
   // Stores the current trap (element) where scrolling is allowed
-  // null if no trap is active
+  // undefined if no trap is active
   const activeTrapRef = useRef<HTMLElement>()
   // Stores the callback to remove the trap behavior
   const deactivateRef = useRef<() => void>()
 
   // Create the context value
   const value = useMemo(() => {
-    const getTrap = (id?: string): Trap<O> | null => {
+    const getTrap = (id?: string): Trap<O> | undefined => {
       const registeredTraps = registeredTrapsRef.current
-      return id ? registeredTraps[id] || null : getActiveTrap(registeredTraps)
+      return id ? registeredTraps[id] : getActiveTrap(registeredTraps)
     }
 
     const enableCurrentTrap = () => {

--- a/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
+++ b/packages/components-providers/src/TrapStack/TrapStackProvider.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import noop from 'lodash/noop'
 import React, { Context, ReactNode, useRef, useMemo } from 'react'
 import { Trap, TrapStackContextProps, TrapMap } from './types'
 import { getActiveTrap } from './utils'
@@ -51,7 +50,7 @@ export const TrapStackProvider = <O,>({
   // null if no trap is active
   const activeTrapRef = useRef<HTMLElement | null>(null)
   // Stores the callback to remove the trap behavior
-  const deactivateRef = useRef<() => void>(noop)
+  const deactivateRef = useRef<() => void>()
 
   // Create the context value
   const value = useMemo(() => {
@@ -62,11 +61,12 @@ export const TrapStackProvider = <O,>({
 
     const enableCurrentTrap = () => {
       const newTrap = getTrap()
-      if (newTrap !== activeTrapRef.current) {
+      if (newTrap?.element !== activeTrapRef.current) {
         // Disable the existing trap and update the activeTrapRef
         // (whether there's a new trap or not)
         activeTrapRef.current = newTrap?.element || null
-        deactivateRef.current()
+        deactivateRef.current?.()
+        deactivateRef.current = undefined
         // If there's a new trap, activate it and
         // save the deactivate function that is returned
         if (newTrap) {
@@ -76,8 +76,8 @@ export const TrapStackProvider = <O,>({
     }
 
     const disableCurrentTrap = () => {
-      deactivateRef.current()
-      deactivateRef.current = noop
+      deactivateRef.current?.()
+      deactivateRef.current = undefined
       activeTrapRef.current = null
     }
 

--- a/packages/components-providers/src/TrapStack/types.ts
+++ b/packages/components-providers/src/TrapStack/types.ts
@@ -35,7 +35,7 @@ export interface TrapStackContextProps<O extends {} = {}> {
   /**
    * Stores the element for the active trap (null if none are active)
    */
-  activeTrapRef?: MutableRefObject<HTMLElement | null>
+  activeTrapRef?: MutableRefObject<HTMLElement | undefined>
   /**
    * @private
    */

--- a/packages/components-providers/src/TrapStack/types.ts
+++ b/packages/components-providers/src/TrapStack/types.ts
@@ -33,7 +33,7 @@ export interface Trap<O extends {} = {}> {
 
 export interface TrapStackContextProps<O extends {} = {}> {
   /**
-   * Stores the element for the active trap (null if none are active)
+   * Stores the element for the active trap (undefined if none are active)
    */
   activeTrapRef?: MutableRefObject<HTMLElement | undefined>
   /**
@@ -51,7 +51,7 @@ export interface TrapStackContextProps<O extends {} = {}> {
   /**
    * @private
    */
-  getTrap?: (id: string) => Trap<O> | null
+  getTrap?: (id: string) => Trap<O> | undefined
   /**
    * @private
    */

--- a/packages/components-providers/src/TrapStack/utils.ts
+++ b/packages/components-providers/src/TrapStack/utils.ts
@@ -26,15 +26,15 @@
 import { TrapMap } from './types'
 
 export const getActiveTrap = <O extends {} = {}>(trapMap: TrapMap<O>) => {
-  // Sort the trap elements according to dom position and return the last
+  // Sort the traps according to their element's dom position and return the last
   // which we assume to be stacked on top since all components using Portal
   // share a single zIndexFloor and use dom order to determine stacking
-  const elements = Object.values(trapMap)
-  if (elements.length === 0) return null
+  const traps = Object.values(trapMap)
+  if (traps.length === 0) return
 
-  const sortedElements = elements.sort((trapA, trapB) => {
+  const sortedTraps = traps.sort((trapA, trapB) => {
     const relationship = trapA.element.compareDocumentPosition(trapB.element)
     return relationship > 3 ? 1 : -1
   })
-  return sortedElements[0] || null
+  return sortedTraps[0]
 }

--- a/packages/components/src/Dialog/useDialog.tsx
+++ b/packages/components/src/Dialog/useDialog.tsx
@@ -161,9 +161,7 @@ export const useDialog = ({
       ? controlledSetOpen
       : setUncontrolledIsOpen
 
-  const [, focusRef] = useFocusTrap({
-    options: { clickOutsideDeactivates: true },
-  })
+  const [, focusRef] = useFocusTrap({ clickOutsideDeactivates: true })
   const [, portalRef] = useScrollLock({ ref: focusRef })
 
   const handleOpen = () => setOpen(true)

--- a/packages/components/src/utils/useFocusTrap.test.tsx
+++ b/packages/components/src/utils/useFocusTrap.test.tsx
@@ -45,7 +45,7 @@ interface TestProps {
 }
 
 const Inner: FC<TestProps> = ({ children, clickOutsideDeactivates }) => {
-  const [, ref] = useFocusTrap({ options: { clickOutsideDeactivates } })
+  const [, ref] = useFocusTrap({ clickOutsideDeactivates })
   const { value, setOff, toggle } = useToggle()
   return (
     <>
@@ -108,7 +108,7 @@ describe('useFocusTrap', () => {
       )
     })
 
-    describe('focus starts on tabbable element by priority', async () => {
+    describe('focus starts on tabbable element by priority', () => {
       const inputElements = (
         <>
           <input type="hidden" />

--- a/packages/components/src/utils/useFocusTrap.ts
+++ b/packages/components/src/utils/useFocusTrap.ts
@@ -24,22 +24,26 @@
 
  */
 
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import {
   FocusTrapContext,
   FocusTrapOptions,
 } from '@looker/components-providers'
-import { useTrapStack, UseTrapStackProps } from './useTrapStack'
+import { useTrapStack, UseTrapStackBaseProps } from './useTrapStack'
 
 export const useFocusTrap = <E extends HTMLElement = HTMLElement>({
-  options,
+  clickOutsideDeactivates,
   ...props
-}: Omit<UseTrapStackProps<E, Partial<FocusTrapOptions>>, 'context'> = {}) => {
+}: UseTrapStackBaseProps<E> & { clickOutsideDeactivates?: boolean }) => {
   const returnFocusRef = useRef<Element>(null)
+  const options = useMemo(() => ({ clickOutsideDeactivates, returnFocusRef }), [
+    returnFocusRef,
+    clickOutsideDeactivates,
+  ])
   return useTrapStack<E, FocusTrapOptions>({
     context: FocusTrapContext,
     // If options.returnFocusRef is set, it will override this one
-    options: { returnFocusRef, ...options },
+    options,
     ...props,
   })
 }

--- a/packages/components/src/utils/useTrapStack.ts
+++ b/packages/components/src/utils/useTrapStack.ts
@@ -29,11 +29,9 @@ import { Context, Ref, useContext, useEffect } from 'react'
 import { useID } from './useID'
 import { useCallbackRef } from './useCallbackRef'
 
-export interface UseTrapStackProps<
-  E extends HTMLElement = HTMLElement,
-  O extends {} = {}
+export interface UseTrapStackBaseProps<
+  Element extends HTMLElement = HTMLElement
 > {
-  context: Context<TrapStackContextProps<O>>
   /**
    * Turns off functionality completely, for use in components
    * where trap behavior can be optionally disabled
@@ -42,8 +40,15 @@ export interface UseTrapStackProps<
   /**
    * A forwarded ref to be merged with the ref returned in the hook result
    */
-  ref?: Ref<E>
-  options?: O
+  ref?: Ref<Element>
+}
+
+export interface UseTrapStackProps<
+  Element extends HTMLElement = HTMLElement,
+  Options extends {} = {}
+> extends UseTrapStackBaseProps<Element> {
+  context: Context<TrapStackContextProps<Options>>
+  options?: Options
 }
 
 /**


### PR DESCRIPTION
Classic `useEffect` dependency mis-use.

[This PR](https://github.com/looker-open-source/components/pull/1886) added a `returnFocusRef` option to `useFocusTrap` in such a way that the `useEffect` in `useTrapStack` would run on every render. For a nested `disabled` focus trap (e.g. `Select`* inside a `Popover`) it would re-activate the a previous focus trap too early (and repeatedly). This PR adds a `useMemo` to fix that.

For the life of me I could not reproduce the bug in jest. But to test on https://looker-open-source.github.io/components/latest/storybook/?path=/story/fieldselect--select-demo try opening the 2nd `Select` as soon as you open the `Popover`. The 1st `Select` will keep focus as the focus trap repeatedly deactivates & re-activates. (See screen captures below.)

*`Select` has a "disabled" focus trap – i.e. it doesn't trap focus to the list because focus remains on the input. But it does disable any existing focus trap, in case focus _does_ need to move to the list, like for dragging the scrollbar thumb, and re-enables a previous focus trap when it closes.

#### Issue:
![75f646a6-655e-45ec-b7e2-d36761833ca5](https://user-images.githubusercontent.com/53451193/109047932-4bd95c80-768b-11eb-8058-9ade8f863d2d.gif)
#### Fixed:
![456541dd-c682-4c8f-8857-6ff1c9246725](https://user-images.githubusercontent.com/53451193/109047968-57c51e80-768b-11eb-8aa2-999940388ddc.gif)

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable