### PR TITLE
feat: Export i18n strings and utilities

### DIFF
--- a/packages/components-providers/package.json
+++ b/packages/components-providers/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@looker/design-tokens": "^0.15.1",
-    "i18next": "^19.8.7",
+    "i18next": "19.9.1",
     "lodash": "^4.17.20",
     "react-helmet-async": "^1.0.7",
     "react-i18next": "11.8.8",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,7 @@
     "date-fns": "^2.17.0",
     "date-fns-tz": "^1.0.12",
     "hotkeys-js": "^3.8.1",
-    "i18next": "^19.8.7",
+    "i18next": "19.9.1",
     "lodash": "^4.17.20",
     "react-day-picker": "^7.4.8",
     "react-hotkeys-hook": "2.3.1",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -72,6 +72,10 @@ export * from './utils'
 export {
   ComponentsProvider,
   ExtendComponentsThemeProvider,
+  i18nInit,
+  i18nInitOptions,
+  i18nResources,
+  i18nUpdate,
 } from '@looker/components-providers'
 
 export { theme, Theme } from '@looker/design-tokens'

--- a/www/src/MDX/Pre/allComponents.ts
+++ b/www/src/MDX/Pre/allComponents.ts
@@ -179,6 +179,7 @@ import {
   useTabs,
   useToggle,
   VisuallyHidden,
+  i18nResources,
 } from '@looker/components'
 
 import { DialogSurface } from '@looker/components/src/Dialog/DialogSurface'
@@ -355,4 +356,5 @@ export const allComponents = {
   Truncate,
   UnorderedList,
   VisuallyHidden,
+  i18nResources,
 }

--- a/www/src/documentation/develop/internationalization.mdx
+++ b/www/src/documentation/develop/internationalization.mdx
@@ -1,0 +1,19 @@
+---
+title: 4. Internationalization
+---
+
+Looker Components uses [`i18next`](https://www.i18next.com/) to support Internationalization.
+The `ComponentsProvider` initializes the `i18next` instance, or, if it is already initialized,
+adds the strings used in components. To add more languages, or to override existing strings and
+language default, use the `resources` and `language` props on `ComponentsProvider`.
+
+```jsx
+<ComponentsProvider
+  resources={{ ...i18nResources, gd: { Chip: { Delete: 'Scrios' } } }}
+  locale="gd"
+>
+  <Chip onDelete={() => alert('The delete button tooltip is in Gaelic!')}>
+    sliseanna
+  </Chip>
+</ComponentsProvider>
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -12411,10 +12411,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-i18next@^19.8.7:
-  version "19.8.7"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.7.tgz#ef023e353974d1b1453e8b6331bd9fb7cba427df"
-  integrity sha512-ezo1gb7QO4OQ5gQCdZMUxopwQSoqpRp6whdEjm1grxMSmkGj1NJ+kYS0UQd4NnpPIVqsgqTQ2L2eqSQYQ+U3Fw==
+i18next@19.9.1:
+  version "19.9.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.9.1.tgz#7a072b75daf677aa51fd4ce55214f21702af3ffd"
+  integrity sha512-9Azzyb3DvMJUMd7sPhwVEs6PQcogvdHmLQTjMQ+P+h3XwW4O66/8lgZTmYShgkjPOCqTw4Fwl5LOp/VhZgPo5A==
   dependencies:
     "@babel/runtime" "^7.12.0"
 


### PR DESCRIPTION
Re-exports i18n strings & utils from the `@looker/components` package so one doesn't have to install `@looker/components-providers`.

Basic documentation on how to add translations & set the language.

Removes caret from the version, because "global-not-global".

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [x] yes
  - [ ] not applicable
