### PR TITLE
fix(StyleDefender): Should not override base font-size

### DIFF
--- a/packages/components-providers/src/StyleDefender.test.tsx
+++ b/packages/components-providers/src/StyleDefender.test.tsx
@@ -41,7 +41,6 @@ describe('StyleDefender', () => {
     expect(test).toHaveStyle(
       "font-family: Roboto,'Noto Sans','Noto Sans JP','Noto Sans CJK KR','Noto Sans Arabic UI','Noto Sans Devanagari UI','Noto Sans Hebrew','Noto Sans Thai UI',Helvetica,Arial,sans-serif"
     )
-    expect(test).toHaveStyle('font-size: 16px')
   })
 
   test('Computed', () => {

--- a/packages/components-providers/src/StyleDefender.tsx
+++ b/packages/components-providers/src/StyleDefender.tsx
@@ -32,8 +32,6 @@ import styled, { css } from 'styled-components'
 export const styleDefenderCSS = css`
   box-sizing: border-box;
   font-family: ${({ theme }) => theme.fonts.body};
-  font-size: 16px;
-  height: 100%;
   line-height: normal;
   width: 100%;
 


### PR DESCRIPTION
Also remove `height: 100%` behavior

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
