### PR TITLE
fix(useHovered): Invalid argument error

### DIFF
--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -250,7 +250,7 @@ export const Hover = () => {
   const close = () => setOpen(false)
 
   return (
-    <Card ref={hoverRef} p="large" raised height="auto">
+    <Card ref={hoverRef} p="large" raised height="auto" tabIndex={0}>
       <Space between>
         <Paragraph>
           Hovering in this card will show the button that triggers the menu.

--- a/packages/components/src/utils/useHovered.test.tsx
+++ b/packages/components/src/utils/useHovered.test.tsx
@@ -1,0 +1,84 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { useRef } from 'react'
+import { useHovered } from './useHovered'
+
+const HoveredComponent = () => {
+  const hoverRef = useRef<HTMLDivElement>(null)
+  const [isHovered] = useHovered(hoverRef)
+  return (
+    <div ref={hoverRef} tabIndex={0}>
+      hover me
+      {isHovered && <button>button</button>}
+    </div>
+  )
+}
+
+describe('useHovered', () => {
+  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>
+  beforeEach(() => {
+    rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: any) => cb())
+  })
+  afterEach(() => {
+    rafSpy.mockRestore()
+  })
+
+  it('toggles on hover', () => {
+    render(<HoveredComponent />)
+    expect(screen.queryByText('button')).not.toBeInTheDocument()
+
+    const hoverMe = screen.getByText('hover me')
+    userEvent.hover(hoverMe)
+    expect(screen.getByText('button')).toBeVisible()
+    userEvent.unhover(hoverMe)
+    expect(screen.queryByText('button')).not.toBeInTheDocument()
+  })
+
+  it('toggles on focus', () => {
+    render(<HoveredComponent />)
+    expect(screen.queryByText('button')).not.toBeInTheDocument()
+    userEvent.tab()
+
+    const button = screen.getByText('button')
+    expect(button).toBeVisible()
+    userEvent.tab()
+
+    // With the button focused, hovering in & out should have no effect
+    const hoverMe = screen.getByText('hover me')
+    userEvent.hover(hoverMe)
+    expect(button).toBeVisible()
+    userEvent.unhover(hoverMe)
+    expect(button).toBeVisible()
+
+    userEvent.tab()
+    expect(screen.queryByText('button')).not.toBeInTheDocument()
+  })
+})

--- a/packages/components/src/utils/useHovered.ts
+++ b/packages/components/src/utils/useHovered.ts
@@ -55,12 +55,14 @@ export function useHovered<E extends HTMLElement = HTMLElement>(
     }
     function handleMouseLeave() {
       window.requestAnimationFrame(() => {
-        const node = getCurrentNode(element) as Node
+        const node = getCurrentNode(element)
 
-        const relationship = node.compareDocumentPosition(
-          document.activeElement as Node
-        )
+        const relationship =
+          document.activeElement && node
+            ? node.compareDocumentPosition(document.activeElement)
+            : Node.DOCUMENT_POSITION_DISCONNECTED
 
+        // Don't set isHovered to false if a child of the element is currently focused
         const activeElementIsChildOfNode =
           relationship ===
           Node.DOCUMENT_POSITION_FOLLOWING + Node.DOCUMENT_POSITION_CONTAINED_BY


### PR DESCRIPTION
`useHovered` was typecasting `as Node` on arguments that might be `null` in order to call `compareDocumentPosition` and detect if a child of the hover element was currently focused. This caused an `Invalid argument` error in IE11 (though no other breakage, as far as I could tell).

This PR adds a check before calling `compareDocumentPosition` and removes the typecasting.

I also added a test suite.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11
