### PR TITLE
docs: Correct assumption of global CSS reset

### DIFF
--- a/www/src/Layout/Layout.tsx
+++ b/www/src/Layout/Layout.tsx
@@ -53,6 +53,7 @@ const setThemeInStorage = (theme: ThemeCustomizations) =>
 const GatsbyOverrides = createGlobalStyle`
   body {
     height: 100vh;
+    margin: 0;
   }
 
   #___gatsby,
@@ -77,7 +78,7 @@ export const Layout: FC = ({ children }) => {
     <ComponentsProvider loadGoogleFonts themeCustomizations={customTheme}>
       <GatsbyOverrides />
       <MDXProvider components={MDXComponents}>
-        <Page>
+        <Page fixed>
           <Header height="4rem">
             <HeaderContent
               updateTheme={updateTheme}

--- a/www/src/components/HeaderContent/AppLogo.tsx
+++ b/www/src/components/HeaderContent/AppLogo.tsx
@@ -46,6 +46,7 @@ export const AppLogo = styled(AppLogoLayout)`
   align-items: center;
   display: flex;
   height: 1.5rem;
+  text-decoration: none;
 
   img {
     height: 24px;

--- a/www/src/components/HeaderContent/HeaderContent.tsx
+++ b/www/src/components/HeaderContent/HeaderContent.tsx
@@ -124,6 +124,7 @@ export const NavigationList = styled.nav`
   ul,
   li {
     height: 100%;
+    list-style: none;
   }
 
   a {

--- a/www/src/components/Navigation/Page.tsx
+++ b/www/src/components/Navigation/Page.tsx
@@ -54,6 +54,7 @@ export const Page = styled(PageLayout)`
     color: ${({ theme }) => theme.colors.link};
     display: block;
     padding: ${({ theme: { space } }) => `${space.xsmall} ${space.xlarge}`};
+    text-decoration: none;
 
     &:hover {
       background: ${({ theme }) => theme.colors.ui1};

--- a/www/src/components/Navigation/Section.tsx
+++ b/www/src/components/Navigation/Section.tsx
@@ -77,4 +77,5 @@ export const Section: FC<SectionProps> = ({ section }) => {
 const PageList = styled.ul`
   font-size: ${({ theme }) => theme.fontSizes.small};
   list-style-type: none;
+  padding: 0;
 `

--- a/www/src/components/Status.tsx
+++ b/www/src/components/Status.tsx
@@ -27,10 +27,12 @@
 import React, { FC } from 'react'
 import { Link } from 'gatsby'
 import { Badge } from '@looker/components'
+import styled from 'styled-components'
 
 export type StatusLabels = 'experimental' | 'deprecated' | 'stable'
 
 export interface StatusProps {
+  className?: string
   status: StatusLabels
 }
 
@@ -45,12 +47,16 @@ const mapStatusToIntent = (status: StatusLabels) => {
   }
 }
 
-export const Status: FC<StatusProps> = ({ status }) => {
+const StatusLayout: FC<StatusProps> = ({ className, status }) => {
   status = status || 'stable'
 
   return (
-    <Link to="/develop/support-levels">
+    <Link to="/develop/support-levels" className={className}>
       <Badge intent={mapStatusToIntent(status)}>{status.toUpperCase()}</Badge>
     </Link>
   )
 }
+
+export const Status = styled(StatusLayout)`
+  text-decoration: none;
+`


### PR DESCRIPTION
Minor corrects to documentation site styling due to refactor of @looker/components CSS reset removal.