### PR TITLE
fix(MenuList): Windowing

### DIFF
--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -451,6 +451,7 @@ export const LongMenus = () => {
       </Space>
       <Space align="start">
         <Menu
+          width={300}
           windowing={!value ? 'none' : undefined}
           content={array3000.map((item, i) => (
             <MenuItem key={i}>{item.label}</MenuItem>
@@ -459,6 +460,7 @@ export const LongMenus = () => {
           <Button>Windowing (3k)</Button>
         </Menu>
         <Menu
+          width={300}
           windowing={!value ? 'none' : undefined}
           content={array3000.map((item, i) => (
             <MenuItem key={i} description={item.description}>
@@ -469,6 +471,7 @@ export const LongMenus = () => {
           <Button>Windowing (description)</Button>
         </Menu>
         <Menu
+          width={300}
           windowing={!value ? 'none' : undefined}
           content={groups.map(({ label, items }, index) => [
             <MenuDivider key={`${label}-${index}-divider`} />,

--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -425,11 +425,6 @@ export const LongMenus = () => {
   }, [longLabels])
   return (
     <SpaceVertical align="start" p="xlarge">
-      <FieldToggleSwitch
-        on={value}
-        label="Enable windowing"
-        onChange={toggle}
-      />
       <Space>
         <Menu
           content={array95.map((item, i) => (
@@ -453,13 +448,15 @@ export const LongMenus = () => {
         >
           <Button>No windowing (groups)</Button>
         </Menu>
+      </Space>
+      <Space align="start">
         <Menu
           windowing={!value ? 'none' : undefined}
           content={array3000.map((item, i) => (
             <MenuItem key={i}>{item.label}</MenuItem>
           ))}
         >
-          <Button>Fixed Windowing (3k)</Button>
+          <Button>Windowing (3k)</Button>
         </Menu>
         <Menu
           windowing={!value ? 'none' : undefined}
@@ -469,8 +466,27 @@ export const LongMenus = () => {
             </MenuItem>
           ))}
         >
-          <Button>Fixed Windowing (description)</Button>
+          <Button>Windowing (description)</Button>
         </Menu>
+        <Menu
+          windowing={!value ? 'none' : undefined}
+          content={groups.map(({ label, items }, index) => [
+            <MenuDivider key={`${label}-${index}-divider`} />,
+            <MenuHeading key={`${label}-${index}-heading`}>
+              {label}
+            </MenuHeading>,
+            ...items.map((item, index2) => (
+              <MenuItem key={`${item.label}-${index2}`}>{item.label}</MenuItem>
+            )),
+          ])}
+        >
+          <Button>Windowing (groups)</Button>
+        </Menu>
+        <FieldToggleSwitch
+          on={value}
+          label="Enable windowing"
+          onChange={toggle}
+        />
         <FieldToggleSwitch
           on={longLabels}
           onChange={toggleLongLabels}

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -32,8 +32,7 @@ import {
   UsePopoverResponseDom,
   popoverPropKeys,
 } from '../Popover'
-import { ListProps } from '../List'
-import { MenuList } from './MenuList'
+import { MenuList, MenuListProps } from './MenuList'
 
 export interface MenuDomProps extends UsePopoverResponseDom {
   'aria-controls': string
@@ -41,7 +40,7 @@ export interface MenuDomProps extends UsePopoverResponseDom {
 
 export interface MenuProps
   extends Omit<PopoverProps, 'children'>,
-    Omit<ListProps, 'children' | 'content'> {
+    Omit<MenuListProps, 'children' | 'content'> {
   /**
    * A ReactElement that accepts dom props
    */

--- a/packages/components/src/Menu/MenuList.test.tsx
+++ b/packages/components/src/Menu/MenuList.test.tsx
@@ -84,6 +84,9 @@ describe('MenuList', () => {
       const height = (totalItems - windowedItems) * defaultItemHeight
       expect(screen.queryByTestId('before')).not.toBeInTheDocument()
       expect(screen.getByTestId('after')).toHaveStyle(`height: ${height}px;`)
+      // Without overflow auto, windowing won't work.
+      // Testing the style here because we can't test rendered height.
+      expect(screen.getByRole('menu')).toHaveStyle('overflow: auto')
     })
   })
 

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -44,4 +44,5 @@ MenuListInternal.displayName = 'MenuListInternal'
 
 export const MenuList = styled(MenuListInternal)`
   min-width: 12rem;
+  overflow: auto;
 `

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -24,13 +24,19 @@
 
  */
 
+import { width, WidthProps } from '@looker/design-tokens'
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import { List, ListProps } from '../List'
 import { NestedMenuProvider } from './NestedMenuProvider'
 
+export interface MenuListProps extends ListProps, WidthProps {}
+
 export const MenuListInternal = forwardRef(
-  ({ children, ...props }: ListProps, forwardedRef: Ref<HTMLUListElement>) => {
+  (
+    { children, ...props }: MenuListProps,
+    forwardedRef: Ref<HTMLUListElement>
+  ) => {
     return (
       <NestedMenuProvider>
         <List role="menu" ref={forwardedRef} {...props}>
@@ -43,6 +49,7 @@ export const MenuListInternal = forwardRef(
 MenuListInternal.displayName = 'MenuListInternal'
 
 export const MenuList = styled(MenuListInternal)`
+  ${width}
   min-width: 12rem;
   overflow: auto;
 `


### PR DESCRIPTION
This PR puts back `overflow: hidden` on `MenuList` that got lost in [this change](https://github.com/looker-open-source/components/pull/1906/files#diff-d6c17c6698ceeea0bf50ca79fad14f8e6b235b2feb1ae07b0cd6b353a2b5380aL248).

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
