### PR TITLE
fix: use DOMRect in lieu of ClientRect

### DIFF
--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -138,7 +138,7 @@ const roundToStep = (
  */
 const calculatePointValue = (
   mouseX: number,
-  containerRect: ClientRect,
+  containerRect: DOMRect,
   min: number,
   max: number,
   step: number

--- a/packages/components/src/utils/useGlobalHotkeys.ts
+++ b/packages/components/src/utils/useGlobalHotkeys.ts
@@ -51,7 +51,7 @@ const keyCommandCollection: { [key: string]: Set<Command> } = {}
  * doRectsIntersect calculates whether two elements (often two focus traps)
  * are layered on top of each other.
  */
-const doRectsIntersect = (r1: ClientRect, r2: ClientRect) => {
+const doRectsIntersect = (r1: DOMRect, r2: DOMRect) => {
   return !(
     r2.left > r1.right ||
     r2.right < r1.left ||
@@ -64,7 +64,7 @@ const doRectsIntersect = (r1: ClientRect, r2: ClientRect) => {
  * calculateIntersectionPoint returns a pixel coordinate where two elements
  * are layered on top of each other.
  */
-const calculateIntersectionPoint = (r1: ClientRect, r2: ClientRect) => {
+const calculateIntersectionPoint = (r1: DOMRect, r2: DOMRect) => {
   const y = Math.max(r2.top, r1.top)
   const x = Math.max(r1.left, r2.left)
   return { x, y }

--- a/packages/components/src/utils/useMeasuredElement.ts
+++ b/packages/components/src/utils/useMeasuredElement.ts
@@ -29,14 +29,7 @@ import { useResize } from './useResize'
 
 function measureElement(element?: HTMLElement | null) {
   if (!element) {
-    return {
-      bottom: 0,
-      height: 0,
-      left: 0,
-      right: 0,
-      top: 0,
-      width: 0,
-    }
+    return new DOMRect()
   }
 
   return element.getBoundingClientRect()
@@ -44,7 +37,7 @@ function measureElement(element?: HTMLElement | null) {
 
 export const useMeasuredElement = (
   element: HTMLElement | null
-): [ClientRect, () => void] => {
+): [DOMRect, () => void] => {
   const [rect, setRect] = useState(measureElement())
 
   const refreshDomRect = useCallback(() => {

--- a/packages/components/src/utils/useMeasuredElement.ts
+++ b/packages/components/src/utils/useMeasuredElement.ts
@@ -29,7 +29,20 @@ import { useResize } from './useResize'
 
 function measureElement(element?: HTMLElement | null) {
   if (!element) {
-    return new DOMRect()
+    return typeof DOMRect === 'function'
+      ? new DOMRect()
+      : {
+          bottom: 0,
+          height: 0,
+          left: 0,
+          rect: {},
+          right: 0,
+          toJSON: () => null,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+        }
   }
 
   return element.getBoundingClientRect()


### PR DESCRIPTION
Align on DOMRect over ClientRect, for interoperability with ESLint's `browser` [environment global](https://github.com/sindresorhus/globals/blob/548191a277c1b946bbcba6e34d593e00290baf48/globals.json#L480).