### PR TITLE
fix(ListItem): Removed background transition

### DIFF
--- a/packages/components/src/List/ListItemLabel.tsx
+++ b/packages/components/src/List/ListItemLabel.tsx
@@ -105,9 +105,6 @@ export const ListItemLabel = styled(ListItemLabelLayout).withConfig({
   outline: none;
   text-align: left;
   text-decoration: none;
-  transition: ${({ theme: { easings, transitions } }) =>
-    `background ${transitions.quick}ms ${easings.ease},
-  color ${transitions.quick}ms ${easings.ease}`};
   width: 100%;
 
   &:hover,

--- a/packages/components/src/Tree/stories/FieldItem.tsx
+++ b/packages/components/src/Tree/stories/FieldItem.tsx
@@ -110,7 +110,10 @@ export const FieldItem: FC<FieldItemProps> = ({
       onKeyDown={(event) => {
         if (event.key === 'Enter' && event.metaKey) {
           alert(`CMD + Enter'ed on ${children}!`)
-        } else if (event.key === 'Enter') {
+        } else if (
+          event.key === 'Enter' &&
+          event.currentTarget === event.target
+        ) {
           toggleField()
         }
       }}

--- a/packages/components/src/Tree/stories/FieldPicker.story.tsx
+++ b/packages/components/src/Tree/stories/FieldPicker.story.tsx
@@ -26,7 +26,7 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import { Box, Paragraph } from '../..'
+import { Box, Paragraph, ParagraphProps } from '../..'
 import { TreeCollection, TreeBranch, Tree } from '..'
 import { generateBorderRadius } from '../utils/generateBorderRadius'
 import { FieldItem } from './FieldItem'
@@ -35,17 +35,19 @@ const BorderRadiusOverrideTree = styled(Tree)`
   ${({ theme }) => generateBorderRadius('medium', theme)}
 `
 
-const FieldGroupHeading = styled(Paragraph).attrs(({ color = 'text1' }) => ({
-  color,
-  fontSize: 'xxsmall',
-  fontWeight: 'semiBold',
-  pb: 'xxsmall',
-  pr: 'xxsmall',
-  pt: 'xsmall',
-  truncate: true,
-}))`
-  line-height: 0.75rem;
-`
+const FieldGroupHeading = (props: ParagraphProps) => (
+  <Paragraph
+    color="text1"
+    fontSize="xxsmall"
+    fontWeight="semiBold"
+    pb="xxsmall"
+    pr="xxsmall"
+    pt="xsmall"
+    truncate
+    style={{ lineHeight: '0.75rem' }}
+    {...props}
+  />
+)
 
 const fields = (
   <>


### PR DESCRIPTION
The `HoverDisclosure` component can be used to conditionally hide and show elements in a `ListItem` on hover. However, child elements of `HoverDisclosure` do not have a transition when appearing or disappearing, which makes the background hover appear to "lag" behind. 

Removing the background transition gets both `HoverDisclosure` children and the background color change to happen at around the same time.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
