### PR TITLE
refactor(ListItem): Marked "current" prop as deprecated

### DIFF
--- a/packages/components/src/List/types.ts
+++ b/packages/components/src/List/types.ts
@@ -105,14 +105,26 @@ export type LimitedColor = {
 
 export type ListItemColorProps = FlexibleColor
 export type ListColorProps = LimitedColor
+type AriaCurrentValue =
+  | 'page'
+  | 'step'
+  | 'location'
+  | 'date'
+  | 'time'
+  | 'true'
+  | 'false'
+  | true
+  | false
 
 export type ListItemStatefulProps = {
   /**
-   * If true, the ListItem will have a darker background color (same as selected)
+   * If truthy, the ListItem will have a darker background color (same as selected)
    * Note: Using current and selected at the same time is not recommended
-   * @default false
+   * @todo - remove prop in 2.x
+   * @deprecated use `selected` instead of `current` to get darker background color
+   *
    */
-  current?: boolean
+  current?: AriaCurrentValue
   /**
    * If true, the ListItem will have a "disabled" presentation.
    * @default false

--- a/packages/components/src/List/types.ts
+++ b/packages/components/src/List/types.ts
@@ -105,16 +105,6 @@ export type LimitedColor = {
 
 export type ListItemColorProps = FlexibleColor
 export type ListColorProps = LimitedColor
-type AriaCurrentValue =
-  | 'page'
-  | 'step'
-  | 'location'
-  | 'date'
-  | 'time'
-  | 'true'
-  | 'false'
-  | true
-  | false
 
 export type ListItemStatefulProps = {
   /**
@@ -124,7 +114,7 @@ export type ListItemStatefulProps = {
    * @deprecated use `selected` instead of `current` to get darker background color
    *
    */
-  current?: AriaCurrentValue
+  current?: boolean
   /**
    * If true, the ListItem will have a "disabled" presentation.
    * @default false


### PR DESCRIPTION
**Changes:**
- Marks the "current" prop as deprecated ahead of v2.0
- Expands the "current" prop type to be equivalent to `aria-current`

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
