### PR TITLE
fix(Tree): Tree Windowing

### DIFF
--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -73,15 +73,18 @@ const dividersCSS = css`
 export const TreeStyle = styled.div<TreeStyleProps>`
   color: ${({ theme }) => theme.colors.text5};
   flex-shrink: 2;
+  /* For windowing / performance */
   height: 100%;
   min-width: 0;
 
   & > ${Accordion} {
+    /* For windowing / performance */
     height: 100%;
 
     & > ${AccordionContent} {
       ${({ border, depth, indicatorSize, theme }) =>
         border && generateTreeBorder(depth, indicatorSize, theme)}
+      /* For windowing / performance */
       height: 100%;
     }
 

--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -73,12 +73,16 @@ const dividersCSS = css`
 export const TreeStyle = styled.div<TreeStyleProps>`
   color: ${({ theme }) => theme.colors.text5};
   flex-shrink: 2;
+  height: 100%;
   min-width: 0;
 
   & > ${Accordion} {
+    height: 100%;
+
     & > ${AccordionContent} {
       ${({ border, depth, indicatorSize, theme }) =>
         border && generateTreeBorder(depth, indicatorSize, theme)}
+      height: 100%;
     }
 
     & > ${AccordionDisclosureStyle} {

--- a/packages/components/src/Tree/stories/Tree.story.tsx
+++ b/packages/components/src/Tree/stories/Tree.story.tsx
@@ -27,6 +27,7 @@
 import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { Tree, TreeProps, TreeItem } from '..'
+import { Box } from '../..'
 
 export * from './BorderRadius.story'
 export * from './ColorfulTree.story'
@@ -65,4 +66,21 @@ export const Border = Template.bind({})
 Border.args = {
   ...Basic.args,
   border: true,
+}
+
+export const Windowing = () => {
+  const array3000 = []
+  for (let i = 0; i < 3000; i++) {
+    array3000.push(i)
+  }
+
+  return (
+    <Box height="500px">
+      <Tree label="Hello World">
+        {array3000.map((i) => (
+          <TreeItem key={i}>{i}</TreeItem>
+        ))}
+      </Tree>
+    </Box>
+  )
 }


### PR DESCRIPTION
`Tree` windowing currently doesn't work because the internal `AccordionContent` cannot respect the height of a parent container above `Tree`.

Giving `height: 100%` to the internal `TreeStyle` div, `Accordion` div, and `AccordionContent` div gets that content container to respect hierarchical height, and thus gets windowing working.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [ ] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [ ] not applicable
