### PR TITLE
fix(HoverDisclosure): Use CSS visibility instead of de-rendering

### DIFF
--- a/packages/components/src/List/ListItem.test.tsx
+++ b/packages/components/src/List/ListItem.test.tsx
@@ -266,9 +266,9 @@ describe('ListItem', () => {
       </ListItem>
     )
 
-    expect(screen.queryByText('Detail')).not.toBeInTheDocument()
+    expect(screen.queryByText('Detail')).not.toBeVisible()
     fireEvent.mouseEnter(screen.getByText('Label'), { bubbles: true })
-    expect(screen.queryByText('Detail')).toBeInTheDocument()
+    expect(screen.queryByText('Detail')).toBeVisible()
   })
 
   test('onKeyUp callback functions', () => {

--- a/packages/components/src/Tree/Tree.test.tsx
+++ b/packages/components/src/Tree/Tree.test.tsx
@@ -196,9 +196,9 @@ describe('Tree', () => {
       </Tree>
     )
 
-    expect(screen.queryByText('Tree Detail')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tree Detail')).not.toBeVisible()
     fireEvent.mouseEnter(screen.getByText('Tree Label'), { bubbles: true })
-    expect(screen.queryByText('Tree Detail')).toBeInTheDocument()
+    expect(screen.queryByText('Tree Detail')).toBeVisible()
   })
 
   describe('color', () => {

--- a/packages/components/src/Tree/TreeItem.test.tsx
+++ b/packages/components/src/Tree/TreeItem.test.tsx
@@ -76,9 +76,9 @@ describe('TreeItem', () => {
       </TreeItem>
     )
 
-    expect(screen.queryByText('Detail')).not.toBeInTheDocument()
+    expect(screen.queryByText('Detail')).not.toBeVisible()
     fireEvent.mouseEnter(screen.getByText('Label'), { bubbles: true })
-    expect(screen.queryByText('Detail')).toBeInTheDocument()
+    expect(screen.queryByText('Detail')).toBeVisible()
   })
 
   test('Triggers onClickWhitespace when indent padding is clicked, itemRole = "none", and labelBackgroundOnly = true', () => {

--- a/packages/components/src/utils/HoverDisclosure/HoverDisclosure.tsx
+++ b/packages/components/src/utils/HoverDisclosure/HoverDisclosure.tsx
@@ -36,5 +36,10 @@ export const HoverDisclosure: FC<HoverDisclosureProps> = ({
   visible,
 }) => {
   const context = useContext(HoverDisclosureContext)
-  return visible || context.visible ? <>{children}</> : null
+  const isVisible = visible || context.visible
+  return (
+    <div style={{ visibility: isVisible ? 'visible' : 'hidden' }}>
+      {children}
+    </div>
+  )
 }


### PR DESCRIPTION

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [x] 🌏 Localization & Internationalization addressed
- [x] 🖼 Image Snapshot coverage