### PR TITLE
fix(DialogLayout): Delay rendering dialog content by one frame

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogLayout.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, ReactNode } from 'react'
+import React, { FC, ReactNode, useState } from 'react'
 import { Spinner } from '../../Spinner'
 import { DialogContent } from './DialogContent'
 import { DialogFooter } from './DialogFooter'
@@ -73,8 +73,16 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
   header,
   headerCloseButton = !footer && true,
   headerDetail,
-  isLoading,
+  isLoading: isContentLoading,
 }) => {
+  // Delay rendering dialog content by one frame.
+  // This resolves a race condition where child content that needs a dom measurement
+  // finds width/height to be zero when it measures before dialog content finishes rendering.
+  const [isInitialLoad, setIsInitialLoad] = useState(true)
+  requestAnimationFrame(() => {
+    setIsInitialLoad(false)
+  })
+
   const dialogHeader = header && (
     <DialogHeader hideClose={!headerCloseButton} detail={headerDetail}>
       {header}
@@ -89,7 +97,7 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
     <>
       {dialogHeader}
       <DialogContent hasFooter={!dialogFooter} hasHeader={!dialogHeader}>
-        {isLoading ? <DialogLoading /> : children}
+        {isContentLoading || isInitialLoad ? <DialogLoading /> : children}
       </DialogContent>
       {dialogFooter}
     </>

--- a/packages/components/src/Dialog/stories/Dialog.story.tsx
+++ b/packages/components/src/Dialog/stories/Dialog.story.tsx
@@ -28,6 +28,9 @@ import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { DialogLongContent } from '../../__mocks__/DialogLongContent'
 import { DialogMediumContent } from '../../__mocks__/DialogMediumContent'
+import { SpaceVertical } from '../../Layout/Space/SpaceVertical'
+import { CopyToClipboard } from '../../CopyToClipboard'
+import { Button } from '../../Button'
 import { Dialog, DialogProps } from '../Dialog'
 import { dialogSizes } from '../dialogWidth'
 import { dialogPlacements } from '../DialogSurface'
@@ -137,6 +140,28 @@ export const ClickOutside = () => {
 }
 
 ClickOutside.parameters = {
+  docs: { disable: true },
+  storyshots: { disable: true },
+}
+
+export const MultiFunctionButton = () => {
+  return (
+    <Dialog
+      content={
+        <DialogLayout header="A Dialog Example">
+          <SpaceVertical>
+            <CopyToClipboard success="Copied" content="Copy content">
+              <Button>Copy</Button>
+            </CopyToClipboard>
+          </SpaceVertical>
+        </DialogLayout>
+      }
+    >
+      <Button>Open Dialog</Button>
+    </Dialog>
+  )
+}
+MultiFunctionButton.parameters = {
   docs: { disable: true },
   storyshots: { disable: true },
 }


### PR DESCRIPTION
This PR resolves a dom measurement race condition that could cause the MultiFunctionButton to set style width=0 and height=0 when used inside a Dialog.

Original YAQs issue: https://yaqs.corp.google.com/eng/q/6551937013359050752

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
