### PR TITLE
chore: Run yarn prebuild in canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: c-hive/gha-yarn-cache@v1
       - run: yarn install
+      - run: yarn prebuild
 
       - name: Build documentation
         run: |

--- a/config/website.sh
+++ b/config/website.sh
@@ -5,9 +5,6 @@ VERSION=$1
 # clean-up previous build if exists
 rm -rf docs/$VERSION
 
-# build icons
-yarn prebuild
-
 # Build Gatsby, then move contents to public folder for publishing
 sed -i -e "s/VERSION/$VERSION/g" www/gatsby-config.js
 yarn workspace www build

--- a/config/website.sh
+++ b/config/website.sh
@@ -5,6 +5,9 @@ VERSION=$1
 # clean-up previous build if exists
 rm -rf docs/$VERSION
 
+# build icons
+yarn prebuild
+
 # Build Gatsby, then move contents to public folder for publishing
 sed -i -e "s/VERSION/$VERSION/g" www/gatsby-config.js
 yarn workspace www build


### PR DESCRIPTION
After the [icon refactor](https://github.com/looker-open-source/components/pull/1925), `yarn prebuild` has been required in order to use `@looker/icons`.

Currently, the CI canary action is failing to build gatsby because it's not running `yarn prebuild`: https://github.com/looker-open-source/components/runs/2477449739?check_suite_focus=true#step:5:44

This PR adds the command right after `yarn install`.