### PR TITLE
fix(SpaceVertical): Remove default alignItems value

### DIFF
--- a/packages/components/src/Layout/Space/SpaceVertical.tsx
+++ b/packages/components/src/Layout/Space/SpaceVertical.tsx
@@ -57,17 +57,10 @@ const flexGap = ({ gap = defaultGap, reverse }: SpaceVerticalProps) => css`
 
 export const SpaceVertical = styled.div
   .withConfig({ shouldForwardProp })
-  .attrs<SpaceVerticalProps>(({ align = 'flex-start', width = '100%' }) => {
-    // Use `flex-start|end` instead of `start|end`
-    if (['start', 'end'].includes('align')) {
-      align = `flex-${align}`
-    }
-
-    return {
-      alignItems: align,
-      width,
-    }
-  })<SpaceVerticalProps>`
+  .attrs<SpaceVerticalProps>(({ align, width = '100%' }) => ({
+    alignItems: ['start', 'end'].includes('align') ? `flex-${align}` : align,
+    width,
+  }))<SpaceVerticalProps>`
   ${spaceCSS}
   ${flexGap}
   flex-direction: ${({ reverse }) => (reverse ? 'column-reverse' : 'column')};


### PR DESCRIPTION
Solving for an issue where `Form` (which is a composition of `SpaceVertical` was getting `align-items: flex-start` causing `Fields` nested within to have a narrowed width:

![image](https://user-images.githubusercontent.com/34253496/111817642-7b9b0f00-889b-11eb-9beb-68f2d73d0d0a.png)


## Developer Checklist [ℹ️](/CONTRIBUTING.md#developer-checklist)

- [ ] 🖼 Image Snapshot coverage
- [x] 📚 Documentation updated
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
