### PR TITLE
fix(List): Fixed List / Menu windowing

### DIFF
--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -65,7 +65,7 @@ IconGutter.args = {
 const array3000 = Array.from(Array(3000), (_, i) => String(i + 1))
 export const LongList = () => {
   return (
-    <Box maxHeight="500px">
+    <Box height="500px">
       <List>
         {array3000.map((item, i) => (
           <ListItem key={i}>{item}</ListItem>

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -26,7 +26,7 @@
 
 import React, { FC, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
-import { Grid, Space } from '../Layout'
+import { Box, Grid, Space } from '../Layout'
 import { DensityRamp } from './types'
 import { List, ListProps } from './List'
 import { ListItem } from './ListItem'
@@ -62,10 +62,17 @@ IconGutter.args = {
   iconGutter: true,
 }
 
-const array200 = Array.from(Array(200), (_, i) => String(i + 1))
-export const LongList = Template.bind({})
-LongList.args = {
-  children: array200.map((item, i) => <ListItem key={i}>{item}</ListItem>),
+const array3000 = Array.from(Array(3000), (_, i) => String(i + 1))
+export const LongList = () => {
+  return (
+    <Box maxHeight="500px">
+      <List>
+        {array3000.map((item, i) => (
+          <ListItem key={i}>{item}</ListItem>
+        ))}
+      </List>
+    </Box>
+  )
 }
 
 LongList.parameters = {

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -137,6 +137,7 @@ export const ListInternal = forwardRef(
           role={role || 'list'}
           {...omitStyledProps(props)}
           {...navProps}
+          ref={ref}
         >
           {content}
         </ul>
@@ -149,4 +150,5 @@ export const List = styled(ListInternal)`
   ${reset}
 
   list-style: none;
+  overflow: auto;
 `

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -148,6 +148,7 @@ export const ListInternal = forwardRef(
 export const List = styled(ListInternal)`
   ${reset}
 
+  height: 100%;
   list-style: none;
   overflow: auto;
 `

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -137,7 +137,6 @@ export const ListInternal = forwardRef(
           role={role || 'list'}
           {...omitStyledProps(props)}
           {...navProps}
-          ref={ref}
         >
           {content}
         </ul>

--- a/packages/components/src/Menu/MenuList.story.tsx
+++ b/packages/components/src/Menu/MenuList.story.tsx
@@ -27,7 +27,7 @@
 import React, { FC, Fragment } from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { IconNames } from '@looker/icons'
-import { Grid } from '../Layout'
+import { Box, Grid } from '../Layout'
 import { DensityRamp } from '../List/types'
 import { MenuHeading, MenuList, MenuItem, MenuItemProps, MenuDivider } from '.'
 
@@ -84,11 +84,17 @@ Basic.args = {
   iconGutter: true,
 }
 
-const array200 = Array.from(Array(200), (_, i) => String(i + 1))
-export const LongList = Template.bind({})
-LongList.args = {
-  children: array200.map((item, i) => <MenuItem key={i}>{item}</MenuItem>),
-  height: '100vh',
+const array3000 = Array.from(Array(3000), (_, i) => String(i + 1))
+export const LongList = () => {
+  return (
+    <Box maxHeight="500px">
+      <MenuList>
+        {array3000.map((item, i) => (
+          <MenuItem key={i}>{item}</MenuItem>
+        ))}
+      </MenuList>
+    </Box>
+  )
 }
 
 LongList.parameters = {

--- a/packages/components/src/Menu/MenuList.story.tsx
+++ b/packages/components/src/Menu/MenuList.story.tsx
@@ -87,7 +87,7 @@ Basic.args = {
 const array3000 = Array.from(Array(3000), (_, i) => String(i + 1))
 export const LongList = () => {
   return (
-    <Box maxHeight="500px">
+    <Box height="500px">
       <MenuList>
         {array3000.map((item, i) => (
           <MenuItem key={i}>{item}</MenuItem>

--- a/packages/components/src/utils/getNextFocus.ts
+++ b/packages/components/src/utils/getNextFocus.ts
@@ -37,11 +37,20 @@ const getFallbackElement = (
   containerElement: HTMLElement,
   tabStops: HTMLElement[]
 ) => {
-  const firstVisibleChild = tabStops.find((childElement) => {
-    return childElement.offsetTop >= containerElement.scrollTop
-  })
+  let fallback
 
-  return direction === 1 ? firstVisibleChild : tabStops[tabStops.length - 1]
+  if (direction === 1) {
+    const firstVisibleChild = tabStops.find((childElement) => {
+      return childElement.offsetTop >= containerElement.scrollTop
+    })
+
+    if (firstVisibleChild) fallback = firstVisibleChild
+    else fallback = tabStops[0]
+  } else {
+    fallback = tabStops[tabStops.length - 1]
+  }
+
+  return fallback
 }
 
 /**

--- a/packages/components/src/utils/getNextFocus.ts
+++ b/packages/components/src/utils/getNextFocus.ts
@@ -31,6 +31,19 @@ export const getTabStops = (ref: HTMLElement): HTMLElement[] =>
     )
   )
 
+// Returns a fallback element (called when the element with focus has been removed from the DOM)
+const getFallbackElement = (
+  direction: 1 | -1,
+  containerElement: HTMLElement,
+  tabStops: HTMLElement[]
+) => {
+  const firstVisibleChild = tabStops.find((childElement) => {
+    return childElement.offsetTop >= containerElement.scrollTop
+  })
+
+  return direction === 1 ? firstVisibleChild : tabStops[tabStops.length - 1]
+}
+
 /**
  * Returns the next focusable inside an element in a given direction
  * @param direction 1 for forward -1 for reverse
@@ -40,12 +53,6 @@ export const getNextFocus = (direction: 1 | -1, element: HTMLElement) => {
   const tabStops = getTabStops(element)
 
   if (tabStops.length > 0) {
-    const firstVisibleChild = tabStops.find((childElement) => {
-      return childElement.offsetTop >= element.scrollTop
-    })
-
-    const fallback =
-      direction === 1 ? firstVisibleChild : tabStops[tabStops.length - 1]
     if (
       document.activeElement &&
       tabStops.includes(document.activeElement as HTMLElement)
@@ -55,12 +62,12 @@ export const getNextFocus = (direction: 1 | -1, element: HTMLElement) => {
 
       if (next === tabStops.length || !tabStops[next]) {
         // Reached the end of tab stops for this direction
-        return fallback
+        return getFallbackElement(direction, element, tabStops)
       }
 
       return tabStops[next]
     }
-    return fallback
+    return getFallbackElement(direction, element, tabStops)
   }
   return null
 }

--- a/packages/components/src/utils/getNextFocus.ts
+++ b/packages/components/src/utils/getNextFocus.ts
@@ -40,8 +40,12 @@ export const getNextFocus = (direction: 1 | -1, element: HTMLElement) => {
   const tabStops = getTabStops(element)
 
   if (tabStops.length > 0) {
+    const firstVisibleChild = tabStops.find((childElement) => {
+      return childElement.offsetTop >= element.scrollTop
+    })
+
     const fallback =
-      direction === 1 ? tabStops[0] : tabStops[tabStops.length - 1]
+      direction === 1 ? firstVisibleChild : tabStops[tabStops.length - 1]
     if (
       document.activeElement &&
       tabStops.includes(document.activeElement as HTMLElement)

--- a/www/src/documentation/components/content/list.mdx
+++ b/www/src/documentation/components/content/list.mdx
@@ -142,4 +142,4 @@ If a `List` contains more than 100 children it will use windowing to display
 only the visible items for performance reasons. Windowing uses the item height to calculate
 positioning for natural scrolling behavior.
 
-**Note:** A parent element of your `List` should have a max height (or an explicit height). If no explicit height is set, your `List` will attempt to render all child items and not utilize the windowing logic.
+**Note:** A parent element of your `List` should have an explicit height. If no explicit height is set, your `List` will attempt to render all child items and not utilize the windowing logic.

--- a/www/src/documentation/components/content/list.mdx
+++ b/www/src/documentation/components/content/list.mdx
@@ -135,3 +135,11 @@ Enabling the `accessory` option will render the detail element outside of the la
   </ListItem>
 </List>
 ```
+
+## Windowing
+
+If a `List` contains more than 100 children it will use windowing to display
+only the visible items for performance reasons. Windowing uses the item height to calculate
+positioning for natural scrolling behavior.
+
+**Note:** A parent element of your `List` should have a max height (or an explicit height). If no explicit height is set, your `List` will attempt to render all child items and not utilize the windowing logic.

--- a/www/src/documentation/components/overlays/menulist.mdx
+++ b/www/src/documentation/components/overlays/menulist.mdx
@@ -43,3 +43,5 @@ Use the `density` prop to set the size and spacing of your `MenuList`. As `densi
 If a `MenuList` contains more than 100 children it will use windowing to display
 only the visible items for performance reasons. Windowing uses the item height to calculate
 positioning for natural scrolling behavior.
+
+**Note:** A parent element of your `MenuList` should have a max height (or an explicit height). If no explicit height is set, your `MenuList` will attempt to render all child items and not utilize the windowing logic.

--- a/www/src/documentation/components/overlays/menulist.mdx
+++ b/www/src/documentation/components/overlays/menulist.mdx
@@ -44,4 +44,4 @@ If a `MenuList` contains more than 100 children it will use windowing to display
 only the visible items for performance reasons. Windowing uses the item height to calculate
 positioning for natural scrolling behavior.
 
-**Note:** A parent element of your `MenuList` should have a max height (or an explicit height). If no explicit height is set, your `MenuList` will attempt to render all child items and not utilize the windowing logic.
+**Note:** A parent element of your `MenuList` should have an explicit height. If no explicit height is set, your `MenuList` will attempt to render all child items and not utilize the windowing logic.


### PR DESCRIPTION
I noticed that scrolling in a long `Menu` seemed to have a bounce / rubber band effect on `main`. See the "Windowing (3k) Menu" on `main`'s storybook:
https://looker-open-source.github.io/components/latest/storybook/?path=/story/menu--long-menus

Turns out, I had forgotten to pass the `ref` returned from `useWindow` to `List`'s underlying `ul` element 🤦 . From what I can tell, this meant that the scroll position event handlers produced by `useScrollPosition` weren't attaching to the container `ul`, which meant that scroll position wasn't being calculated properly on scroll (which caused the bounce effect).

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
