### PR TITLE
fix(ListItem): Properly disperse ARIA props onto ListItem's label container

### DIFF
--- a/packages/components/src/List/ListItem.test.tsx
+++ b/packages/components/src/List/ListItem.test.tsx
@@ -307,4 +307,20 @@ describe('ListItem', () => {
 
     global.console = globalConsole
   })
+
+  test('properly passes aria related props to label container', () => {
+    renderWithTheme(
+      <ListItem aria-current="location" aria-describedby="something-else">
+        ListItem with aria props
+      </ListItem>
+    )
+
+    const label = screen.getByRole('listitem')
+    expect(label).toHaveAttribute('aria-current', 'location')
+    expect(label).toHaveAttribute('aria-describedby', 'something-else')
+
+    const wrapper = screen.getByRole('none')
+    expect(wrapper).not.toHaveAttribute('aria-current', 'location')
+    expect(wrapper).not.toHaveAttribute('aria-describedby', 'something-else')
+  })
 })

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -266,6 +266,14 @@ const ListItemInternal = forwardRef(
       selected,
     }
 
+    const ariaProps = {}
+    const wrapperProps = {}
+    Object.entries(restProps).forEach(([propKey, propValue]) =>
+      propKey.startsWith('aria-')
+        ? (ariaProps[propKey] = propValue)
+        : (wrapperProps[propKey] = propValue)
+    )
+
     const LabelCreator: FC<{
       children: ReactNode
       className?: string
@@ -283,6 +291,7 @@ const ListItemInternal = forwardRef(
         role={role || 'listitem'}
         target={target}
         tabIndex={tabIndex}
+        {...ariaProps}
         {...focusVisibleHandlers}
         {...statefulProps}
       >
@@ -354,7 +363,7 @@ const ListItemInternal = forwardRef(
           ref={actualRef}
           renderAsDiv={renderAsDiv}
           {...itemDimensions}
-          {...restProps}
+          {...wrapperProps}
         >
           {listItemContent}
         </ListItemWrapper>

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -43,6 +43,10 @@ import { indicatorDefaults } from './utils'
 import { TreeItemInner, TreeItemInnerDetail, TreeStyle } from './TreeStyle'
 import { treeItemInnerPropKeys, TreeProps } from './types'
 
+/**
+ * TODO: When labelToggle is introduced the aria-* attributes should land on the nested ListItem's
+ * label container (i.e. the focusable element).
+ */
 const TreeLayout: FC<TreeProps> = ({
   branchFontWeight,
   border: propsBorder,


### PR DESCRIPTION
Moved aria related props to be passed to label rather than wrapper

**TODO:** Follow-up PR that does the following:
- Extract "aria partitioning" logic into its own function and file (`Tree` can then use this same function to partition out its `aria`-related props and send them to the nested item when `labelToggle === true`)
- Move `ListItemProps` to a separate file (need to do this otherwise we'll have a circular dependency between the "aria partitioning" function file and `ListItem.tsx`)

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
