### PR TITLE
fix(RangeSlider): Value state reverting if re-rendered before prop is updated

### DIFF
--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
@@ -44,7 +44,6 @@ const NumberFilter = ({
   AST: { value?: number[] }
   onChange: (value: number[]) => void
 }) => {
-  // const rangeValue = React.useMemo(() => getRange(value), [value])
   const rangeValue = getRange(value)
   return (
     <RangeSlider min={0} max={100} value={rangeValue} onChange={onChange} />
@@ -86,5 +85,6 @@ export const RerenderRepro = () => {
 }
 
 RerenderRepro.parameters = {
+  docs: { disable: true },
   storyshots: { disable: true },
 }

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
@@ -1,0 +1,90 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React from 'react'
+import { RangeSlider } from './RangeSlider'
+
+export default {
+  component: RangeSlider,
+  title: 'RangeSlider',
+}
+
+const getRange = (value?: number[]) => [
+  value && value[0] ? value[0] : 0,
+  value && value[1] ? value[1] : 0,
+]
+
+const NumberFilter = ({
+  AST: { value },
+  onChange,
+}: {
+  AST: { value?: number[] }
+  onChange: (value: number[]) => void
+}) => {
+  // const rangeValue = React.useMemo(() => getRange(value), [value])
+  const rangeValue = getRange(value)
+  return (
+    <RangeSlider min={0} max={100} value={rangeValue} onChange={onChange} />
+  )
+}
+
+const getValue = (expression: string) =>
+  expression.split(',').map((text) => parseInt(text, 10))
+
+const Filter = ({
+  expression,
+  onChange,
+}: {
+  expression: string
+  onChange: (expression: string) => void
+}) => {
+  const [AST, setAST] = React.useState({
+    value: getValue(expression),
+  })
+  const expressionRef = React.useRef(expression)
+  React.useEffect(() => {
+    if (expressionRef.current !== expression) {
+      setAST({ value: getValue(expression) })
+      expressionRef.current = expression
+    }
+  }, [expression])
+  const handleChange = (newValue: number[]) => {
+    onChange(newValue.join(','))
+  }
+  return <NumberFilter AST={AST} onChange={handleChange} />
+}
+
+export const RerenderRepro = () => {
+  const [expression, setExpression] = React.useState('0,10')
+  const handleChange = (newValue: string) => {
+    setExpression(newValue)
+  }
+  return <Filter expression={expression} onChange={handleChange} />
+}
+
+RerenderRepro.parameters = {
+  storyshots: { disable: true },
+}

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
@@ -25,12 +25,13 @@
  */
 
 import React from 'react'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import {
   renderWithTheme,
   withThemeProvider,
 } from '@looker/components-test-utils'
 import { RangeSlider } from './RangeSlider'
+import { RerenderRepro } from './RangeSlider.story'
 
 const globalConsole = global.console
 const globalRequestAnimationFrame = global.requestAnimationFrame
@@ -239,5 +240,21 @@ describe('disabled prop', () => {
 
     expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
     expect(handleChange).toHaveBeenCalledTimes(1)
+  })
+
+  test('intermediate re-render does not cause value to revert', () => {
+    renderWithTheme(<RerenderRepro />)
+
+    const minThumb = screen.getByLabelText('Minimum Value')
+    const maxThumb = screen.getByLabelText('Maximum Value')
+
+    expect(minThumb).toHaveAttribute('aria-valuenow', '0')
+    expect(maxThumb).toHaveAttribute('aria-valuenow', '10')
+
+    maxThumb.focus()
+    fireEvent.keyDown(maxThumb, { key: 'ArrowRight' })
+
+    expect(minThumb).toHaveAttribute('aria-valuenow', '0')
+    expect(maxThumb).toHaveAttribute('aria-valuenow', '11')
   })
 })

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -343,8 +343,15 @@ export const InternalRangeSlider = forwardRef(
       if (!isEqual(value, boundedValue)) {
         setValue(sort(boundedValue))
       }
+      // Use JSON stringify for deep comparison
+      // Fixes issue where if a re-render occurs in the parent/ancestor
+      // between setValue(newValue) and the value prop updating,
+      // but the value prop is not memoized in the parent/ancestor
+      // shallow diffing in the deps array causes state value
+      // to be reverted to the stale prop value
+
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [valueProp])
+    }, [JSON.stringify(valueProp)])
 
     /*
      * Fire onChange callback when internal value changes

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -343,15 +343,12 @@ export const InternalRangeSlider = forwardRef(
       if (!isEqual(value, boundedValue)) {
         setValue(sort(boundedValue))
       }
-      // Use JSON stringify for deep comparison
-      // Fixes issue where if a re-render occurs in the parent/ancestor
-      // between setValue(newValue) and the value prop updating,
-      // but the value prop is not memoized in the parent/ancestor
-      // shallow diffing in the deps array causes state value
-      // to be reverted to the stale prop value
-
+      // Compares of the min & max values (or fallbacks) themselves to avoid
+      // unintentionally reverting state value due to shallow diffing
+      // a newly instantiated but stale valueProp, if [valueProp] were used
+      // (see RerenderRepro story)
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [JSON.stringify(valueProp)])
+    }, valueProp || [min, max])
 
     /*
      * Fire onChange callback when internal value changes


### PR DESCRIPTION
This `RangeSlider` issue was uncovered in the core product Filter component when an intermediate re-render occurs _after_ the user drags a slider thumb but _before_ the prop reflects the change. Because the `value` prop is an array, newly instantiated on each render, the shallow diffing on the `[valueProp]` dependency array in a `useEffect` in `RangeSlider` caused the state value to be reverted to the stale prop value.

This PR removes the `[]` around `valueProp` in the dependency array to allow comparison of the min & max values themselves.

The use of the `RerenderRepro` story in the unit test is a newish pattern for us (used once in `Drawer.test.tsx`), an idea from @lukelooker a while back that I thought was great.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11
