### PR TITLE
fix(design-tokens): text5 color is now identical to text (blend=100%)

### DIFF
--- a/packages/design-tokens/src/color/blendPoints.ts
+++ b/packages/design-tokens/src/color/blendPoints.ts
@@ -24,8 +24,7 @@
 
  */
 
-export type TextColorLevels = 0 | 1 | 2 | 3 | 4 | 5
-export const textBlends = [45, 65, 78, 88, 95, 99]
+export const textBlends = [45, 65, 78, 88, 100]
 
 export type UIColorLevels = 0 | 1 | 2 | 3 | 4
 export const uiBlends = [4, 12, 23, 34, 85]

--- a/packages/design-tokens/src/color/utils/generateBlendColors.test.tsx
+++ b/packages/design-tokens/src/color/utils/generateBlendColors.test.tsx
@@ -38,19 +38,19 @@ describe('generateBlendColors', () => {
     expect(generateBlendColors(specifiableColors)).toMatchInlineSnapshot(
       {},
       `
-        Object {
-          "text1": "#9da0a3",
-          "text2": "#71767a",
-          "text3": "#555b5f",
-          "text4": "#40464b",
-          "text5": "#30373d",
-          "ui1": "#f4f4f4",
-          "ui2": "#e0e0e0",
-          "ui3": "#c4c4c4",
-          "ui4": "#a8a8a8",
-          "ui5": "#262626",
-        }
-      `
+      Object {
+        "text1": "#9da0a3",
+        "text2": "#71767a",
+        "text3": "#555b5f",
+        "text4": "#40464b",
+        "text5": "#262D33",
+        "ui1": "#f4f4f4",
+        "ui2": "#e0e0e0",
+        "ui3": "#c4c4c4",
+        "ui4": "#a8a8a8",
+        "ui5": "#262626",
+      }
+    `
     )
   })
 
@@ -64,19 +64,19 @@ describe('generateBlendColors', () => {
     ).toMatchInlineSnapshot(
       {},
       `
-        Object {
-          "text1": "#878b8e",
-          "text2": "#b3b5b7",
-          "text3": "#cfd0d2",
-          "text4": "#e4e5e6",
-          "text5": "#f4f4f4",
-          "ui1": "#33393f",
-          "ui2": "#4d5257",
-          "ui3": "#707579",
-          "ui4": "#94989b",
-          "ui5": "#fff",
-        }
-      `
+      Object {
+        "text1": "#878b8e",
+        "text2": "#b3b5b7",
+        "text3": "#cfd0d2",
+        "text4": "#e4e5e6",
+        "text5": "#FFFFFF",
+        "ui1": "#33393f",
+        "ui2": "#4d5257",
+        "ui3": "#707579",
+        "ui4": "#94989b",
+        "ui5": "#fff",
+      }
+    `
     )
   })
 })

--- a/packages/design-tokens/src/color/utils/mixColors.test.ts
+++ b/packages/design-tokens/src/color/utils/mixColors.test.ts
@@ -35,13 +35,15 @@ describe('mixColors', () => {
     test('text1', () =>
       expect(mixColors(textBlends[0], text, background)).toEqual('#9da0a3'))
     test('text5', () =>
-      expect(mixColors(textBlends[4], text, background)).toEqual('#30373d'))
+      expect(mixColors(textBlends[4], text, background)).toEqual(colors.text))
   })
 
   describe('dark-mode', () => {
     test('text1', () =>
       expect(mixColors(textBlends[0], background, text)).toEqual('#878b8e'))
     test('text5', () =>
-      expect(mixColors(textBlends[4], background, text)).toEqual('#f4f4f4'))
+      expect(mixColors(textBlends[4], background, text)).toEqual(
+        colors.background
+      ))
   })
 })

--- a/packages/design-tokens/src/color/utils/mixColors.ts
+++ b/packages/design-tokens/src/color/utils/mixColors.ts
@@ -30,4 +30,5 @@ export const mixColors = (
   mixAmount: number,
   foreground: string,
   background: string
-) => mix(mixAmount / 100, foreground, background)
+) =>
+  mixAmount === 100 ? foreground : mix(mixAmount / 100, foreground, background)

--- a/packages/design-tokens/src/theme/utils/generateTheme.test.ts
+++ b/packages/design-tokens/src/theme/utils/generateTheme.test.ts
@@ -35,7 +35,7 @@ describe('generateTheme', () => {
     expect(generated.colors).toMatchInlineSnapshot(`
       Object {
         "background": "#FFFFFF",
-        "body": "#0c0c0c",
+        "body": "black",
         "calculation": "#319220",
         "calculationAccent": "#deeddb",
         "calculationBorder": "#319220",
@@ -100,8 +100,8 @@ describe('generateTheme', () => {
         "text2": "#595959",
         "text3": "#383838",
         "text4": "#1e1e1e",
-        "text5": "#0c0c0c",
-        "title": "#0c0c0c",
+        "text5": "black",
+        "title": "black",
         "ui1": "#f4f4f4",
         "ui2": "#e0e0e0",
         "ui3": "#c4c4c4",
@@ -120,7 +120,7 @@ describe('generateTheme', () => {
     expect(generated.colors).toMatchInlineSnapshot(`
       Object {
         "background": "black",
-        "body": "#f2f2f2",
+        "body": "white",
         "calculation": "#319220",
         "calculationAccent": "#0d2708",
         "calculationBorder": "#319220",
@@ -185,8 +185,8 @@ describe('generateTheme', () => {
         "text2": "#a5a5a5",
         "text3": "#c6c6c6",
         "text4": "#e0e0e0",
-        "text5": "#f2f2f2",
-        "title": "#f2f2f2",
+        "text5": "white",
+        "title": "white",
         "ui1": "#0f0f0f",
         "ui2": "#2d2d2d",
         "ui3": "#575757",


### PR DESCRIPTION
Make text5 = text

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] 🖼 Image Snapshot coverage
