### PR TITLE
refactor(ListItem): Moved icon gap by -2px

### DIFF
--- a/packages/components/src/List/ListItemLabel.tsx
+++ b/packages/components/src/List/ListItemLabel.tsx
@@ -26,13 +26,20 @@
 
 import { CompatibleHTMLProps, shouldForwardProp } from '@looker/design-tokens'
 import React, { FC } from 'react'
-import styled from 'styled-components'
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { ListItemRole, ListItemStatefulWithHoveredProps } from './types'
 import { listItemBackgroundColor } from './utils'
 
 export const ListItemLabelButton = styled.button``
 export const ListItemLabelLink = styled.a``
 export const ListItemLabelDiv = styled.div``
+
+// Use listItemLabelCSS to target the internal button / link / div CSS of ListItem
+export const listItemLabelCSS = (style: FlattenSimpleInterpolation) => css`
+  > ${ListItemLabelButton}, > ${ListItemLabelLink}, > ${ListItemLabelDiv} {
+    ${style}
+  }
+`
 
 const listItemLabelElement = (itemRole: ListItemRole, disabled?: boolean) => {
   if (!disabled && itemRole === 'link') return ListItemLabelLink

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -73,7 +73,7 @@ const TreeLayout: FC<TreeProps> = ({
   const depth = treeContext.depth ? treeContext.depth : startingDepth
 
   const density = propsDensity || treeContext.density
-  const { iconSize } = listItemDimensions(density)
+  const { iconGap, iconSize } = listItemDimensions(density)
 
   const { accessory, content, hoverDisclosure } = getDetailOptions(propsDetail)
 
@@ -163,6 +163,7 @@ const TreeLayout: FC<TreeProps> = ({
         disabled={disabled}
         dividers={dividers}
         hovered={hovered}
+        iconGap={iconGap}
         indicatorSize={iconSize}
         keyColor={useKeyColor}
         selected={selected}

--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -81,8 +81,8 @@ export const TreeStyle = styled.div<TreeStyleProps>`
   ${ListItem} {
     ${({ iconGap, theme }) =>
       listItemLabelCSS(css`
-        svg,
-        ${StyledIconBase}, ${IconPlaceholder} {
+        > svg,
+        > ${StyledIconBase}, > ${IconPlaceholder} {
           /* The -2px gets the icon gap to match design specs */
           margin-right: calc(${theme.space[iconGap]} - 2px);
         }

--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -25,6 +25,8 @@
  */
 
 import styled, { css } from 'styled-components'
+import { StyledIconBase } from '@styled-icons/styled-icon'
+import { SpacingSizes } from '@looker/design-tokens'
 import {
   Accordion,
   AccordionContent,
@@ -33,12 +35,8 @@ import {
 import { listItemBackgroundColor } from '../List/utils'
 import { ListItemStatefulWithHoveredProps } from '../List/types'
 import { List, ListItem } from '../List'
-import {
-  ListItemLabelLink,
-  ListItemLabelDiv,
-  ListItemLabelButton,
-} from '../List/ListItemLabel'
-import { IconSize } from '../Icon'
+import { listItemLabelCSS } from '../List/ListItemLabel'
+import { IconPlaceholder, IconSize } from '../Icon'
 import { TreeItem } from './TreeItem'
 import { TreeBranch } from './TreeBranch'
 import { generateIndent, generateTreeBorder } from './utils'
@@ -48,15 +46,15 @@ interface TreeStyleProps extends ListItemStatefulWithHoveredProps {
   branchFontWeight?: boolean
   depth: number
   dividers?: boolean
+  iconGap: SpacingSizes
   indicatorSize: IconSize
 }
 
 export const TreeItemInner = styled(TreeItem)`
-  > button,
-  > a {
+  ${listItemLabelCSS(css`
     background-color: transparent;
     padding-left: 0;
-  }
+  `)}
 `
 
 export const TreeItemInnerDetail = styled.div``
@@ -79,6 +77,17 @@ export const TreeStyle = styled.div<TreeStyleProps>`
   color: ${({ theme }) => theme.colors.text5};
   flex-shrink: 2;
   min-width: 0;
+
+  ${ListItem} {
+    ${({ iconGap, theme }) =>
+      listItemLabelCSS(css`
+        svg,
+        ${StyledIconBase}, ${IconPlaceholder} {
+          /* The -2px gets the icon gap to match design specs */
+          margin-right: calc(${theme.space[iconGap]} - 2px);
+        }
+      `)}
+  }
 
   > ${Accordion} {
     > ${AccordionContent} {
@@ -107,10 +116,8 @@ export const TreeStyle = styled.div<TreeStyleProps>`
 
   > ${Accordion} > ${AccordionContent} > ${List} {
     > ${ListItem} {
-      > ${ListItemLabelButton}, > ${ListItemLabelLink}, > ${ListItemLabelDiv} {
-        ${({ depth, indicatorSize, theme }) =>
-          generateIndent(depth + 2, indicatorSize, theme)}
-      }
+      ${({ depth, indicatorSize, theme }) =>
+        listItemLabelCSS(generateIndent(depth + 2, indicatorSize, theme))}
     }
 
     > ${TreeBranch} {
@@ -124,10 +131,8 @@ export const TreeStyle = styled.div<TreeStyleProps>`
    */
   > ${List} {
     > ${ListItem} {
-      > ${ListItemLabelButton}, > ${ListItemLabelLink}, > ${ListItemLabelDiv} {
-        ${({ depth, indicatorSize, theme }) =>
-          generateIndent(depth + 2, indicatorSize, theme)}
-      }
+      ${({ depth, indicatorSize, theme }) =>
+        listItemLabelCSS(generateIndent(depth + 2, indicatorSize, theme))}
     }
 
     > ${TreeBranch} {

--- a/packages/components/src/Tree/stories/Tree.story.tsx
+++ b/packages/components/src/Tree/stories/Tree.story.tsx
@@ -25,8 +25,10 @@
  */
 
 import React from 'react'
+import { Download, Pivot } from '@looker/icons'
 import { Story } from '@storybook/react/types-6-0'
 import { Tree, TreeProps, TreeItem } from '..'
+import { Space } from '../../Layout'
 
 export * from './BorderRadius.story'
 export * from './ColorfulTree.story'
@@ -66,3 +68,18 @@ Border.args = {
   ...Basic.args,
   border: true,
 }
+
+export const Icon = () => (
+  <Tree
+    defaultOpen
+    icon={<Pivot />}
+    label={
+      <Space between>
+        "Pivot" icon has margin-right, but "Download" icon does not
+        <Download size={20} />
+      </Space>
+    }
+  >
+    <TreeItem>Don't mind me</TreeItem>
+  </Tree>
+)


### PR DESCRIPTION
As per Jared's design suggestions, we're tightening the gap between a `Tree`'s optional icon and label element.
![Screen Shot 2021-03-30 at 4 55 22 PM](https://user-images.githubusercontent.com/16812885/113071008-b98c1300-9178-11eb-8970-09dd0dc7defb.png)

I also created a util function that spits out selectors for the internal button / link / div of a `ListItem`. We can use this throughout `TreeStyle` to target `ListItem` styling and make life a little easier, hopefully.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
