### PR TITLE
docs(Icon): Correct documentation link to Styled Icons (bad markdown formatting)

### DIFF
--- a/www/src/documentation/components/content/icon.mdx
+++ b/www/src/documentation/components/content/icon.mdx
@@ -49,7 +49,7 @@ When using an `Icon` we strongly encourage specification of a `title` attribute.
 
 # Material Design Icons
 
-(Styled Icons)[https://styled-icons.js.org/] has a massive suite of prebuilt icons for an array of icon libraries including the Material Design collection. Within suite of components we often leverage `@styled-icons/material`, `@styled-icons/material-outlined` and `@styled-icons/material-rounded`
+[Styled Icons](https://styled-icons.js.org/) has a massive suite of prebuilt icons for an array of icon libraries including the Material Design collection. Within suite of components we often leverage `@styled-icons/material`, `@styled-icons/material-outlined` and `@styled-icons/material-rounded`
 
 ```js static
 import { Add } from '@styled-icons/material/Add'


### PR DESCRIPTION
- [x] 📚 Documentation updated