### PR TITLE
refactor(Tree): Update alignment

### DIFF
--- a/packages/components/src/Accordion/AccordionDisclosureLayout.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosureLayout.tsx
@@ -55,7 +55,7 @@ const Layout: FC<AccordionDisclosureLayoutProps> = ({
   )
 }
 
-const Indicator = styled.div`
+export const Indicator = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;

--- a/packages/components/src/List/ListItemLayoutAccessory.tsx
+++ b/packages/components/src/List/ListItemLayoutAccessory.tsx
@@ -61,8 +61,8 @@ export const ListItemLayoutAccessoryInternal: FC<ListItemLayoutProps> = ({
 
 export const ListItemLayoutAccessory = styled(
   ListItemLayoutAccessoryInternal
-).attrs(({ color, disabled }) => ({
-  color: disabled ? 'text1' : color || 'text1',
+).attrs(({ color = 'text2', disabled }) => ({
+  color: disabled ? 'text1' : color,
 }))`
   ${(props) => listItemPadding({ ...props })}
   ${listItemIconCSS}

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -79,7 +79,6 @@ const TreeLayout: FC<TreeProps> = ({
 
   const density = propsDensity || treeContext.density
   const { iconGap } = listItemDimensions(density)
-  const indicatorSize = 'medium'
 
   const { accessory, content, hoverDisclosure } = getDetailOptions(propsDetail)
 
@@ -137,11 +136,7 @@ const TreeLayout: FC<TreeProps> = ({
 
   const indicatorColor = disabled ? 'text1' : color
   const innerAccordion = (
-    <Accordion
-      {...indicatorDefaults}
-      {...restProps}
-      indicatorSize={indicatorSize}
-    >
+    <Accordion {...indicatorDefaults} {...restProps}>
       <AccordionDisclosure
         color={indicatorColor}
         onMouseEnter={handleMouseEnter}
@@ -175,7 +170,6 @@ const TreeLayout: FC<TreeProps> = ({
         dividers={dividers}
         hovered={hovered}
         iconGap={iconGap}
-        indicatorSize={indicatorSize}
         keyColor={useKeyColor}
         labelBackgroundOnly={hasLabelBackgroundOnly}
         selected={selected}

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -78,7 +78,8 @@ const TreeLayout: FC<TreeProps> = ({
   const depth = treeContext.depth ? treeContext.depth : startingDepth
 
   const density = propsDensity || treeContext.density
-  const { iconGap, iconSize } = listItemDimensions(density)
+  const { iconGap } = listItemDimensions(density)
+  const indicatorSize = 'medium'
 
   const { accessory, content, hoverDisclosure } = getDetailOptions(propsDetail)
 
@@ -136,7 +137,11 @@ const TreeLayout: FC<TreeProps> = ({
 
   const indicatorColor = disabled ? 'text1' : color
   const innerAccordion = (
-    <Accordion {...indicatorDefaults} {...restProps} indicatorSize={iconSize}>
+    <Accordion
+      {...indicatorDefaults}
+      {...restProps}
+      indicatorSize={indicatorSize}
+    >
       <AccordionDisclosure
         color={indicatorColor}
         onMouseEnter={handleMouseEnter}
@@ -170,7 +175,7 @@ const TreeLayout: FC<TreeProps> = ({
         dividers={dividers}
         hovered={hovered}
         iconGap={iconGap}
-        indicatorSize={iconSize}
+        indicatorSize={indicatorSize}
         keyColor={useKeyColor}
         labelBackgroundOnly={hasLabelBackgroundOnly}
         selected={selected}

--- a/packages/components/src/Tree/TreeArtificial.tsx
+++ b/packages/components/src/Tree/TreeArtificial.tsx
@@ -38,9 +38,9 @@ import { TreeStyle } from './TreeStyle'
 export const TreeArtificial: FC<{
   density?: DensityRamp
 }> = ({ children, density = 0 }) => {
-  const { iconGap, iconSize } = listItemDimensions(density)
+  const { iconGap } = listItemDimensions(density)
   return (
-    <TreeStyle depth={-1} iconGap={iconGap} indicatorSize={iconSize} dividers>
+    <TreeStyle depth={-1} iconGap={iconGap} dividers>
       <TreeContext.Provider value={{ density, depth: 0 }}>
         <List>{children}</List>
       </TreeContext.Provider>

--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -51,9 +51,11 @@ interface TreeStyleProps extends ListItemStatefulWithHoveredProps {
   depth: number
   dividers?: boolean
   iconGap: SpacingSizes
-  indicatorSize: IconSize
   labelBackgroundOnly?: boolean
 }
+
+const indicatorSvgSize = 'small'
+const indicatorContainerSize = 'medium'
 
 export const TreeItemInner = styled(TreeItem)`
   ${listItemLabelCSS(css`
@@ -117,13 +119,21 @@ export const TreeStyle = styled.div<TreeStyleProps>`
 
   > ${Accordion} {
     > ${AccordionContent} {
-      ${({ border, depth, indicatorSize, theme }) =>
-        border && generateTreeBorder(depth, indicatorSize, theme)}
+      ${({ border, depth, theme }) =>
+        border && generateTreeBorder(depth, indicatorContainerSize, theme)}
     }
 
     > ${AccordionDisclosureStyle} {
       ${AccordionDisclosureLayout} > ${Indicator} {
+        height: ${({ theme }) => theme.sizes[indicatorContainerSize]};
         margin-right: 0;
+        width: ${({ theme }) => theme.sizes[indicatorContainerSize]};
+
+        /* stylelint-disable max-nesting-depth */
+        svg {
+          height: ${({ theme }) => theme.sizes[indicatorSvgSize]};
+          width: ${({ theme }) => theme.sizes[indicatorSvgSize]};
+        }
       }
 
       ${ListItem} {
@@ -141,8 +151,8 @@ export const TreeStyle = styled.div<TreeStyleProps>`
         Tree's padding-right is handled by the internal item
        */
       padding-right: 0;
-      ${({ depth, indicatorSize, theme }) =>
-        generateIndent(depth, indicatorSize, theme)}
+      ${({ depth, theme }) =>
+        generateIndent(depth, indicatorContainerSize, theme)}
     }
   }
 
@@ -150,13 +160,18 @@ export const TreeStyle = styled.div<TreeStyleProps>`
 
   > ${Accordion} > ${AccordionContent} > ${List} {
     > ${ListItem} {
-      ${({ depth, indicatorSize, labelBackgroundOnly, theme }) =>
-        treeItemIndent(depth, indicatorSize, !!labelBackgroundOnly, theme)}
+      ${({ depth, labelBackgroundOnly, theme }) =>
+        treeItemIndent(
+          depth,
+          indicatorContainerSize,
+          !!labelBackgroundOnly,
+          theme
+        )}
     }
 
     > ${TreeBranch} {
-      ${({ depth, indicatorSize, theme }) =>
-        generateIndent(depth + 2, indicatorSize, theme)}
+      ${({ depth, theme }) =>
+        generateIndent(depth + 2, indicatorContainerSize, theme)}
     }
   }
 
@@ -165,13 +180,18 @@ export const TreeStyle = styled.div<TreeStyleProps>`
    */
   > ${List} {
     > ${ListItem} {
-      ${({ depth, indicatorSize, labelBackgroundOnly, theme }) =>
-        treeItemIndent(depth, indicatorSize, !!labelBackgroundOnly, theme)}
+      ${({ depth, labelBackgroundOnly, theme }) =>
+        treeItemIndent(
+          depth,
+          indicatorContainerSize,
+          !!labelBackgroundOnly,
+          theme
+        )}
     }
 
     > ${TreeBranch} {
-      ${({ depth, indicatorSize, theme }) =>
-        generateIndent(depth + 2, indicatorSize, theme)}
+      ${({ depth, theme }) =>
+        generateIndent(depth + 2, indicatorContainerSize, theme)}
     }
   }
 `

--- a/packages/components/src/Tree/TreeStyle.tsx
+++ b/packages/components/src/Tree/TreeStyle.tsx
@@ -37,6 +37,10 @@ import { ListItemStatefulWithHoveredProps } from '../List/types'
 import { List, ListItem } from '../List'
 import { listItemLabelCSS } from '../List/ListItemLabel'
 import { IconPlaceholder, IconSize } from '../Icon'
+import {
+  AccordionDisclosureLayout,
+  Indicator,
+} from '../Accordion/AccordionDisclosureLayout'
 import { TreeItem } from './TreeItem'
 import { TreeBranch } from './TreeBranch'
 import { generateIndent, generateTreeBorder } from './utils'
@@ -118,6 +122,10 @@ export const TreeStyle = styled.div<TreeStyleProps>`
     }
 
     > ${AccordionDisclosureStyle} {
+      ${AccordionDisclosureLayout} > ${Indicator} {
+        margin-right: 0;
+      }
+
       ${ListItem} {
         ${({ labelBackgroundOnly, ...restProps }) =>
           labelBackgroundOnly && listItemBackgroundColor(restProps)}

--- a/packages/components/src/Tree/stories/BorderRadius.story.tsx
+++ b/packages/components/src/Tree/stories/BorderRadius.story.tsx
@@ -27,6 +27,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { AccordionDisclosureStyle } from '../../Accordion'
+import { ListItem } from '../../List/ListItem'
 import { ListItemLabel } from '../../List/ListItemLabel'
 import { TreeItem, Tree } from '..'
 
@@ -39,8 +40,16 @@ export const BorderRadiusOverride = () => (
   </BorderRadiusOverrideTree>
 )
 
-const BorderRadiusOverrideTree = styled(Tree)`
-  ${AccordionDisclosureStyle},
+// TODO: Package these overrides into a util function
+export const BorderRadiusOverrideTree = styled(Tree)`
+  ${AccordionDisclosureStyle} {
+    border-radius: ${({ theme }) => theme.radii.medium};
+
+    ${ListItem} {
+      border-radius: ${({ theme }) => theme.radii.medium};
+    }
+  }
+
   ${ListItemLabel} {
     border-radius: ${({ theme }) => theme.radii.medium};
   }

--- a/packages/components/src/Tree/stories/FieldPicker.story.tsx
+++ b/packages/components/src/Tree/stories/FieldPicker.story.tsx
@@ -24,31 +24,24 @@
 
  */
 
-import React, { FC, ReactNode, useState } from 'react'
+import React, { FC, useState } from 'react'
 import styled from 'styled-components'
 import { FilterList } from '@styled-icons/material/FilterList'
 import { MoreVert } from '@styled-icons/material/MoreVert'
 import { SubdirectoryArrowLeft } from '@styled-icons/material/SubdirectoryArrowLeft'
 import { Info } from '@styled-icons/material-outlined/Info'
-import { ChevronRight } from '@styled-icons/material-rounded/ChevronRight'
-import { ExpandMore } from '@styled-icons/material-rounded/ExpandMore'
 import {
   IconButton,
   Menu,
   MenuItem,
   Tooltip,
   Popover,
-  Accordion,
-  AccordionContent,
-  AccordionDisclosure,
-  Space,
-  Truncate,
   Badge,
   Paragraph,
   Flex,
   FlexItem,
 } from '../..'
-import { Tree, TreeArtificial, TreeItem, TreeBranch } from '..'
+import { Tree, TreeItem, TreeBranch } from '..'
 import { HoverDisclosure } from '../../utils'
 
 const PickerItem: FC<{ color?: string; truncate?: boolean }> = ({
@@ -138,7 +131,7 @@ const StyledParagraph = styled(Paragraph)`
 `
 
 const fields = (
-  <TreeArtificial density={-3}>
+  <>
     <TreeBranch>
       <StyledParagraph
         color="text1"
@@ -175,35 +168,24 @@ const fields = (
     </TreeBranch>
     <PickerItem color="orange">Sum</PickerItem>
     <PickerItem color="orange">Max</PickerItem>
-  </TreeArtificial>
-)
-
-const ViewAccordion: FC<{
-  children: ReactNode
-  defaultOpen?: boolean
-  label: string
-}> = ({ children, defaultOpen, label }) => (
-  <Accordion
-    defaultOpen={defaultOpen}
-    indicatorSize="xxsmall"
-    indicatorIcons={{ close: <ChevronRight />, open: <ExpandMore /> }}
-  >
-    <AccordionDisclosure px="xxsmall" py="none" fontSize="xsmall">
-      <Space between>
-        <Truncate>{label}</Truncate>
-        <Badge intent="inform">1</Badge>
-      </Space>
-    </AccordionDisclosure>
-    <AccordionContent>{children}</AccordionContent>
-  </Accordion>
+  </>
 )
 
 export const FieldPicker = () => (
   <>
-    <ViewAccordion defaultOpen={true} label="Orders">
+    <Tree
+      density={-3}
+      defaultOpen={true}
+      detail={<Badge intent="inform">1</Badge>}
+      label="Orders"
+    >
       {fields}
-    </ViewAccordion>
-    <ViewAccordion label="Order Items">{fields}</ViewAccordion>
-    <ViewAccordion label="Users">{fields}</ViewAccordion>
+    </Tree>
+    <Tree density={-3} label="Order Items">
+      {fields}
+    </Tree>
+    <Tree density={-3} label="Users">
+      {fields}
+    </Tree>
   </>
 )

--- a/packages/components/src/Tree/stories/FieldPicker.story.tsx
+++ b/packages/components/src/Tree/stories/FieldPicker.story.tsx
@@ -31,18 +31,19 @@ import { MoreVert } from '@styled-icons/material/MoreVert'
 import { SubdirectoryArrowLeft } from '@styled-icons/material/SubdirectoryArrowLeft'
 import { Info } from '@styled-icons/material-outlined/Info'
 import {
+  Box,
   IconButton,
   Menu,
   MenuItem,
   Tooltip,
   Popover,
-  Badge,
   Paragraph,
   Flex,
   FlexItem,
 } from '../..'
-import { Tree, TreeItem, TreeBranch } from '..'
+import { TreeItem, TreeBranch } from '..'
 import { HoverDisclosure } from '../../utils'
+import { BorderRadiusOverrideTree } from './BorderRadius.story'
 
 const PickerItem: FC<{ color?: string; truncate?: boolean }> = ({
   children = 'Cost',
@@ -100,7 +101,7 @@ const PickerItem: FC<{ color?: string; truncate?: boolean }> = ({
       }}
       truncate={truncate}
     >
-      <Flex alignItems="center">
+      <Flex alignItems="center" px="xxsmall">
         <FlexItem flex={1}>{children}</FlexItem>
         <HoverDisclosure>
           <IconButton
@@ -145,11 +146,14 @@ const fields = (
         DIMENSIONS
       </StyledParagraph>
     </TreeBranch>
-    <Tree branchFontWeight label="Created">
+    <BorderRadiusOverrideTree
+      branchFontWeight
+      label={<Box px="xxsmall">Created</Box>}
+    >
       <PickerItem>Created Date</PickerItem>
       <PickerItem>Created Month</PickerItem>
       <PickerItem>Created Year</PickerItem>
-    </Tree>
+    </BorderRadiusOverrideTree>
     <PickerItem>City</PickerItem>
     <PickerItem>Country</PickerItem>
     <PickerItem>ID</PickerItem>
@@ -173,19 +177,28 @@ const fields = (
 
 export const FieldPicker = () => (
   <>
-    <Tree
+    <BorderRadiusOverrideTree
       density={-3}
       defaultOpen={true}
-      detail={<Badge intent="inform">1</Badge>}
-      label="Orders"
+      detail={3}
+      label={<Box px="xxsmall">Orders</Box>}
+      labelBackgroundOnly
     >
       {fields}
-    </Tree>
-    <Tree density={-3} label="Order Items">
+    </BorderRadiusOverrideTree>
+    <BorderRadiusOverrideTree
+      density={-3}
+      label={<Box px="xxsmall">Order Items</Box>}
+      labelBackgroundOnly
+    >
       {fields}
-    </Tree>
-    <Tree density={-3} label="Users">
+    </BorderRadiusOverrideTree>
+    <BorderRadiusOverrideTree
+      density={-3}
+      label={<Box px="xxsmall">Users</Box>}
+      labelBackgroundOnly
+    >
       {fields}
-    </Tree>
+    </BorderRadiusOverrideTree>
   </>
 )

--- a/packages/components/src/Tree/utils/generateBorderRadius.tsx
+++ b/packages/components/src/Tree/utils/generateBorderRadius.tsx
@@ -30,7 +30,7 @@ import { AccordionDisclosureStyle } from '../../Accordion'
 import { ListItem } from '../../List/ListItem'
 import { ListItemLabel } from '../../List/ListItemLabel'
 
-// util function to create medium border radius on Tree and sub-Tree components
+// Creates CSS for generating border radius on Tree and sub-Tree components
 export const generateBorderRadius = (
   borderRadius: RadiusSizes,
   theme: Theme

--- a/packages/components/src/Tree/utils/generateBorderRadius.tsx
+++ b/packages/components/src/Tree/utils/generateBorderRadius.tsx
@@ -24,20 +24,30 @@
 
  */
 
-import React from 'react'
-import styled from 'styled-components'
-import { TreeItem, Tree } from '..'
-import { generateBorderRadius } from '../utils/generateBorderRadius'
+import { RadiusSizes, Theme } from '@looker/design-tokens'
+import { css } from 'styled-components'
+import { AccordionDisclosureStyle } from '../../Accordion'
+import { ListItem } from '../../List/ListItem'
+import { ListItemLabel } from '../../List/ListItemLabel'
 
-export const BorderRadiusOverride = () => (
-  <BorderRadiusOverrideTree selected label="Created" defaultOpen dividers>
-    <TreeItem selected>Created Date</TreeItem>
-    <TreeItem selected>Created Month</TreeItem>
-    <TreeItem selected>Created Year</TreeItem>
-    <TreeItem selected>Created Quarter</TreeItem>
-  </BorderRadiusOverrideTree>
-)
+// util function to create medium border radius on Tree and sub-Tree components
+export const generateBorderRadius = (
+  borderRadius: RadiusSizes,
+  theme: Theme
+) => {
+  const { radii } = theme
 
-export const BorderRadiusOverrideTree = styled(Tree)`
-  ${({ theme }) => generateBorderRadius('medium', theme)}
-`
+  return css`
+    ${AccordionDisclosureStyle} {
+      border-radius: ${radii[borderRadius]};
+
+      ${ListItem} {
+        border-radius: ${radii[borderRadius]};
+      }
+    }
+
+    ${ListItemLabel} {
+      border-radius: ${radii[borderRadius]};
+    }
+  `
+}

--- a/packages/components/src/Tree/utils/generateIndent.ts
+++ b/packages/components/src/Tree/utils/generateIndent.ts
@@ -27,20 +27,16 @@
 import { css } from 'styled-components'
 import { Theme } from '@looker/design-tokens'
 import { IconSize } from '../../Icon'
-import { indicatorDefaults } from './indicatorDefaults'
 
 export const generateIndent = (
   depth: number,
   indicatorSize: IconSize,
   theme: Theme
 ) => {
-  const { sizes, space } = theme
-  const { indicatorGap } = indicatorDefaults
+  const { sizes } = theme
 
-  const treePaddingSize = space.xxsmall
   const indicatorIconSize = sizes[indicatorSize]
-  const indicatorGapSize = space[indicatorGap]
-  const indentCalculation = `${treePaddingSize} + (${indicatorIconSize} + ${indicatorGapSize}) * ${depth}`
+  const indentCalculation = `(${indicatorIconSize}) * ${depth}`
 
   return css`
     padding-left: calc(${indentCalculation});


### PR DESCRIPTION
- Updated alignment logic to only use constant indicator icon size when calculating indent padding

**NOTE:** `border` prop is currently broken because of indentation changes. I need to patch this up (or perform a follow-up PR).

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
