### PR TITLE
chore(ci): Cancel CI runs from previous pushes to branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  cancel:
+    name: "Cancel Previous Runs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
   lint:
     name: "Lint: ESLint + Prettier, Stylelint, Typescript"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github Actions have been really slow today (sitting in queue for a looong time) - I realized that one thing we could do to save resources is to cancel runs when a developer does another push to the same Pull Request before the previous run has not yet finished.

This PR leverages a Github Action to do so: https://github.com/marketplace/actions/cancel-workflow-action