### PR TITLE
refactor: List and Menu quality of life updates

### DIFF
--- a/packages/components/src/List/index.ts
+++ b/packages/components/src/List/index.ts
@@ -26,4 +26,5 @@
 
 export * from './List'
 export * from './ListItem'
+export * from './ListItemContext'
 export { listItemDimensions } from './utils'

--- a/packages/components/src/Menu/MenuHeading.tsx
+++ b/packages/components/src/Menu/MenuHeading.tsx
@@ -27,9 +27,9 @@
 import React, { FC, useContext, useRef, ReactNode, RefObject } from 'react'
 import styled from 'styled-components'
 import {
-  ColorProps,
+  TextColorProps,
   TypographyProps,
-  SpaceProps,
+  PaddingProps,
   pickStyledProps,
 } from '@looker/design-tokens'
 import { Heading } from '../Text/Heading'
@@ -37,7 +37,10 @@ import { listItemDimensions } from '../List'
 import { ListItemContext } from '../List/ListItemContext'
 import { useElementVisibility } from './MenuHeading.hooks'
 
-interface MenuHeadingProps extends ColorProps, TypographyProps, SpaceProps {
+interface MenuHeadingProps
+  extends TextColorProps,
+    TypographyProps,
+    PaddingProps {
   children: ReactNode
 }
 

--- a/packages/components/src/Menu/MenuHeading.tsx
+++ b/packages/components/src/Menu/MenuHeading.tsx
@@ -42,10 +42,12 @@ interface MenuHeadingProps
     TypographyProps,
     PaddingProps {
   children: ReactNode
+  className?: string
 }
 
-export const MenuHeading: FC<MenuHeadingProps> = ({
+const MenuHeadingInternal: FC<MenuHeadingProps> = ({
   children,
+  className,
   ...restProps
 }) => {
   const labelShimRef: RefObject<any> = useRef()
@@ -55,7 +57,10 @@ export const MenuHeading: FC<MenuHeadingProps> = ({
   const { px } = listItemDimensions(density)
 
   return (
-    <MenuHeadingWrapper renderBoxShadow={!isLabelShimVisible}>
+    <MenuHeadingWrapper
+      className={className}
+      renderBoxShadow={!isLabelShimVisible}
+    >
       {/*
         NOTE: The labelShimRef div is required for box-shadow to appear when the heading
         is sticky to the top of the container. Using IntersectionObserver,
@@ -79,6 +84,8 @@ export const MenuHeading: FC<MenuHeadingProps> = ({
     </MenuHeadingWrapper>
   )
 }
+
+export const MenuHeading = styled(MenuHeadingInternal)``
 
 interface MenuHeadingWrapperProps {
   renderBoxShadow: boolean

--- a/packages/components/src/Menu/MenuHeading.tsx
+++ b/packages/components/src/Menu/MenuHeading.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, useContext, useRef, RefObject } from 'react'
+import React, { FC, useContext, useRef, ReactNode, RefObject } from 'react'
 import styled from 'styled-components'
 import {
   ColorProps,
@@ -38,7 +38,7 @@ import { ListItemContext } from '../List/ListItemContext'
 import { useElementVisibility } from './MenuHeading.hooks'
 
 interface MenuHeadingProps extends ColorProps, TypographyProps, SpaceProps {
-  children: string
+  children: ReactNode
 }
 
 export const MenuHeading: FC<MenuHeadingProps> = ({


### PR DESCRIPTION
- Export `ListItemContext` so external components can utilize context + `listItemDimensions` util function to pull from our density scale (i.e. if they're using a non-text child for their `ListItem`)
- Change `MenuHeading` child to `ReactNode` (the `MainNav` has `<Highlight/>` children for search in the Explore dropdown, and the heading can be included in the search results so it can't just be a text child afaik)

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [ ] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [ ] not applicable
