### PR TITLE
fix(Portal): Insert element earlier to support measured components

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogLayout.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, ReactNode, useState } from 'react'
+import React, { FC, ReactNode } from 'react'
 import { Spinner } from '../../Spinner'
 import { DialogContent } from './DialogContent'
 import { DialogFooter } from './DialogFooter'
@@ -73,16 +73,8 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
   header,
   headerCloseButton = !footer && true,
   headerDetail,
-  isLoading: isContentLoading,
+  isLoading,
 }) => {
-  // Delay rendering dialog content by one frame.
-  // This resolves a race condition where child content that needs a dom measurement
-  // finds width/height to be zero when it measures before dialog content finishes rendering.
-  const [isInitialLoad, setIsInitialLoad] = useState(true)
-  requestAnimationFrame(() => {
-    setIsInitialLoad(false)
-  })
-
   const dialogHeader = header && (
     <DialogHeader hideClose={!headerCloseButton} detail={headerDetail}>
       {header}
@@ -97,7 +89,7 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
     <>
       {dialogHeader}
       <DialogContent hasFooter={!dialogFooter} hasHeader={!dialogHeader}>
-        {isContentLoading || isInitialLoad ? <DialogLoading /> : children}
+        {isLoading ? <DialogLoading /> : children}
       </DialogContent>
       {dialogFooter}
     </>

--- a/packages/components/src/Dialog/Layout/DialogLayout.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, ReactNode } from 'react'
+import React, { FC, ReactNode, useState } from 'react'
 import { Spinner } from '../../Spinner'
 import { DialogContent } from './DialogContent'
 import { DialogFooter } from './DialogFooter'
@@ -73,8 +73,16 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
   header,
   headerCloseButton = !footer && true,
   headerDetail,
-  isLoading,
+  isLoading: isContentLoading,
 }) => {
+  // Delay rendering dialog content by one frame.
+  // This resolves a race condition where child content that needs a dom measurement
+  // finds width/height to be zero when it measures before dialog content finishes rendering.
+  const [isInitialLoad, setIsInitialLoad] = useState(true)
+  requestAnimationFrame(() => {
+    setIsInitialLoad(false)
+  })
+
   const dialogHeader = header && (
     <DialogHeader hideClose={!headerCloseButton} detail={headerDetail}>
       {header}
@@ -89,7 +97,7 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
     <>
       {dialogHeader}
       <DialogContent hasFooter={!dialogFooter} hasHeader={!dialogHeader}>
-        {isLoading ? <DialogLoading /> : children}
+        {isContentLoading || isInitialLoad ? <DialogLoading /> : children}
       </DialogContent>
       {dialogFooter}
     </>

--- a/packages/components/src/Dialog/stories/Dialog.story.tsx
+++ b/packages/components/src/Dialog/stories/Dialog.story.tsx
@@ -28,6 +28,9 @@ import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { DialogLongContent } from '../../__mocks__/DialogLongContent'
 import { DialogMediumContent } from '../../__mocks__/DialogMediumContent'
+import { SpaceVertical } from '../../Layout/Space/SpaceVertical'
+import { CopyToClipboard } from '../../CopyToClipboard'
+import { Button } from '../../Button'
 import { Dialog, DialogProps } from '../Dialog'
 import { dialogSizes } from '../dialogWidth'
 import { dialogPlacements } from '../DialogSurface'
@@ -137,6 +140,28 @@ export const ClickOutside = () => {
 }
 
 ClickOutside.parameters = {
+  docs: { disable: true },
+  storyshots: { disable: true },
+}
+
+export const MultiFunctionButton = () => {
+  return (
+    <Dialog
+      content={
+        <DialogLayout header="A Dialog Example">
+          <SpaceVertical>
+            <CopyToClipboard success="Copied" content="Copy content">
+              <Button>Copy</Button>
+            </CopyToClipboard>
+          </SpaceVertical>
+        </DialogLayout>
+      }
+    >
+      <Button>Open Dialog</Button>
+    </Dialog>
+  )
+}
+MultiFunctionButton.parameters = {
   docs: { disable: true },
   storyshots: { disable: true },
 }

--- a/packages/components/src/Popover/stories/Popover.story.tsx
+++ b/packages/components/src/Popover/stories/Popover.story.tsx
@@ -33,6 +33,7 @@ import {
   Box,
   Button,
   ButtonOutline,
+  CopyToClipboard,
   Dialog,
   FieldSelect,
   FieldToggleSwitch,
@@ -436,5 +437,25 @@ export const MouseUp = () => {
 }
 
 MouseUp.parameters = {
+  storyshots: { disable: true },
+}
+
+export const MultiFunctionButton = () => {
+  return (
+    <Popover
+      content={
+        <PopoverContent>
+          <CopyToClipboard success="Copied" content="Copy content">
+            <Button>Copy</Button>
+          </CopyToClipboard>
+        </PopoverContent>
+      }
+    >
+      <Button>Open Popover</Button>
+    </Popover>
+  )
+}
+MultiFunctionButton.parameters = {
+  docs: { disable: true },
   storyshots: { disable: true },
 }

--- a/packages/components/src/Portal/Portal.tsx
+++ b/packages/components/src/Portal/Portal.tsx
@@ -24,7 +24,13 @@
 
  */
 
-import React, { forwardRef, Ref, useEffect, useRef, ReactNode } from 'react'
+import React, {
+  forwardRef,
+  Ref,
+  useLayoutEffect,
+  useRef,
+  ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 
@@ -66,7 +72,7 @@ export const Portal = forwardRef(
   (props: PortalProps, ref: Ref<HTMLDivElement>) => {
     const el = useRef(document.createElement('div'))
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       const root = getPortalRoot()
       if (!root) return
 


### PR DESCRIPTION
- `Portal` initially renders its contents into an unattached `div` which it then appends to `div#modal-root` in a `useEffect` hook
- `MultiFunctionButton` contains a `useEffect` hook that measures the height & width of the button & alternate
- When `MultiFunctionButton` is inside a `Portal` (e.g. in a `Dialog` or `Popover`), its measurement `useEffect` occurs before the `Portal`'s dom-attachment `useEffect`, so the measurements return 0
- Changing `Portal`'s `useEffect` to `useLayoutEffect` moves it before the `useEffect`s of any children, so `MultiFunctionButton`'s measurements will happen after the elements have been inserted and return appropriate values

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
