### PR TITLE
refactor(ListItem): Moved Truncate within Text for proper styling

### DIFF
--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -57,11 +57,9 @@ const TruncateWrapper: FC<{
   fontSize?: FontSizes
   lineHeight?: FontSizes
 }> = ({ children, color, fontSize, lineHeight }) => (
-  <Truncate>
-    <Text color={color} fontSize={fontSize} lineHeight={lineHeight}>
-      {children}
-    </Text>
-  </Truncate>
+  <Text color={color} fontSize={fontSize} lineHeight={lineHeight}>
+    <Truncate>{children}</Truncate>
+  </Text>
 )
 
 export interface ListItemProps

--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -29,7 +29,6 @@ import omit from 'lodash/omit'
 import React, { forwardRef, ReactNode, Ref } from 'react'
 import styled from 'styled-components'
 import { Icon } from '../Icon'
-import { Truncate } from '../Truncate'
 import {
   ListItemStatefulWithHoveredProps,
   ListItemDimensions,
@@ -128,10 +127,6 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
     align-self: ${({ description }) => (description ? 'flex-start' : 'center')};
     transition: color
       ${({ theme }) => `${theme.transitions.quick}ms ${theme.easings.ease}`};
-  }
-
-  ${Truncate} {
-    line-height: 1;
   }
 
   &[aria-current='true'] {

--- a/packages/components/src/Truncate/Truncate.tsx
+++ b/packages/components/src/Truncate/Truncate.tsx
@@ -87,7 +87,7 @@ const TruncateLayout: FC<TruncateProps> = ({
 
 const TextStyle = styled.span<WidthProps>`
   display: block;
-  overflow: hidden;
+  overflow-x: hidden;
   text-overflow: ellipsis;
   ${widthHelper}
   white-space: nowrap;


### PR DESCRIPTION
Previously, the `ListItem` child wrapper and description wrapper followed this composition:
```
<Truncate>
  <Text         
       color={labelColor}
       fontSize={itemDimensions.labelFontSize}
       lineHeight={itemDimensions.labelLineHeight}
   >
    {children}
  </Text>
</Truncate>
```

I had mistakenly thought that `Truncate` would only work if its immediate parent wasn't an inline element 🤦  Because of this old composition, the `Truncate` element wasn't receiving the density-respecting styles (i.e. font size and line height) and required a `line-height: 1` style override to get the right heights for each density.

Moving `Truncate` within the `Text` element means that `Truncate` just "absorbs" the density-respecting styles on the `Text` element.

### Requirements

Please check the following items are addressed in your pull request (or are not applicable)

- [ ] a11y impact (FUTURE: Make aXe pass req'd for CI ✅)

#### Image snapshots (choose one)

  - [ ] yes
  - [ ] not applicable

#### Documentation updated (choose one)

  - [ ] yes
  - [ ] not applicable
