### PR TITLE
fix(DataTable): Sticky "columns" should display a bottom-border (firefox)

### DIFF
--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -178,9 +178,9 @@ const stickyColumns = css<TableProps>`
 `
 
 export const Table = styled(TableLayout)`
+  border-collapse: initial;
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
-  height: initial;
   line-height: 1;
   width: 100%;
 


### PR DESCRIPTION
**problem:** if page has `border-collapse: collapse;` as a global css rule. It was causing the border-bottom of the sticky first column to not display.

To see the error on PDT open the link below on Firefox
https://lenslatest.dev.looker.com/admin/pdts?connection=All%20Connections

To see the problem locally add this to: `storybook/storybook/preview-head.html`
this will make the `border-collapse` rule be placed as global to storybook.
```
<style>e
table { border-collapse: collapse }
</style>
```
then open storybook on Firefox and open the `DataTable - select-active-items` example.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
