### PR TITLE
chore: Remove unneeded import jest-styled-components

### DIFF
--- a/packages/components-test-utils/src/create_with_theme.tsx
+++ b/packages/components-test-utils/src/create_with_theme.tsx
@@ -27,7 +27,6 @@
 import { ComponentsProvider } from '@looker/components-providers'
 import { render, RenderOptions } from '@testing-library/react'
 import { mount } from 'enzyme'
-import 'jest-styled-components'
 import React, { ReactElement } from 'react'
 
 export const withThemeProvider = (Component: ReactElement<any>) => (

--- a/packages/components/src/Button/ButtonOutline.test.tsx
+++ b/packages/components/src/Button/ButtonOutline.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import { renderWithTheme } from '@looker/components-test-utils'
 import React from 'react'

--- a/packages/components/src/Button/ButtonTransparent.test.tsx
+++ b/packages/components/src/Button/ButtonTransparent.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import { renderWithTheme } from '@looker/components-test-utils'
 import React from 'react'

--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Favorite } from '@styled-icons/material'

--- a/packages/components/src/Button/MultiFunctionButton.test.tsx
+++ b/packages/components/src/Button/MultiFunctionButton.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { fireEvent, screen, act } from '@testing-library/react'

--- a/packages/components/src/Dialog/Dialog.test.tsx
+++ b/packages/components/src/Dialog/Dialog.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import {

--- a/packages/components/src/Dialog/Layout/DialogHeader.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Divider/Divider.test.tsx
+++ b/packages/components/src/Divider/Divider.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Divider/DividerVertical.test.tsx
+++ b/packages/components/src/Divider/DividerVertical.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Drawer/Drawer.test.tsx
+++ b/packages/components/src/Drawer/Drawer.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React, { useContext } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import {

--- a/packages/components/src/Form/Fields/FieldCheckbox/FieldCheckbox.test.tsx
+++ b/packages/components/src/Form/Fields/FieldCheckbox/FieldCheckbox.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Form/Fields/FieldCheckboxGroup/FieldCheckboxGroup.test.tsx
+++ b/packages/components/src/Form/Fields/FieldCheckboxGroup/FieldCheckboxGroup.test.tsx
@@ -23,7 +23,6 @@
  SOFTWARE.
 
  */
-import 'jest-styled-components'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Form/Fields/FieldChips/FieldChips.test.tsx
+++ b/packages/components/src/Form/Fields/FieldChips/FieldChips.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { mountWithTheme } from '@looker/components-test-utils'
 import { FieldChips } from './FieldChips'

--- a/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
+++ b/packages/components/src/Form/Fields/FieldColor/FieldColor.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import React, { FormEvent, useState } from 'react'
 import { fireEvent } from '@testing-library/react'

--- a/packages/components/src/Form/Fields/FieldDate/FieldDate.test.tsx
+++ b/packages/components/src/Form/Fields/FieldDate/FieldDate.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { mountWithTheme, renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Form/Fields/FieldDateRange/FieldDateRange.test.tsx
+++ b/packages/components/src/Form/Fields/FieldDateRange/FieldDateRange.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { mountWithTheme, renderWithTheme } from '@looker/components-test-utils'
 import { FieldDateRange } from './FieldDateRange'

--- a/packages/components/src/Form/Fields/FieldRadio/FieldRadio.test.tsx
+++ b/packages/components/src/Form/Fields/FieldRadio/FieldRadio.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Form/Fields/FieldRadioGroup/FieldRadioGroup.test.tsx
+++ b/packages/components/src/Form/Fields/FieldRadioGroup/FieldRadioGroup.test.tsx
@@ -23,7 +23,6 @@
  SOFTWARE.
 
  */
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import map from 'lodash/map'

--- a/packages/components/src/Form/Fields/FieldTextArea/FieldTextArea.test.tsx
+++ b/packages/components/src/Form/Fields/FieldTextArea/FieldTextArea.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Form/Fields/FieldTime/FieldTime.test.tsx
+++ b/packages/components/src/Form/Fields/FieldTime/FieldTime.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.test.tsx
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Form/Fieldset/Fieldset.test.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen, fireEvent } from '@testing-library/react'

--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { mountWithTheme } from '@looker/components-test-utils'
 import { Button } from '../Button/Button'

--- a/packages/components/src/Form/Inputs/InputColor/InputColor.test.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import React, { FormEvent, useState } from 'react'
 import { fireEvent, screen } from '@testing-library/react'

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.test.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React, { createRef } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { fireEvent, screen } from '@testing-library/react'

--- a/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.test.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.test.tsx
@@ -23,7 +23,6 @@
  SOFTWARE.
 
  */
-import 'jest-styled-components'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.test.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.test.tsx
@@ -23,7 +23,6 @@
  SOFTWARE.
 
  */
-import 'jest-styled-components'
 import React, { useState } from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Form/Inputs/Radio/Radio.test.tsx
+++ b/packages/components/src/Form/Inputs/Radio/Radio.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen, fireEvent } from '@testing-library/react'

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.test.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Icon/Icon.test.tsx
+++ b/packages/components/src/Icon/Icon.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { theme } from '@looker/design-tokens'

--- a/packages/components/src/Layout/Box/Box.test.tsx
+++ b/packages/components/src/Layout/Box/Box.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Layout/Grid/Grid.test.tsx
+++ b/packages/components/src/Layout/Grid/Grid.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Layout/Semantics/Semantics.test.tsx
+++ b/packages/components/src/Layout/Semantics/Semantics.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Layout/Space/Space.test.tsx
+++ b/packages/components/src/Layout/Space/Space.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Layout/Space/SpaceVertical.test.tsx
+++ b/packages/components/src/Layout/Space/SpaceVertical.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'

--- a/packages/components/src/Link/Link.test.tsx
+++ b/packages/components/src/Link/Link.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { theme } from '@looker/design-tokens'

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import * as React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { ListItem } from './ListItem'

--- a/packages/components/src/List/ListItem.test.tsx
+++ b/packages/components/src/List/ListItem.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { fireEvent, configure, screen } from '@testing-library/react'

--- a/packages/components/src/Menu/MenuItem.test.tsx
+++ b/packages/components/src/Menu/MenuItem.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Beaker } from '@looker/icons'

