### PR TITLE
fix(useClickable): Improve and export onClick type

### DIFF
--- a/packages/components/src/utils/useClickable.ts
+++ b/packages/components/src/utils/useClickable.ts
@@ -25,15 +25,26 @@
  */
 
 import { CompatibleHTMLProps } from '@looker/design-tokens'
-import { FocusEvent, KeyboardEvent, MouseEvent, useState, useMemo } from 'react'
+import {
+  FocusEvent,
+  KeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  useState,
+  useMemo,
+} from 'react'
 
 // These 2 are helper interfaces for components using this hook
 export interface FocusVisibleProps {
   focusVisible: boolean
 }
+
+export type GenericOnClick<E extends HTMLElement> = (
+  e: ReactMouseEvent<E, MouseEvent> | KeyboardEvent<E>
+) => void
+
 export interface GenericClickProps<E extends HTMLElement>
   extends Omit<CompatibleHTMLProps<E>, 'onClick'> {
-  onClick?: (e: MouseEvent<E> | KeyboardEvent<E>) => void
+  onClick?: GenericOnClick<E>
 }
 
 type Attributes = 'disabled' | 'onBlur' | 'onKeyUp' | 'role'
@@ -66,7 +77,7 @@ export function useClickable<E extends HTMLElement>({
         onBlur?.(e)
         setFocusVisible(false)
       },
-      onClick: (e: MouseEvent<E>) => {
+      onClick: (e: ReactMouseEvent<E, MouseEvent>) => {
         if (!disabled) {
           onClick?.(e)
           setFocusVisible(false)


### PR DESCRIPTION
Added a missing `MouseEvent` to the generic `onClick` type in `useClickable`. I also exported `GenericOnClick` from there to slightly improve the awkwardness of matching it up with a "regular" `onClick`. This hook calls `onClick` from `onKeyDown` for the space & enter keys, which is why `| KeyboardEvent<E>` is needed.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
