### PR TITLE
docs(DataTable): Update examples with deprecated widthPercent prop (size is correct)

### DIFF
--- a/www/src/documentation/components/content/data-table.mdx
+++ b/www/src/documentation/components/content/data-table.mdx
@@ -317,13 +317,13 @@ The following properties are **optional** in the object passed into the `select`
       id: 'id',
       title: 'ID',
       type: 'number',
-      widthPercent: 20,
+      size: 20,
     },
     {
       id: 'name',
       title: 'Name',
       type: 'string',
-      widthPercent: 80,
+      size: 80,
     },
   ]
 
@@ -416,13 +416,13 @@ The `useSelectManager` hook can be used to quickly create the standard building 
       id: 'id',
       title: 'ID',
       type: 'number',
-      widthPercent: 20,
+      size: 20,
     },
     {
       id: 'name',
       title: 'Name',
       type: 'string',
-      widthPercent: 80,
+      size: 80,
     },
   ]
 
@@ -502,13 +502,13 @@ The `bulk` prop is used to configure a `DataTable`'s control bar. The object pas
       id: 'id',
       title: 'ID',
       type: 'number',
-      widthPercent: 20,
+      size: 20,
     },
     {
       id: 'name',
       title: 'Name',
       type: 'string',
-      widthPercent: 80,
+      size: 80,
     },
   ]
 
@@ -599,13 +599,13 @@ DataTable plays nicely with [Truncate](/components/text/truncate), when you wish
       id: 'title',
       title: 'Title',
       type: 'string',
-      widthPercent: 20,
+      size: 20,
     },
     {
       id: 'description',
       title: 'Description',
       type: 'string',
-      widthPercent: 80,
+      size: 80,
     },
   ]
 


### PR DESCRIPTION

- [x] 📚 Documentation updated