### PR TITLE
refactor(Tree): Replaced useHovered with simpleHandlers

### DIFF
--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -93,4 +93,40 @@ describe('Accordion', () => {
     fireEvent.click(accordionLabel)
     getByText('My Accordion Content')
   })
+
+  // TODO: Move handler props to Accordion during AccordionDisclosure refactor PR
+  test('Wraps handlers passed into AccordionDisclosure', () => {
+    const handleKeyDown = jest.fn()
+    const handleKeyUp = jest.fn()
+    const handleClick = jest.fn()
+    const handleBlur = jest.fn()
+
+    const { getByText } = renderWithTheme(
+      <Accordion>
+        <AccordionDisclosure
+          onKeyDown={handleKeyDown}
+          onKeyUp={handleKeyUp}
+          onClick={handleClick}
+          onBlur={handleBlur}
+        >
+          My Accordion Label
+        </AccordionDisclosure>
+        <AccordionContent>My Accordion Content</AccordionContent>
+      </Accordion>
+    )
+
+    const accordionLabel = getByText('My Accordion Label')
+    fireEvent.click(accordionLabel)
+    expect(handleClick).toHaveBeenCalled()
+    fireEvent.blur(accordionLabel)
+    expect(handleBlur).toHaveBeenCalled()
+    fireEvent.keyDown(accordionLabel, {
+      key: 'Enter',
+    })
+    expect(handleKeyDown).toHaveBeenCalled()
+    fireEvent.keyUp(accordionLabel, {
+      key: 'Enter',
+    })
+    expect(handleKeyUp).toHaveBeenCalled()
+  })
 })

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -27,6 +27,7 @@
 import React, {
   FC,
   KeyboardEvent,
+  MouseEvent,
   useContext,
   Ref,
   forwardRef,
@@ -39,7 +40,6 @@ import {
   CompatibleHTMLProps,
   padding,
   PaddingProps,
-  pickStyledProps,
   shouldForwardProp,
   TextColorProps,
   color as colorStyleFn,
@@ -59,7 +59,7 @@ export interface AccordionDisclosureProps
 }
 
 const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, onClick, onKeyDown, onKeyUp, ...props }, ref) => {
     const [isFocusVisible, setFocusVisible] = useState(false)
     const {
       accordionContentId,
@@ -79,19 +79,23 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
     }
 
     const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-      if (event.keyCode === 13) {
-        handleToggle()
-      }
+      if (event.key === 'Enter') handleToggle()
+
+      onKeyDown && onKeyDown(event)
     }
 
     const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
-      if (event.keyCode === 9 && event.currentTarget === event.target)
+      if (event.key === 'Tab' && event.currentTarget === event.target)
         setFocusVisible(true)
+
+      onKeyUp && onKeyUp(event)
     }
 
-    const handleClick = () => {
+    const handleClick = (event: MouseEvent<HTMLElement>) => {
       setFocusVisible(false)
       handleToggle()
+
+      onClick && onClick(event)
     }
 
     const handleBlur = () => {
@@ -112,7 +116,7 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
         onKeyUp={handleKeyUp}
         ref={ref}
         tabIndex={0}
-        {...pickStyledProps(props)}
+        {...props}
       >
         <AccordionDisclosureLayout {...accordionProps} isOpen={isOpen}>
           {children}

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -25,10 +25,16 @@
  */
 
 import styled from 'styled-components'
-import React, { FC, KeyboardEvent, MouseEvent, useContext, useRef } from 'react'
+import React, {
+  FC,
+  KeyboardEvent,
+  MouseEvent,
+  useContext,
+  useRef,
+  useState,
+} from 'react'
 import { Accordion, AccordionContent, AccordionDisclosure } from '../Accordion'
-import { useHovered } from '../utils/useHovered'
-import { undefinedCoalesce } from '../utils'
+import { undefinedCoalesce, useWrapEvent } from '../utils'
 import { List } from '../List'
 import { listItemDimensions, getDetailOptions } from '../List/utils'
 import { TreeContext } from './TreeContext'
@@ -51,13 +57,14 @@ const TreeLayout: FC<TreeProps> = ({
   label: propsLabel,
   onClick,
   onKeyUp,
+  onMouseEnter,
+  onMouseLeave,
   selected,
   truncate,
   ...restProps
 }) => {
-  const disclosureRef = useRef<HTMLDivElement>(null)
   const detailRef = useRef<HTMLDivElement>(null)
-  const [isHovered] = useHovered(disclosureRef)
+  const [hovered, setHovered] = useState(false)
 
   const treeContext = useContext(TreeContext)
   const hasBorder = undefinedCoalesce([propsBorder, treeContext.border])
@@ -89,6 +96,9 @@ const TreeLayout: FC<TreeProps> = ({
       event.stopPropagation()
     }
   }
+
+  const handleMouseEnter = useWrapEvent(() => setHovered(true), onMouseEnter)
+  const handleMouseLeave = useWrapEvent(() => setHovered(false), onMouseLeave)
 
   const detail = {
     content: (
@@ -122,7 +132,12 @@ const TreeLayout: FC<TreeProps> = ({
   const indicatorColor = disabled ? 'text1' : color
   const innerAccordion = (
     <Accordion {...indicatorDefaults} {...restProps} indicatorSize={iconSize}>
-      <AccordionDisclosure color={indicatorColor} ref={disclosureRef} py="none">
+      <AccordionDisclosure
+        color={indicatorColor}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        py="none"
+      >
         {label}
       </AccordionDisclosure>
       <AccordionContent>
@@ -147,9 +162,9 @@ const TreeLayout: FC<TreeProps> = ({
         depth={depth}
         disabled={disabled}
         dividers={dividers}
-        hovered={isHovered}
-        keyColor={useKeyColor}
+        hovered={hovered}
         indicatorSize={iconSize}
+        keyColor={useKeyColor}
         selected={selected}
       >
         {innerAccordion}


### PR DESCRIPTION
`useHovered` was designed specifically for the "hidden element revealed when hovering over some other element" pattern. In `Tree`'s case, we just need simple mouseEnter and mouseLeave handlers to track hover state for styling purposes.

**Note:** Needed to update some code in `AccordionDisclosure` since it had CompatibleHTMLProps in its interface, but didn't actually pass those down to underlying DOM elements.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [ ] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [ ] not applicable
