### PR TITLE
fix(SelectOptions): Render an option, not a header, when value is an empty string

### DIFF
--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.test.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.test.tsx
@@ -132,7 +132,11 @@ describe('InputSearch', () => {
   })
 
   describe('options', () => {
-    const options = [{ value: 'FOO' }, { value: 'BAR' }]
+    const options = [
+      { value: 'FOO' },
+      { value: 'BAR' },
+      { label: 'Empty', value: '' },
+    ]
 
     test('list opens on change, not click', () => {
       renderWithTheme(<InputSearch options={options} placeholder="type here" />)
@@ -142,7 +146,7 @@ describe('InputSearch', () => {
 
       fireEvent.change(input, { target: { value: 'F' } })
       expect(input).toHaveDisplayValue('F')
-      expect(screen.queryAllByRole('option')).toHaveLength(2)
+      expect(screen.queryAllByRole('option')).toHaveLength(3)
 
       // Close popover to silence act() warning
       fireEvent.click(document)

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -280,7 +280,7 @@ export const SelectOptions = (props: SelectOptionsProps) => {
             ...optionsToRender.map((option, index) => {
               // Add start to index to keep key consistent if options are windowed
               const key = `${keyPrefix}-${start + index}`
-              if (option.value) {
+              if (option.value !== undefined) {
                 const OptionLayoutToUse = isMulti
                   ? MultiOptionLayout
                   : OptionLayout


### PR DESCRIPTION
## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
