### PR TITLE
fix(useArrowKeyNav): Focus lost when item is removed

### DIFF
--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -104,11 +104,12 @@ export const ExpandingList = () => {
       <List>
         {showMore2 ? (
           <>
-            <ListItem>Cheddar</ListItem>
-            <ListItem>Swiss</ListItem>
-            <ListItem>Gouda</ListItem>
-            <ListItem>American</ListItem>
+            <ListItem key="0">Cheddar</ListItem>
+            <ListItem key="1">Swiss</ListItem>
+            <ListItem key="2">Gouda</ListItem>
+            <ListItem key="3">American</ListItem>
             <ListItem
+              key="4"
               onClick={() => setShowMore2(false)}
               description="Replaces all items"
             >
@@ -117,9 +118,10 @@ export const ExpandingList = () => {
           </>
         ) : (
           <>
-            <ListItem>Cheddar</ListItem>
-            <ListItem>Gouda</ListItem>
+            <ListItem key="5">Cheddar</ListItem>
+            <ListItem key="6">Gouda</ListItem>
             <ListItem
+              key="7"
               onClick={() => setShowMore2(true)}
               description="Replaces all items"
             >

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -26,7 +26,7 @@
 
 import React, { FC, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
-import { Grid } from '../Layout'
+import { Grid, Space } from '../Layout'
 import { DensityRamp } from './types'
 import { List, ListProps } from './List'
 import { ListItem } from './ListItem'
@@ -74,30 +74,61 @@ LongList.parameters = {
 
 export const ExpandingList = () => {
   const [showMore, setShowMore] = useState(false)
+  const [showMore2, setShowMore2] = useState(false)
   return (
-    <List>
-      <ListItem>Cheddar</ListItem>
-      <ListItem>Gouda</ListItem>
-      {showMore ? (
-        <>
-          <ListItem>Swiss</ListItem>
-          <ListItem>American</ListItem>
+    <Space align="start">
+      <List>
+        <ListItem>Cheddar</ListItem>
+        <ListItem>Gouda</ListItem>
+        {showMore ? (
+          <>
+            <ListItem>Swiss</ListItem>
+            <ListItem>American</ListItem>
+            <ListItem
+              onClick={() => setShowMore(false)}
+              description="Keyboard nav should still work"
+            >
+              Show Less
+            </ListItem>
+          </>
+        ) : (
           <ListItem
-            onClick={() => setShowMore(false)}
-            description="Keyboard nav should still work"
+            onClick={() => setShowMore(true)}
+            description="To test keyboard nav"
           >
-            Show Less
+            Show More
           </ListItem>
-        </>
-      ) : (
-        <ListItem
-          onClick={() => setShowMore(true)}
-          description="To test keyboard nav"
-        >
-          Show More
-        </ListItem>
-      )}
-    </List>
+        )}
+      </List>
+
+      <List>
+        {showMore2 ? (
+          <>
+            <ListItem>Cheddar</ListItem>
+            <ListItem>Swiss</ListItem>
+            <ListItem>Gouda</ListItem>
+            <ListItem>American</ListItem>
+            <ListItem
+              onClick={() => setShowMore2(false)}
+              description="Replaces all items"
+            >
+              Show less
+            </ListItem>
+          </>
+        ) : (
+          <>
+            <ListItem>Cheddar</ListItem>
+            <ListItem>Gouda</ListItem>
+            <ListItem
+              onClick={() => setShowMore2(true)}
+              description="Replaces all items"
+            >
+              Show more
+            </ListItem>
+          </>
+        )}
+      </List>
+    </Space>
   )
 }
 

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -76,13 +76,26 @@ export const ExpandingList = () => {
   const [showMore, setShowMore] = useState(false)
   return (
     <List>
+      <ListItem>Cheddar</ListItem>
+      <ListItem>Gouda</ListItem>
       {showMore ? (
         <>
-          <ListItem>Stuff</ListItem>
-          <ListItem onClick={() => setShowMore(false)}>Show Less</ListItem>
+          <ListItem>Swiss</ListItem>
+          <ListItem>American</ListItem>
+          <ListItem
+            onClick={() => setShowMore(false)}
+            description="Keyboard nav should still work"
+          >
+            Show Less
+          </ListItem>
         </>
       ) : (
-        <ListItem onClick={() => setShowMore(true)}>Show More</ListItem>
+        <ListItem
+          onClick={() => setShowMore(true)}
+          description="To test keyboard nav"
+        >
+          Show More
+        </ListItem>
       )}
     </List>
   )

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { Grid } from '../Layout'
 import { DensityRamp } from './types'
@@ -69,6 +69,26 @@ LongList.args = {
 }
 
 LongList.parameters = {
+  storyshots: false,
+}
+
+export const ExpandingList = () => {
+  const [showMore, setShowMore] = useState(false)
+  return (
+    <List>
+      {showMore ? (
+        <>
+          <ListItem>Stuff</ListItem>
+          <ListItem onClick={() => setShowMore(false)}>Show Less</ListItem>
+        </>
+      ) : (
+        <ListItem onClick={() => setShowMore(true)}>Show More</ListItem>
+      )}
+    </List>
+  )
+}
+
+ExpandingList.parameters = {
   storyshots: false,
 }
 

--- a/packages/components/src/utils/checkElementRemoved.ts
+++ b/packages/components/src/utils/checkElementRemoved.ts
@@ -24,21 +24,23 @@
 
  */
 
-export const checkFocusedItemRemoved = (
+/**
+ * Checks a list of mutations against an element
+ * and returns true if it was removed
+ * @param mutationsList the list of mutations from a MutationObserver
+ * @param element
+ */
+export const checkElementRemoved = (
   mutationsList: MutationRecord[],
-  focusedItem?: HTMLElement
+  element?: HTMLElement
 ) => {
-  if (!focusedItem) return false
-  // Use traditional 'for loops' for IE 11
-  for (const { type, removedNodes } of mutationsList) {
+  if (!element) return false
+  return mutationsList.some(({ type, removedNodes }) => {
     if (type === 'childList' && removedNodes.length > 0) {
-      const focusRemoved = Array.from(removedNodes).some((node) => {
-        return node.contains(focusedItem)
+      return Array.from(removedNodes).some((node) => {
+        return node.contains(element)
       })
-      if (focusRemoved) {
-        return true
-      }
     }
-  }
-  return false
+    return false
+  })
 }

--- a/packages/components/src/utils/checkFocusedItemRemoved.ts
+++ b/packages/components/src/utils/checkFocusedItemRemoved.ts
@@ -1,0 +1,44 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+export const checkFocusedItemRemoved = (
+  mutationsList: MutationRecord[],
+  focusedItem?: HTMLElement
+) => {
+  if (!focusedItem) return false
+  // Use traditional 'for loops' for IE 11
+  for (const { type, removedNodes } of mutationsList) {
+    if (type === 'childList' && removedNodes.length > 0) {
+      const focusRemoved = Array.from(removedNodes).some((node) => {
+        return node.contains(focusedItem)
+      })
+      if (focusRemoved) {
+        return true
+      }
+    }
+  }
+  return false
+}

--- a/packages/components/src/utils/useArrowKeyNav.ts
+++ b/packages/components/src/utils/useArrowKeyNav.ts
@@ -147,6 +147,8 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
         // Otherwise focus the first item
         placeInitialFocus()
       }
+    } else {
+      focusedItemRef.current = e.target
     }
   }
 

--- a/packages/components/src/utils/useArrowKeyNav.ts
+++ b/packages/components/src/utils/useArrowKeyNav.ts
@@ -33,7 +33,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { checkFocusedItemRemoved } from './checkFocusedItemRemoved'
+import { checkElementRemoved } from './checkElementRemoved'
 import { getNextFocus as getNextFocusDefault } from './getNextFocus'
 import { useForkedRef } from './useForkedRef'
 import { useWrapEvent } from './useWrapEvent'
@@ -162,7 +162,7 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
 
     // Create an observer to check if the focused element is removed
     const observer = new MutationObserver((mutationsList) => {
-      if (checkFocusedItemRemoved(mutationsList, focusedItemRef.current)) {
+      if (checkElementRemoved(mutationsList, focusedItemRef.current)) {
         // If it was, start focus back at the beginning
         placeInitialFocus()
       }

--- a/packages/components/src/utils/useArrowKeyNav.ts
+++ b/packages/components/src/utils/useArrowKeyNav.ts
@@ -126,7 +126,6 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
     if (internalRef.current) {
       const toFocus = getNextFocus(1, internalRef.current)
       if (toFocus) {
-        // No need to update focusedItem with this since it's the default
         toFocus.focus()
         focusedItemRef.current = toFocus
       }

--- a/packages/components/src/utils/useArrowKeyNav.ts
+++ b/packages/components/src/utils/useArrowKeyNav.ts
@@ -25,7 +25,7 @@
  */
 
 import {
-  FocusEvent as ReactFocusEvent,
+  FocusEvent,
   KeyboardEvent,
   Ref,
   useCallback,
@@ -59,11 +59,11 @@ export interface UseArrowKeyNavProps<E extends HTMLElement> {
   /**
    * will be merged with the onBlur in the return
    */
-  onBlur?: (e: ReactFocusEvent<E>) => void
+  onBlur?: (e: FocusEvent<E>) => void
   /**
    * will be merged with the onFocus in the return
    */
-  onFocus?: (e: ReactFocusEvent<E>) => void
+  onFocus?: (e: FocusEvent<E>) => void
   /**
    * will be merged with the onKeyDown in the return
    */
@@ -133,8 +133,7 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
     }
   }, [getNextFocus])
 
-  const handleFocus = (e: ReactFocusEvent<E>) => {
-    blurCountRef.current = 0
+  const handleFocus = (e: FocusEvent<E>) => {
     setFocusInside(true)
 
     // When focus lands on the container
@@ -152,7 +151,6 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
     }
   }
 
-  const blurCountRef = useRef(0)
   const handleBlur = () => {
     setFocusInside(false)
   }

--- a/packages/components/src/utils/useArrowKeyNav.ts
+++ b/packages/components/src/utils/useArrowKeyNav.ts
@@ -100,7 +100,6 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
       if (newFocusedItem) {
         e.preventDefault()
         newFocusedItem.focus()
-        focusedItemRef.current = newFocusedItem
       }
     }
   }
@@ -127,7 +126,6 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
       const toFocus = getNextFocus(1, internalRef.current)
       if (toFocus) {
         toFocus.focus()
-        focusedItemRef.current = toFocus
       }
     }
   }, [getNextFocus])


### PR DESCRIPTION
If `useArrowKeyNav`'s currently focused element is removed from the DOM, it becomes impossible to get focus back into the list. But as long as the list itself hasn't been removed, we want focus to stay inside until the user moves it elsewhere.

React does not trigger `onBlur` in this scenario. Some browsers do trigger a `focusout` event, but not all. The only reliable way to catch it is using a `MutationObserver` that checks if an element being removed was the focused item.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [x] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
