### PR TITLE
fix: InputDate & InputDateRange accessibility improvements

### DIFF
--- a/packages/components-providers/src/I18n/resources.ts
+++ b/packages/components-providers/src/I18n/resources.ts
@@ -86,6 +86,10 @@ export const i18nResources: Resource = {
     InputDate: {
       Date: 'Date',
     },
+    InputDateRange: {
+      'End date': 'End date',
+      'Start date': 'Start date',
+    },
     InputFilters: {
       'Clear Filters': 'Clear Filters',
       'Filter List': 'Filter List',

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -35,6 +35,7 @@ import { CalendarContext } from './CalendarContext'
 import { CalendarNav } from './CalendarNav'
 import { dayPickerCss } from './dayPickerCss'
 import { CalendarNavDisabled } from './CalendarNavDisabled'
+import { formatMonthTitle } from './formatMonthTitle'
 
 export interface CalendarLocalization {
   firstDayOfWeek: number
@@ -63,7 +64,7 @@ const NoopComponent: FC = () => null
 const InternalCalendar: FC<CalendarProps> = ({
   className,
   disabled,
-  localization = {},
+  localization,
   onDayClick,
   onMonthChange,
   onNextClick,
@@ -84,14 +85,6 @@ const InternalCalendar: FC<CalendarProps> = ({
     return (...args: any[]) => (disabled ? noop() : cb(...args))
   }
 
-  const formatMonthTitle = (month: Date) => {
-    if (localization.months) {
-      return `${localization.months[month.getMonth()]} ${month.getFullYear()}`
-    } else {
-      return LocaleUtils.formatMonthTitle(month)
-    }
-  }
-
   return (
     <CalendarContext.Provider
       value={{
@@ -104,8 +97,11 @@ const InternalCalendar: FC<CalendarProps> = ({
       }}
     >
       <DayPicker
-        {...localization}
-        localeUtils={{ ...LocaleUtils, formatMonthTitle }}
+        {...(localization || {})}
+        localeUtils={{
+          ...LocaleUtils,
+          formatMonthTitle: formatMonthTitle(localization),
+        }}
         className={`${renderDateRange && 'render-date-range'} ${className}`}
         selectedDays={selectedDates}
         month={viewMonth}

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -36,12 +36,7 @@ import { CalendarNav } from './CalendarNav'
 import { dayPickerCss } from './dayPickerCss'
 import { CalendarNavDisabled } from './CalendarNavDisabled'
 import { formatMonthTitle } from './formatMonthTitle'
-
-export interface CalendarLocalization {
-  firstDayOfWeek: number
-  months: string[]
-  weekdaysShort: string[]
-}
+import { CalendarLocalization } from './types'
 
 interface CalendarProps {
   className?: string

--- a/packages/components/src/Calendar/formatMonthTitle.ts
+++ b/packages/components/src/Calendar/formatMonthTitle.ts
@@ -23,6 +23,20 @@
  SOFTWARE.
 
  */
-export * from './Calendar'
-export * from './formatMonthTitle'
-export type { CalendarSize } from './calendar-size'
+import { LocaleUtils } from 'react-day-picker'
+import { CalendarLocalization } from '@looker/components'
+
+/**
+ * Curried month formatter function.
+ * Takes a Date and returns a string containing the month and year (i.g. 'May 2021').
+ * Used to label the currently shown month and year in the Calendar component.
+ */
+export const formatMonthTitle = (localization?: CalendarLocalization) => (
+  month: Date
+) => {
+  if (localization?.months) {
+    return `${localization.months[month.getMonth()]} ${month.getFullYear()}`
+  } else {
+    return LocaleUtils.formatMonthTitle(month)
+  }
+}

--- a/packages/components/src/Calendar/formatMonthTitle.ts
+++ b/packages/components/src/Calendar/formatMonthTitle.ts
@@ -24,7 +24,7 @@
 
  */
 import { LocaleUtils } from 'react-day-picker'
-import { CalendarLocalization } from '@looker/components'
+import { CalendarLocalization } from './Calendar'
 
 /**
  * Curried month formatter function.

--- a/packages/components/src/Calendar/index.ts
+++ b/packages/components/src/Calendar/index.ts
@@ -25,4 +25,5 @@
  */
 export * from './Calendar'
 export * from './formatMonthTitle'
+export * from './types'
 export type { CalendarSize } from './calendar-size'

--- a/packages/components/src/Calendar/types.ts
+++ b/packages/components/src/Calendar/types.ts
@@ -23,20 +23,8 @@
  SOFTWARE.
 
  */
-import { LocaleUtils } from 'react-day-picker'
-import { CalendarLocalization } from './types'
-
-/**
- * Curried month formatter function.
- * Takes a Date and returns a string containing the month and year (i.g. 'May 2021').
- * Used to label the currently shown month and year in the Calendar component.
- */
-export const formatMonthTitle = (localization?: CalendarLocalization) => (
-  month: Date
-) => {
-  if (localization?.months) {
-    return `${localization.months[month.getMonth()]} ${month.getFullYear()}`
-  } else {
-    return LocaleUtils.formatMonthTitle(month)
-  }
+export interface CalendarLocalization {
+  firstDayOfWeek: number
+  months: string[]
+  weekdaysShort: string[]
 }

--- a/packages/components/src/Form/Fields/FieldDateRange/FieldDateRange.tsx
+++ b/packages/components/src/Form/Fields/FieldDateRange/FieldDateRange.tsx
@@ -53,6 +53,7 @@ const FieldDateRangeComponent = forwardRef(
         <InputDateRange
           {...omitFieldProps(props)}
           aria-describedby={`describedby-${id}`}
+          aria-labelledby={`labelledby-${id}`}
           id={id}
           validationType={validationMessage && validationMessage.type}
           ref={ref}

--- a/packages/components/src/Form/Inputs/InputDate/InputDate.test.tsx
+++ b/packages/components/src/Form/Inputs/InputDate/InputDate.test.tsx
@@ -113,13 +113,15 @@ test('value can be controlled externally', () => {
 test('user can change the selected date via text input field', () => {
   renderWithTheme(<ControlledInputDate />)
 
-  expect(screen.getByText('June 2019')).toBeInTheDocument()
+  expect(screen.getAllByText('June 2019')).toHaveLength(2)
 
   const TextInput = screen.getByDisplayValue('06/03/2019')
   fireEvent.change(TextInput, { target: { value: '01/01/2012' } })
   fireEvent.blur(TextInput) // update value on blur
 
-  expect(screen.getByText('January 2012')).toBeInTheDocument()
+  expect(
+    screen.getByText('January 2012', { selector: 'h5' })
+  ).toBeInTheDocument()
 })
 
 test('user can clear the selected date by deleting text input content', () => {
@@ -141,9 +143,9 @@ test('navigates from month to month', () => {
     value: new Date('June 3, 2019'),
   }
   renderWithTheme(<InputDate {...mockProps} />)
-  expect(screen.getByText('June 2019')).toBeInTheDocument()
+  expect(screen.getAllByText('June 2019')).toHaveLength(2)
   fireEvent.click(screen.getByText('Previous Month'))
-  expect(screen.getByText('May 2019')).toBeInTheDocument()
+  expect(screen.getAllByText('May 2019')).toHaveLength(2)
 })
 
 test('fills TextInput with defaultValue', () => {
@@ -198,7 +200,9 @@ test('localizes calendar', () => {
     <InputDate localization={localizationProps} />
   )
 
-  expect(screen.getByText('Febbraio 2020')).toBeInTheDocument()
+  expect(
+    screen.getByText('Febbraio 2020', { selector: 'h5' })
+  ).toBeInTheDocument()
   expect(
     (container.querySelector('.DayPicker-WeekdaysRow') as HTMLElement)
       .textContent

--- a/packages/components/src/Form/Inputs/InputDate/InputDate.tsx
+++ b/packages/components/src/Form/Inputs/InputDate/InputDate.tsx
@@ -37,8 +37,13 @@ import styled from 'styled-components'
 import isFunction from 'lodash/isFunction'
 import isEqual from 'lodash/isEqual'
 import { BorderProps, SpaceProps } from '@looker/design-tokens'
+import { VisuallyHidden } from '../../../VisuallyHidden'
 import { InputText } from '../InputText'
-import { Calendar, CalendarLocalization } from '../../../Calendar'
+import {
+  Calendar,
+  CalendarLocalization,
+  formatMonthTitle,
+} from '../../../Calendar'
 import { ValidationType } from '../../ValidationMessage'
 import {
   Locales,
@@ -188,11 +193,15 @@ export const InputDate: FC<InputDateProps> = forwardRef(
           readOnly={readOnly}
         />
         <CalendarWrapper>
+          <VisuallyHidden aria-live="assertive">
+            {viewMonth ? formatMonthTitle(localization)(viewMonth) : ''}
+          </VisuallyHidden>
           <Calendar
             selectedDates={selectedDate}
             onDayClick={handleDayClick}
             localization={localization}
             viewMonth={viewMonth}
+            onMonthChange={setViewMonth}
             onNowClick={handleNavClick}
             onNextClick={handleNavClick}
             onPrevClick={handleNavClick}

--- a/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
+++ b/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
@@ -40,6 +40,7 @@ import max from 'lodash/max'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import values from 'lodash/values'
+import { useTranslation } from 'react-i18next'
 import { VisuallyHidden } from '../../../VisuallyHidden'
 import { Icon } from '../../../Icon'
 import { ValidationType } from '../../ValidationMessage'
@@ -65,6 +66,7 @@ import { useID } from '../../../utils/useID'
 import { useReadOnlyWarn } from '../../../utils/useReadOnlyWarn'
 
 export interface InputDateRangeProps {
+  'aria-labelledby'?: string
   disabled?: boolean
   dateStringLocale?: Locales
   defaultValue?: Partial<RangeModifier>
@@ -139,6 +141,7 @@ const isDateRangeInView = (
 export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
   (
     {
+      'aria-labelledby': ariaLabelledby,
       dateStringLocale,
       defaultValue = {},
       disabled,
@@ -354,6 +357,10 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
       setViewMonth(transformMonth(month, viewMonthDiff))
     }
 
+    const { t } = useTranslation('InputDateRange')
+    const startDateLabelledby = `startDate-labelledby-${id}`
+    const endDateLabelledby = `startDate-labelledby-${id}`
+
     const _formatMonthTitle = formatMonthTitle(localization)
     const monthTitle = `${_formatMonthTitle(viewMonth)} ${_formatMonthTitle(
       viewNextMonth
@@ -369,6 +376,9 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
           }
         >
           <InputTextWrapper inputLength={inputs.from.value.length}>
+            <VisuallyHidden id={startDateLabelledby}>
+              {t('Start date')}
+            </VisuallyHidden>
             <InlineInputTextBase
               placeholder={`${formatDateString(
                 new Date(Date.now()),
@@ -383,12 +393,19 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
               onFocus={partial(handleTextInputFocus, 'from')}
               readOnly={readOnly}
               value={inputs.from.value}
+              aria-labelledby={`${ariaLabelledby} ${startDateLabelledby}`}
             />
           </InputTextWrapper>
-          <HyphenWrapper hasInputValues={!isEmpty(dateRange)}>
+          <HyphenWrapper
+            hasInputValues={!isEmpty(dateRange)}
+            aria-hidden="true"
+          >
             &ndash;
           </HyphenWrapper>
           <InputTextWrapper inputLength={inputs.to.value.length}>
+            <VisuallyHidden id={endDateLabelledby}>
+              {t('End date')}
+            </VisuallyHidden>
             <InlineInputTextBase
               placeholder={formatDateString(
                 new Date(Date.now()),
@@ -403,6 +420,7 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
               onFocus={partial(handleTextInputFocus, 'to')}
               readOnly={readOnly}
               value={inputs.to.value}
+              aria-labelledby={`${ariaLabelledby} ${endDateLabelledby}`}
             />
           </InputTextWrapper>
           {(inputs.from.isValid && inputs.to.isValid) || (

--- a/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
+++ b/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
@@ -359,7 +359,7 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
 
     const { t } = useTranslation('InputDateRange')
     const startDateLabelledby = `startDate-labelledby-${id}`
-    const endDateLabelledby = `startDate-labelledby-${id}`
+    const endDateLabelledby = `endDate-labelledby-${id}`
 
     const _formatMonthTitle = formatMonthTitle(localization)
     const monthTitle = `${_formatMonthTitle(viewMonth)} ${_formatMonthTitle(

--- a/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
+++ b/packages/components/src/Form/Inputs/InputDateRange/InputDateRange.tsx
@@ -40,6 +40,7 @@ import max from 'lodash/max'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import values from 'lodash/values'
+import { VisuallyHidden } from '../../../VisuallyHidden'
 import { Icon } from '../../../Icon'
 import { ValidationType } from '../../ValidationMessage'
 import {
@@ -50,7 +51,11 @@ import {
   inputTextDisabled,
 } from '../InputText'
 import { InlineInputTextBase } from '../../Inputs/InlineInputText'
-import { Calendar, CalendarLocalization } from '../../../Calendar'
+import {
+  Calendar,
+  CalendarLocalization,
+  formatMonthTitle,
+} from '../../../Calendar'
 import {
   Locales,
   formatDateString,
@@ -349,6 +354,11 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
       setViewMonth(transformMonth(month, viewMonthDiff))
     }
 
+    const _formatMonthTitle = formatMonthTitle(localization)
+    const monthTitle = `${_formatMonthTitle(viewMonth)} ${_formatMonthTitle(
+      viewNextMonth
+    )}`
+
     return (
       <InputDateRangeWrapper ref={ref}>
         <InputTextGroupWrapper
@@ -408,6 +418,7 @@ export const InputDateRange: FC<InputDateRangeProps> = forwardRef(
           )}
         </InputTextGroupWrapper>
         <MultiCalendarLayout>
+          <VisuallyHidden aria-live="assertive">{monthTitle}</VisuallyHidden>
           <CalendarWrapper>
             <Calendar
               disabled={disabled}


### PR DESCRIPTION
I'm addressing 2 concerns related to a11y with date picker component. Both InputDate and InputRangeDate are affected.

1. Read out the Month+Year, currently displayed on the calendar when it's changed (either via Previous/Next month buttons or Up/Down to change year).
2. Add labels to input texts.

InputDate:
1. Added `aria-live="polite"` to `CalendarNav` makes VO read the new Month+Year nicely.
2. No change. Already labelled.

InputRangeDate:
1. Multiple `aria-live` doesn't seem to work with VO. Only the last Month+Year is mentioned. I need some suggestions on how to address this.
2. Added `aria-labelledby` to both the Start and End date input texts.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
