### PR TITLE
fix(List): Only define height when windowing

### DIFF
--- a/config/i18nIgnoredProps.js
+++ b/config/i18nIgnoredProps.js
@@ -34,6 +34,7 @@ const ours = [
   'iconVerticalAlign',
   'iconViewBox',
   'textDecoration',
+  'windowing',
 ]
 const aria = [
   'aria-autocomplete',

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -28,7 +28,7 @@ import React, { FC, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { DateRange } from '@styled-icons/material-outlined/DateRange'
 import { SubdirectoryArrowLeft } from '@styled-icons/material/SubdirectoryArrowLeft'
-import { Box, Grid, Space } from '../Layout'
+import { Flex, Grid, Space } from '../Layout'
 import { DensityRamp } from './types'
 import { List, ListProps } from './List'
 import { ListItem } from './ListItem'
@@ -67,13 +67,21 @@ IconGutter.args = {
 const array3000 = Array.from(Array(3000), (_, i) => String(i))
 export const LongList = () => {
   return (
-    <Box height="500px">
-      <List>
+    <Flex height={500}>
+      <List width={200}>
         {array3000.map((item, i) => (
-          <ListItem key={i}>{item}</ListItem>
+          <ListItem key={i}>
+            {i > 0 && i % 30 === 0
+              ? 'Longlonglonglonglonglonglonglonglonglonglong'
+              : item}
+          </ListItem>
         ))}
       </List>
-    </Box>
+      <div>
+        Without width on List, windowing plus variable item widths causes the
+        layout to be unstable.
+      </div>
+    </Flex>
   )
 }
 

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -24,6 +24,7 @@
 
  */
 
+/* istanbul ignore file */
 import React, { FC, useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { DateRange } from '@styled-icons/material-outlined/DateRange'

--- a/packages/components/src/List/List.story.tsx
+++ b/packages/components/src/List/List.story.tsx
@@ -64,7 +64,7 @@ IconGutter.args = {
   iconGutter: true,
 }
 
-const array3000 = Array.from(Array(3000), (_, i) => String(i + 1))
+const array3000 = Array.from(Array(3000), (_, i) => String(i))
 export const LongList = () => {
   return (
     <Box height="500px">

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -25,10 +25,10 @@
  */
 
 import 'jest-styled-components'
-import * as React from 'react'
+import React from 'react'
+import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'
-import { ListItem } from './ListItem'
-import { List } from './List'
+import { Basic, LongList } from './List.story'
 
 /* eslint-disable-next-line @typescript-eslint/unbound-method */
 const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
@@ -62,28 +62,17 @@ describe('List', () => {
     })
 
     test('fixed', () => {
-      const arr3000 = Array.from(Array(3000), (_, i) => i)
-      const {
-        getByTestId,
-        getByText,
-        queryByTestId,
-        queryByText,
-      } = renderWithTheme(
-        <List>
-          {arr3000.map((num) => (
-            <ListItem key={num}>{num}</ListItem>
-          ))}
-        </List>
-      )
+      renderWithTheme(<LongList />)
 
+      expect(screen.getByRole('list')).toHaveStyle('height: 100%')
       /**
        * We expect the first 16 elements based on the math below:
        * 6 + 360px / 36px
        * (buffer elements) + (ul height from mock / default ListItem height)
        */
-      expect(getByText('0')).toBeVisible()
-      expect(getByText('15')).toBeVisible()
-      expect(queryByText('16')).not.toBeInTheDocument()
+      expect(screen.getByText('0')).toBeVisible()
+      expect(screen.getByText('15')).toBeVisible()
+      expect(screen.queryByText('16')).not.toBeInTheDocument()
 
       /**
        * We expect the after container to have height: 107424px based on the math below:
@@ -91,8 +80,14 @@ describe('List', () => {
        * (total ListItems - displayed ListItems) * default ListItem height
        */
       const height = (3000 - 16) * 36
-      expect(queryByTestId('before')).not.toBeInTheDocument()
-      expect(getByTestId('after')).toHaveStyle(`height: ${height}px;`)
+      expect(screen.queryByTestId('before')).not.toBeInTheDocument()
+      expect(screen.getByTestId('after')).toHaveStyle(`height: ${height}px;`)
+    })
+
+    test('no height: 100% without windowing', () => {
+      renderWithTheme(<Basic />)
+
+      expect(screen.getByRole('list')).not.toHaveStyle('height: 100%')
     })
   })
 })

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -36,7 +36,6 @@ import styled from 'styled-components'
 import {
   CompatibleHTMLProps,
   reset,
-  omitStyledProps,
   shouldForwardProp,
 } from '@looker/design-tokens'
 import { useArrowKeyNav, useWindow } from '../utils'
@@ -137,6 +136,7 @@ export const ListInternal = forwardRef(
           tabIndex={-1}
           role={role || 'list'}
           windowing={windowing}
+          {...props}
           {...navProps}
         >
           {content}

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -37,6 +37,7 @@ import {
   CompatibleHTMLProps,
   reset,
   omitStyledProps,
+  shouldForwardProp,
 } from '@looker/design-tokens'
 import { useArrowKeyNav, useWindow } from '../utils'
 import { ListItemContext } from './ListItemContext'
@@ -132,23 +133,27 @@ export const ListInternal = forwardRef(
 
     return (
       <ListItemContext.Provider value={context}>
-        <ul
+        <ListStyle
           tabIndex={-1}
           role={role || 'list'}
-          {...omitStyledProps(props)}
+          windowing={windowing}
           {...navProps}
         >
           {content}
-        </ul>
+        </ListStyle>
       </ListItemContext.Provider>
     )
   }
 )
 
-export const List = styled(ListInternal)`
+const ListStyle = styled.ul.withConfig({ shouldForwardProp })<
+  Pick<ListProps, 'windowing'>
+>`
   ${reset}
 
-  height: 100%;
+  ${({ windowing }) => windowing !== 'none' && 'height: 100%;'}
   list-style: none;
   overflow: auto;
 `
+
+export const List = styled(ListInternal)``

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -25,14 +25,15 @@
  */
 
 import React, { cloneElement, forwardRef, Ref, ReactElement } from 'react'
-import { useID } from '../utils'
+import { ListProps } from '../List'
 import {
   Popover,
   PopoverProps,
   UsePopoverResponseDom,
   popoverPropKeys,
 } from '../Popover'
-import { MenuList, MenuListProps } from './MenuList'
+import { useID } from '../utils'
+import { MenuList } from './MenuList'
 
 export interface MenuDomProps extends UsePopoverResponseDom {
   'aria-controls': string
@@ -40,7 +41,7 @@ export interface MenuDomProps extends UsePopoverResponseDom {
 
 export interface MenuProps
   extends Omit<PopoverProps, 'children'>,
-    Omit<MenuListProps, 'children' | 'content'> {
+    Omit<ListProps, 'children' | 'content'> {
   /**
    * A ReactElement that accepts dom props
    */

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -24,20 +24,14 @@
 
  */
 
-import { width, WidthProps } from '@looker/design-tokens'
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import { List, ListProps } from '../List'
 import { listPadding } from '../List/utils'
 import { NestedMenuProvider } from './NestedMenuProvider'
 
-export interface MenuListProps extends ListProps, WidthProps {}
-
 export const MenuListInternal = forwardRef(
-  (
-    { children, ...props }: MenuListProps,
-    forwardedRef: Ref<HTMLUListElement>
-  ) => {
+  ({ children, ...props }: ListProps, forwardedRef: Ref<HTMLUListElement>) => {
     return (
       <NestedMenuProvider>
         <List role="menu" ref={forwardedRef} {...props}>
@@ -50,9 +44,7 @@ export const MenuListInternal = forwardRef(
 MenuListInternal.displayName = 'MenuListInternal'
 
 export const MenuList = styled(MenuListInternal)`
-  ${width}
   min-width: 12rem;
-  overflow: auto;
 
   ${listPadding}
 `

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -146,7 +146,9 @@ const TreeLayout: FC<TreeProps> = ({
         {label}
       </AccordionDisclosure>
       <AccordionContent>
-        <List density={density}>{children}</List>
+        <List density={density} windowing="none">
+          {children}
+        </List>
       </AccordionContent>
     </Accordion>
   )


### PR DESCRIPTION
The `height: 100%` style on `List` is necessary for windowing to work, but it can be problematic for non-scrolling, non-windowed lists when the container's height is defined (say 100% of the window height) but `List` is not the only child and is not intended to take up the full height of the container. For example, this page shouldn't need to scroll: https://codesandbox.io/s/stupefied-sanne-9vsm1

This PR removes `height: 100%` when `windowing` is `none`.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
