### PR TITLE
feat(Select): Caret icon always has default cursor icon

### DIFF
--- a/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
+++ b/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
@@ -129,5 +129,6 @@ const SearchControlDivider = styled.div`
 
 const CaretIcon = styled(Icon).attrs(() => ({ mr: 'xxsmall', size: 20 }))`
   ${iconButtonColor}
+  cursor: default;
   opacity: ${({ disabled }) => (disabled ? '0.75' : '1')};
 `


### PR DESCRIPTION
Currently on a `Select` or `SelectMulti` with `isFilterable`, the entire input shows `cursor: text`,* including the caret icon, which feels weird. (Any icon buttons inside the input, like the clear button, are `cursor: pointer`.)

![image-20210302-153913](https://user-images.githubusercontent.com/53451193/110582230-bd4feb00-8120-11eb-802b-8f7f61902760.png)

This PR adds `cursor: default` to the caret icon to approximate the [native browser `input` + `datalist` experience](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist).


### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [x] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [x] not applicable
