### PR TITLE
feat(Accordion): Toggle on spacebar key

### DIFF
--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -39,10 +39,9 @@ import {
   TextColorProps,
   TypographyProps,
   typography,
-  CompatibleHTMLProps,
 } from '@looker/design-tokens'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
-import { useID } from '../utils'
+import { GenericClickProps, useID } from '../utils'
 import { accordionDefaults, accordionLeftDefaults } from './accordionDefaults'
 import { AccordionContent } from './AccordionContent'
 import { AccordionDisclosure } from './AccordionDisclosure'
@@ -68,7 +67,7 @@ export const AccordionControlPropKeys = [
 export interface AccordionProps
   extends AccordionControlProps,
     AccordionIndicatorProps,
-    Omit<CompatibleHTMLProps<HTMLElement>, 'content'>,
+    Omit<GenericClickProps<HTMLElement>, 'content'>,
     SimpleLayoutProps,
     TextColorProps,
     TypographyProps {

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -24,19 +24,23 @@
 
  */
 
-import React, { FC, KeyboardEvent, Ref, forwardRef, useState } from 'react'
+import React, { FC, Ref, forwardRef } from 'react'
 import styled from 'styled-components'
 import {
   TypographyProps,
   typography,
-  CompatibleHTMLProps,
   padding,
   PaddingProps,
   shouldForwardProp,
   TextColorProps,
   color as colorStyleFn,
 } from '@looker/design-tokens'
-import { useWrapEvent } from '../utils'
+import {
+  FocusVisibleProps,
+  GenericClickProps,
+  useClickable,
+  useWrapEvent,
+} from '../utils'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout/utils/simple'
 import { AccordionDisclosureLayout } from './AccordionDisclosureLayout'
 import { AccordionControlProps, AccordionIndicatorProps } from './types'
@@ -45,12 +49,11 @@ import { accordionDefaults } from './accordionDefaults'
 export interface AccordionDisclosureProps
   extends TypographyProps,
     Omit<AccordionDisclosureStyleProps, 'focusVisible'>,
-    CompatibleHTMLProps<HTMLElement>,
+    GenericClickProps<HTMLElement>,
     SimpleLayoutProps,
     AccordionControlProps,
     AccordionIndicatorProps {
   className?: string
-  focusVisible?: boolean
   ref?: Ref<HTMLDivElement>
   /**
    * ID of the corresponding AccordionContent container
@@ -72,9 +75,9 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
       accordionDisclosureId,
       children,
       className,
+      disabled,
       onBlur,
-      onClick,
-      onKeyDown,
+      onClick: propsOnClick,
       onKeyUp,
       defaultOpen,
       isOpen,
@@ -89,35 +92,15 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
     },
     ref
   ) => {
-    const [isFocusVisible, setFocusVisible] = useState(false)
-
     const handleOpen = () => onOpen && onOpen()
     const handleClose = () => onClose && onClose()
     const handleToggle = () => {
       isOpen ? handleClose() : handleOpen()
       toggleOpen && toggleOpen(!isOpen)
     }
+    const onClick = useWrapEvent(handleToggle, propsOnClick)
 
-    const handleKeyDown = useWrapEvent(
-      (event: KeyboardEvent<HTMLElement>) =>
-        event.key === 'Enter' && handleToggle(),
-      onKeyDown
-    )
-
-    const handleKeyUp = useWrapEvent(
-      (event: KeyboardEvent<HTMLElement>) =>
-        event.key === 'Tab' &&
-        event.currentTarget === event.target &&
-        setFocusVisible(true),
-      onKeyUp
-    )
-
-    const handleClick = useWrapEvent(() => {
-      setFocusVisible(false)
-      handleToggle()
-    }, onClick)
-
-    const handleBlur = useWrapEvent(() => setFocusVisible(false), onBlur)
+    const clickableProps = useClickable({ disabled, onBlur, onClick, onKeyUp })
 
     return (
       <AccordionDisclosureStyle
@@ -125,14 +108,10 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
         role="button"
         aria-controls={accordionContentId}
         aria-expanded={isOpen}
-        focusVisible={isFocusVisible}
         id={accordionDisclosureId}
-        onBlur={handleBlur}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        onKeyUp={handleKeyUp}
         ref={ref}
         tabIndex={0}
+        {...clickableProps}
         {...props}
       >
         <AccordionDisclosureLayout
@@ -153,9 +132,10 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
 
 AccordionDisclosureInternal.displayName = 'AccordionDisclosureInternal'
 
-interface AccordionDisclosureStyleProps extends TextColorProps, PaddingProps {
-  focusVisible: boolean
-}
+interface AccordionDisclosureStyleProps
+  extends TextColorProps,
+    PaddingProps,
+    FocusVisibleProps {}
 
 export const AccordionDisclosureStyle = styled.div
   .withConfig({ shouldForwardProp })

--- a/packages/components/src/Accordion/AccordionDisclosure.tsx
+++ b/packages/components/src/Accordion/AccordionDisclosure.tsx
@@ -79,6 +79,7 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
       onBlur,
       onClick: propsOnClick,
       onKeyUp,
+      role,
       defaultOpen,
       isOpen,
       toggleOpen,
@@ -100,12 +101,17 @@ const AccordionDisclosureInternal: FC<AccordionDisclosureProps> = forwardRef(
     }
     const onClick = useWrapEvent(handleToggle, propsOnClick)
 
-    const clickableProps = useClickable({ disabled, onBlur, onClick, onKeyUp })
+    const clickableProps = useClickable({
+      disabled,
+      onBlur,
+      onClick,
+      onKeyUp,
+      role,
+    })
 
     return (
       <AccordionDisclosureStyle
         className={className}
-        role="button"
         aria-controls={accordionContentId}
         aria-expanded={isOpen}
         id={accordionDisclosureId}

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -57,7 +57,6 @@ const TreeLayout: FC<TreeProps> = ({
   color: propsColor,
   label: propsLabel,
   labelBackgroundOnly: propsLabelBackgroundOnly,
-  onClick,
   onKeyUp,
   onMouseEnter,
   onMouseLeave,

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -57,7 +57,6 @@ const TreeLayout: FC<TreeProps> = ({
   color: propsColor,
   label: propsLabel,
   labelBackgroundOnly: propsLabelBackgroundOnly,
-  onKeyUp,
   onMouseEnter,
   onMouseLeave,
   selected,

--- a/packages/components/src/Tree/types.ts
+++ b/packages/components/src/Tree/types.ts
@@ -37,7 +37,7 @@ export type TreeProps = Omit<
   | 'indicatorPosition'
   | 'indicatorSize'
 > &
-  ListItemProps & {
+  Omit<ListItemProps, 'onClick'> & {
     /**
      * If true, vertical lines will extend from the Tree indicator (and all sub-Trees' indicators)
      * @default false


### PR DESCRIPTION
_Preliminary work for focus visible refactor._

As I was pulling out the focus visible logic in here to replace with the upcoming `useFocusVisible` hook, I realized `AccordionDisclosure` is actually a great use case for `useClickable`. This hook is aimed at accessibility for non-buttons that are being used in a button-y way. It adds keyup handlers for enter and spacebar keys, and it has focus visible behavior built-in. The enter key was already triggering the accordion toggle, so the only change from `useClickable` is toggling on the spacebar key.

Doing this change in a separate PR helps make the focus visible refactor more sane. 

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11
