### PR TITLE
fix(DataTable): Safari stick cell bug

### DIFF
--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -142,7 +142,6 @@ export const DataTableRow = styled(DataTableRowLayout)`
     background: ${({ checked, isHeaderRow, theme: { colors } }) =>
       checked && !isHeaderRow ? colors.keySubtle : colors.background};
     border-bottom: solid 1px ${(props) => props.theme.colors.ui2};
-
     &:first-of-type > div {
       border-left: 1px solid transparent;
       border-right: 1px solid transparent; /* Keeps checkbox centered */

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -180,7 +180,6 @@ const stickyColumns = css<TableProps>`
 export const Table = styled(TableLayout)`
   border-spacing: 0;
   font-size: ${({ theme }) => theme.fontSizes.small};
-  height: initial;
   line-height: 1;
   width: 100%;
 
@@ -200,6 +199,7 @@ export const Table = styled(TableLayout)`
 
   tbody td {
     color: ${({ theme }) => theme.colors.text4};
+    height: initial;
   }
 
   &.overflow {

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -199,7 +199,6 @@ export const Table = styled(TableLayout)`
 
   tbody td {
     color: ${({ theme }) => theme.colors.text4};
-    height: initial;
   }
 
   &.overflow {
@@ -207,6 +206,7 @@ export const Table = styled(TableLayout)`
       td,
       th {
         ${stickyColumns}
+        height: initial;
       }
     }
   }


### PR DESCRIPTION
in Safari the DataTable sticky cell wasn't behaving properly.
<img width="768" alt="Screen Shot 2021-02-24 at 5 20 54 PM" src="https://user-images.githubusercontent.com/23616264/109088655-acd15680-76c4-11eb-8000-1a9c82c9a356.png">

to see the error on PDT open the link below in Safari:

To repeat the error:
1. on `columns.ts` line 33
    - switch `size: 'medium',` for `size: 'nowrap',`
2. on `item.tsx` line 78
    - remove ` description={type}`
3. open storybook on `datatable--select-active-items`  in Safari and make the screen smaller so the first column is sticky. The `border-bottom` on that first column changes place.


### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
