### PR TITLE
fix(Truncate): Prevent spurious scrollbar presentation due to browser settings

### DIFF
--- a/packages/components/src/Truncate/Truncate.tsx
+++ b/packages/components/src/Truncate/Truncate.tsx
@@ -87,7 +87,7 @@ const TruncateLayout: FC<TruncateProps> = ({
 
 const TextStyle = styled.span<WidthProps>`
   display: block;
-  overflow-x: hidden;
+  overflow: hidden;
   text-overflow: ellipsis;
   ${widthHelper}
   white-space: nowrap;


### PR DESCRIPTION
In some cases scroll bars may be displayed on `Truncate` components

- If users have checked the "always visible" scrollbar option on MacOS
- Firefox on Windows _sometimes_ triggers (not sure of exact setting)
- Chrome on Linux _sometimes_


## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] 🖼 Image Snapshot coverage
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11
