### PR TITLE
docs(README): removing yarn develop language and adding message to use gatsby or st…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ We recommend using [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm#in
 
 ### Common Project Commands
 
-- **yarn develop** shortcut for booting up www, playground, and server packages for local development
 - **yarn playground** starts a bare-bones React app used for developing components
 - **yarn gatsby** starts the Gatsby server (powers our documentation site)
 - **yarn storybook** starts Storybook in "Docs" mode (includes stories from all packages)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "pretest:a11y": "yarn storyshots",
     "test:a11y": "yarn jest --config jest-a11y.config.js",
     "website-canary": "./config/website-canary.sh",
-    "website-latest": "./config/website-latest.sh"
+    "website-latest": "./config/website-latest.sh",
+    "develop":"echo -e 'Use `yarn gatsby` to start Gatsby \nUse `yarn storybook` to start Storybook'"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.16",


### PR DESCRIPTION
This change removes the language referring to `yarn develop` in the README and adds a message for the command to use yarn gatsby or yarn storybook. 

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] 📚 Documentation updated

