### PR TITLE
feat(TabPanel): Added tabStop boolean prop to TabPanel

### DIFF
--- a/packages/components/src/Tabs/TabPanel.tsx
+++ b/packages/components/src/Tabs/TabPanel.tsx
@@ -30,6 +30,10 @@ import styled from 'styled-components'
 export interface TabPanelProps {
   className?: string
   selected?: boolean
+  /**
+   * Set tabIndex to 0 if you'd like the TabPanel to be reached via keyboard tabbing
+   * @default -1
+   */
   tabIndex?: number
 }
 
@@ -37,7 +41,7 @@ const TabPanelLayout: FC<TabPanelProps> = ({
   children,
   className,
   selected,
-  tabIndex = 0,
+  tabIndex = -1,
 }) =>
   selected ? (
     <div className={className} tabIndex={tabIndex}>

--- a/packages/components/src/Tabs/TabPanel.tsx
+++ b/packages/components/src/Tabs/TabPanel.tsx
@@ -42,10 +42,10 @@ const TabPanelLayout: FC<TabPanelProps> = ({
   children,
   className,
   selected,
-  tabIndex = -1,
+  tabStop = false,
 }) =>
   selected ? (
-    <div className={className} tabIndex={tabIndex}>
+    <div className={className} tabIndex={tabStop ? 0 : -1}>
       {children}
     </div>
   ) : null

--- a/packages/components/src/Tabs/TabPanel.tsx
+++ b/packages/components/src/Tabs/TabPanel.tsx
@@ -31,10 +31,11 @@ export interface TabPanelProps {
   className?: string
   selected?: boolean
   /**
-   * Set tabIndex to 0 if you'd like the TabPanel to be reached via keyboard tabbing
-   * @default -1
+   * Set to `true` if you would like TabPanel to be reached via tab-key.
+   * Generally this is _only_ the case when the TabPanel contains no tab-stopping items (a, button, etc.)
+   * @default false
    */
-  tabIndex?: number
+  tabStop?: boolean
 }
 
 const TabPanelLayout: FC<TabPanelProps> = ({

--- a/packages/components/src/Tabs/TabPanel.tsx
+++ b/packages/components/src/Tabs/TabPanel.tsx
@@ -35,17 +35,17 @@ export interface TabPanelProps {
    * Generally this is _only_ the case when the TabPanel contains no tab-stopping items (a, button, etc.)
    * @default false
    */
-  tabStop?: boolean
+  isTabStop?: boolean
 }
 
 const TabPanelLayout: FC<TabPanelProps> = ({
   children,
   className,
   selected,
-  tabStop = false,
+  isTabStop = false,
 }) =>
   selected ? (
-    <div className={className} tabIndex={tabStop ? 0 : -1}>
+    <div className={className} tabIndex={isTabStop ? 0 : -1}>
       {children}
     </div>
   ) : null

--- a/packages/components/src/Tabs/TabPanel.tsx
+++ b/packages/components/src/Tabs/TabPanel.tsx
@@ -30,11 +30,17 @@ import styled from 'styled-components'
 export interface TabPanelProps {
   className?: string
   selected?: boolean
+  tabIndex?: number
 }
 
-const TabPanelLayout: FC<TabPanelProps> = ({ children, className, selected }) =>
+const TabPanelLayout: FC<TabPanelProps> = ({
+  children,
+  className,
+  selected,
+  tabIndex = 0,
+}) =>
   selected ? (
-    <div className={className} tabIndex={0}>
+    <div className={className} tabIndex={tabIndex}>
       {children}
     </div>
   ) : null

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -29,6 +29,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { renderWithTheme } from '@looker/components-test-utils'
 import React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Tab } from './Tab'
 import { TabList } from './TabList'
 import { TabPanel } from './TabPanel'
@@ -195,6 +196,28 @@ describe('focus behavior', () => {
     expect(screen.getByText('tab2')).toHaveStyle(
       'box-shadow: 0 0 0 0.15rem rgba(151,133,242,0.25);'
     )
+  })
+
+  test('Tab Focus: TabPanel can use tabIndex to exclude itself from tab flow', () => {
+    renderWithTheme(
+      <Tabs>
+        <TabList>
+          <Tab>tab1</Tab>
+          <Tab>tab2</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel tabIndex={-1}>
+            <button>Some button</button>
+          </TabPanel>
+          <TabPanel>this is tab2 content</TabPanel>
+        </TabPanels>
+      </Tabs>
+    )
+    const tab1 = screen.getByText('tab1')
+    userEvent.tab()
+    expect(tab1).toHaveFocus()
+    userEvent.tab()
+    expect(screen.getByText('Some button')).toHaveFocus()
   })
 
   test('Tab keyboard navigation', () => {

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -198,7 +198,7 @@ describe('focus behavior', () => {
     )
   })
 
-  test('Tab Focus: TabPanel can use tabIndex to exclude itself from tab flow', () => {
+  test('Tab Focus: By default, TabPanel is not tabbable', () => {
     renderWithTheme(
       <Tabs>
         <TabList>
@@ -206,18 +206,44 @@ describe('focus behavior', () => {
           <Tab>tab2</Tab>
         </TabList>
         <TabPanels>
-          <TabPanel tabIndex={-1}>
+          <TabPanel>
             <button>Some button</button>
           </TabPanel>
           <TabPanel>this is tab2 content</TabPanel>
         </TabPanels>
       </Tabs>
     )
-    const tab1 = screen.getByText('tab1')
     userEvent.tab()
-    expect(tab1).toHaveFocus()
+    expect(screen.getByText('tab1')).toHaveFocus()
+
     userEvent.tab()
     expect(screen.getByText('Some button')).toHaveFocus()
+  })
+
+  test('Tab Focus: TabPanel can use "tabStop" prop to become tabbable element', () => {
+    renderWithTheme(
+      <Tabs>
+        <TabList>
+          <Tab>tab1</Tab>
+          <Tab>tab2</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel tabStop>
+            <button>Some button</button>
+          </TabPanel>
+          <TabPanel>this is tab2 content</TabPanel>
+        </TabPanels>
+      </Tabs>
+    )
+    userEvent.tab()
+    expect(screen.getByText('tab1')).toHaveFocus()
+
+    const button = screen.getByText('Some button')
+    userEvent.tab()
+    expect(button.closest('div'))
+
+    userEvent.tab()
+    expect(button).toHaveFocus()
   })
 
   test('Tab keyboard navigation', () => {

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -228,7 +228,7 @@ describe('focus behavior', () => {
           <Tab>tab2</Tab>
         </TabList>
         <TabPanels>
-          <TabPanel tabStop>
+          <TabPanel isTabStop>
             <button>Some button</button>
           </TabPanel>
           <TabPanel>this is tab2 content</TabPanel>

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -220,7 +220,7 @@ describe('focus behavior', () => {
     expect(screen.getByText('Some button')).toHaveFocus()
   })
 
-  test('Tab Focus: TabPanel can use "tabStop" prop to become tabbable element', () => {
+  test('Tab Focus: TabPanel can use "isTabStop" prop to become tabbable element', () => {
     renderWithTheme(
       <Tabs>
         <TabList>

--- a/www/src/documentation/components/content/tabs.mdx
+++ b/www/src/documentation/components/content/tabs.mdx
@@ -132,3 +132,26 @@ Using the distribute prop on `TabList` will equally distributed each `Tab` in th
   )
 }
 ```
+
+## Keyboard Navigation
+
+When focused on a `Tab`, use the left and right arrow keys to navigate to sibling `Tab`s.
+
+If you'd like a `TabPanel` to be reachable via keyboard tabbing, set its `tabIndex` prop to 0. By default, this value is set to -1 to keep `TabPanel` out of the standard tab flow.
+
+```jsx
+;() => {
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>tabIndex = 0</Tab>
+        <Tab>tabIndex = 1</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel tabIndex={0}>I'm reachable by pressing the tab key</TabPanel>
+        <TabPanel>I'm not reachable by pressing the tab key</TabPanel>
+      </TabPanels>
+    </Tabs>
+  )
+}
+```

--- a/www/src/documentation/components/content/tabs.mdx
+++ b/www/src/documentation/components/content/tabs.mdx
@@ -137,18 +137,18 @@ Using the distribute prop on `TabList` will equally distributed each `Tab` in th
 
 When focused on a `Tab`, use the left and right arrow keys to navigate to sibling `Tab`s.
 
-If you'd like a `TabPanel` to be reachable via keyboard tabbing, set its `tabIndex` prop to 0. By default, this value is set to -1 to keep `TabPanel` out of the standard tab flow.
+By default, `TabPanel` is not reachable via the "Tab" key. If you'd like `TabPanel` to be reachable via the "Tab" key, set the `tabStop` prop to `true`.
 
 ```jsx
 ;() => {
   return (
     <Tabs>
       <TabList>
-        <Tab>tabIndex = 0</Tab>
-        <Tab>tabIndex = 1</Tab>
+        <Tab>tabStop = true</Tab>
+        <Tab>tabStop = false (Default)</Tab>
       </TabList>
       <TabPanels>
-        <TabPanel tabIndex={0}>I'm reachable by pressing the tab key</TabPanel>
+        <TabPanel tabStop>I'm reachable by pressing the tab key</TabPanel>
         <TabPanel>I'm not reachable by pressing the tab key</TabPanel>
       </TabPanels>
     </Tabs>

--- a/www/src/documentation/components/content/tabs.mdx
+++ b/www/src/documentation/components/content/tabs.mdx
@@ -137,18 +137,18 @@ Using the distribute prop on `TabList` will equally distributed each `Tab` in th
 
 When focused on a `Tab`, use the left and right arrow keys to navigate to sibling `Tab`s.
 
-By default, `TabPanel` is not reachable via the "Tab" key. If you'd like `TabPanel` to be reachable via the "Tab" key, set the `tabStop` prop to `true`.
+By default, `TabPanel` is not reachable via the "Tab" key. If you'd like `TabPanel` to be reachable via the "Tab" key, set the `isTabStop` prop to `true`.
 
 ```jsx
 ;() => {
   return (
     <Tabs>
       <TabList>
-        <Tab>tabStop = true</Tab>
-        <Tab>tabStop = false (Default)</Tab>
+        <Tab>isTabStop = true</Tab>
+        <Tab>isTabStop = false (Default)</Tab>
       </TabList>
       <TabPanels>
-        <TabPanel tabStop>I'm reachable by pressing the tab key</TabPanel>
+        <TabPanel isTabStop>I'm reachable by pressing the tab key</TabPanel>
         <TabPanel>I'm not reachable by pressing the tab key</TabPanel>
       </TabPanels>
     </Tabs>


### PR DESCRIPTION
In the new Field Picker experience, a keyboard user has to tab from the `Tab` to the `TabPanel` to the first `Tree` in order to focus on the `Tree` items and begin field keyboard traversal. Ideally, I think it'd be cleaner to just tab from the `Tab` directly to the `TreeCollection` since it is the only element in the `TabPanel`.

Adding `tabIndex` as a prop allows devs to pass a non-zero value to `TabPanel`'s `tabIndex` prop and thus remove it from the tab flow.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
