### PR TITLE
refactor(FadeIn): Change styles to support toBeVisible tests

### DIFF
--- a/packages/components/src/Animate/Animate.test.tsx
+++ b/packages/components/src/Animate/Animate.test.tsx
@@ -26,7 +26,8 @@
 
 import 'jest-styled-components'
 import React from 'react'
-import { assertSnapshot } from '@looker/components-test-utils'
+import { screen } from '@testing-library/react'
+import { assertSnapshot, renderWithTheme } from '@looker/components-test-utils'
 import { FadeIn } from './Animate'
 
 describe('FadeIn', () => {
@@ -35,5 +36,14 @@ describe('FadeIn', () => {
   })
   it('renders with delay and duration props', () => {
     assertSnapshot(<FadeIn delay="intricate" duration="complex" />)
+  })
+
+  it('renders elements inside', () => {
+    renderWithTheme(
+      <FadeIn>
+        <span>Some text</span>
+      </FadeIn>
+    )
+    expect(screen.getByText('Some text')).toBeVisible()
   })
 })

--- a/packages/components/src/Animate/Animate.tsx
+++ b/packages/components/src/Animate/Animate.tsx
@@ -62,7 +62,6 @@ export const Animate = styled((props: AnimateProps) => (
 `
 
 export const FadeIn = styled(Animate)`
-  animation-fill-mode: forwards;
+  animation-fill-mode: both;
   animation-name: ${fadeIn};
-  opacity: 0;
 `

--- a/packages/components/src/Animate/__snapshots__/Animate.test.tsx.snap
+++ b/packages/components/src/Animate/__snapshots__/Animate.test.tsx.snap
@@ -10,11 +10,10 @@ exports[`FadeIn renders with defaults 1`] = `
 }
 
 .c1 {
-  -webkit-animation-fill-mode: forwards;
-  animation-fill-mode: forwards;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
   -webkit-animation-name: lbWRkT;
   animation-name: lbWRkT;
-  opacity: 0;
 }
 
 <div
@@ -32,11 +31,10 @@ exports[`FadeIn renders with delay and duration props 1`] = `
 }
 
 .c1 {
-  -webkit-animation-fill-mode: forwards;
-  animation-fill-mode: forwards;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
   -webkit-animation-name: lbWRkT;
   animation-name: lbWRkT;
-  opacity: 0;
 }
 
 <div


### PR DESCRIPTION
This PR will allow `FadeIn` to be used in the core product without breaking a bunch of `toBeVisible` tests. The `animation-fill-mode: both` style makes the initial `opacity: 0` unnecessary by using the beginning of the `animation-name` as the initial state. Removing the extra `opacity: 0` means that `toBeVisible` tests will pass.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