--- a/packages/components/src/Menu/MenuList.test.tsx
+++ b/packages/components/src/Menu/MenuList.test.tsx
@@ -25,7 +25,6 @@
  */
 
 import { screen } from '@testing-library/react'
-import 'jest-styled-components'
 import * as React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { MenuItem } from './MenuItem'

--- a/packages/components/src/MessageBar/MessageBar.test.tsx
+++ b/packages/components/src/MessageBar/MessageBar.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { theme } from '@looker/design-tokens'

--- a/packages/components/src/OrderedList/OrderedList.test.tsx
+++ b/packages/components/src/OrderedList/OrderedList.test.tsx
@@ -28,8 +28,6 @@ import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { OrderedList } from './OrderedList'
 
-import 'jest-styled-components'
-
 describe('OrderedList', () => {
   test('Should display child li elements', () => {
     const { getByText } = renderWithTheme(

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -26,7 +26,6 @@
 
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent } from '@testing-library/react'
-import 'jest-styled-components'
 import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Panel, Panels, usePanel } from './'

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -26,7 +26,6 @@
 
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent } from '@testing-library/react'
-import 'jest-styled-components'
 import React, { useRef } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Button } from '../Button'

--- a/packages/components/src/Spinner/Spinner.test.tsx
+++ b/packages/components/src/Spinner/Spinner.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Status/Status.test.tsx
+++ b/packages/components/src/Status/Status.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Table/TableSection/TableFoot.test.tsx
+++ b/packages/components/src/Table/TableSection/TableFoot.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import '@testing-library/jest-dom/extend-expect'
 import { mountWithTheme, renderWithTheme } from '@looker/components-test-utils'
 import React from 'react'

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import 'jest-styled-components'
 import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { act, fireEvent, screen } from '@testing-library/react'

--- a/packages/components/src/UnorderedList/UnorderedList.test.tsx
+++ b/packages/components/src/UnorderedList/UnorderedList.test.tsx
@@ -28,8 +28,6 @@ import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { UnorderedList } from './UnorderedList'
 
-import 'jest-styled-components'
-
 describe('UnorderedList', () => {
   test('Should display child li elements', () => {
     const { getByText } = renderWithTheme(


### PR DESCRIPTION
This is only needed within jest.setup.js