### PR TITLE
fix(Listitem): Improved strategy for :focus-visible CSS (remove z-index from MenuHeading)

### DIFF
--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -144,13 +144,19 @@ export const AccordionDisclosureStyle = styled.div
     color ? colorStyleFn : `color: ${theme.colors.ui5};`}
   cursor: pointer;
   display: flex;
-  outline: 1px solid transparent;
-  outline-color: ${({ focusVisible, theme }) =>
-    focusVisible && theme.colors.keyFocus};
   ${padding}
+  outline: none;
   text-align: left;
   width: 100%;
-`
+
+  ${({ focusVisible, theme }) =>
+    focusVisible &&
+    `
+      &:focus {
+        box-shadow: inset 0 0 0 1px ${theme.colors.keyFocus};
+      }
+    `}
+  `
 
 export const AccordionDisclosure = styled(AccordionDisclosureInternal).attrs(
   (props) => ({

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -153,7 +153,7 @@ export const AccordionDisclosureStyle = styled.div
     focusVisible &&
     `
       &:focus {
-        box-shadow: inset 0 0 0 1px ${theme.colors.keyFocus};
+        box-shadow: inset 0 0 0 2px ${theme.colors.keyFocus};
       }
     `}
   `

--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -102,26 +102,17 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)`
     &:hover,
     &:focus {
       color: inherit;
-      position: relative;
       text-decoration: none;
     }
   }
 
-  ${({ focusVisible, theme: { colors } }) =>
+  ${({ focusVisible, theme }) =>
     focusVisible &&
-    `&:focus-within > button:after,
-    &:focus-within > a:after {
-      content: '';
-      display:block;
-      border: solid 2px ${colors.keyFocus};
-      border-radius: 2px;
-      margin: 0 1px;
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-    }
+    `
+      &:focus-within > button,
+      &:focus-within > a {
+        box-shadow: inset 0 0 0 2px ${theme.colors.keyFocus};
+      }
     `}
 
   ${Icon} {

--- a/packages/components/src/Menu/MenuHeading.tsx
+++ b/packages/components/src/Menu/MenuHeading.tsx
@@ -97,8 +97,4 @@ const MenuHeadingWrapper = styled.li<MenuHeadingWrapperProps>`
     renderBoxShadow ? `0 4px 8px -2px ${colors.ui2}` : 'none'};
   position: sticky;
   top: -1px;
-  /* Prevents a conflict with position: relative items
-    (which have an additional stacking-context) from
-    creating a problematic rendering */
-  z-index: 2;
 `


### PR DESCRIPTION
Per a conversation earlier today I realized that the strategy I used to display `focus-visible` on `ListItem` to prevent conflicts with `MenuHeading` was probably going to cause issues (either now or in the future). T

his change alters the strategy to `box-shadow` (per @jhardy's suggestion) and removes the problematic usage of `position: relative` abdicating the need for `z-index` on `MenuHeading`

While surveying our other strategies for displaying the "focus ring" I noticed that we were using `outline` on `AccordionDisclosure` and went ahead and pulled it into the same approach used for `Listitem` to reduce the number of strategies in use. 

### Developer Pre-Review Checklist

- [ ] a11y impact
- [ ] Needs new snapshot coverage
- [ ] Needs documentation update
