### PR TITLE
refactor(ListItem): Refactor getAriaProps

### DIFF
--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -57,9 +57,9 @@ import { ListItemWrapper } from './ListItemWrapper'
 import { listItemIconColor, listItemLabelColor } from './utils/listItemColor'
 import {
   createSafeRel,
-  getAriaProps,
   getDetailOptions,
   listItemDimensions,
+  partitionAriaProps,
 } from './utils'
 import { ListItemProps } from './types'
 
@@ -205,7 +205,7 @@ const ListItemInternal = forwardRef(
       selected,
     }
 
-    const [ariaProps, wrapperProps] = getAriaProps(restProps)
+    const [ariaProps, wrapperProps] = partitionAriaProps(restProps)
 
     const LabelCreator: FC<{
       children: ReactNode

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -205,11 +205,7 @@ const ListItemInternal = forwardRef(
       selected,
     }
 
-    /**
-     * Passing restProps directly into getAriaProps leads to a "Index signature is missing in type" TS error
-     * Spreading the props gets around this, but hopefully we can find the right typing to avoid this error
-     *  */
-    const [ariaProps, wrapperProps] = getAriaProps({ ...restProps })
+    const [ariaProps, wrapperProps] = getAriaProps(restProps)
 
     const LabelCreator: FC<{
       children: ReactNode

--- a/packages/components/src/List/utils/getAriaProps.ts
+++ b/packages/components/src/List/utils/getAriaProps.ts
@@ -28,10 +28,10 @@
  * Partitions an object into 2 objects, the first containing all aria related prop keys and their respective values
  * and the second containing all other prop keys and their respective values
  *
- * @param {Record<string, unknown>} props
+ * @param {Record<string, any>} props
  * @returns {Array} A tuple where the first object contains all aria related props and the second object contains the remaining props
  */
-export const getAriaProps = (props: Record<string, unknown>) => {
+export const getAriaProps = (props: Record<string, any>) => {
   const aria = {}
   const remainder = {}
   Object.entries(props).forEach(([key, value]) =>

--- a/packages/components/src/List/utils/getAriaProps.ts
+++ b/packages/components/src/List/utils/getAriaProps.ts
@@ -24,11 +24,13 @@
 
  */
 
+import React from 'react'
+
 /**
  * Partitions an object into 2 objects, the first containing all aria related prop keys and their respective values
  * and the second containing all other prop keys and their respective values
  *
- * @param {Record<string, any>} props
+ * @param {T extends React.AriaAttribute} props
  * @returns {Array} A tuple where the first object contains all aria related props and the second object contains the remaining props
  */
 export const partitionAriaProps = <T extends React.AriaAttributes>(

--- a/packages/components/src/List/utils/getAriaProps.ts
+++ b/packages/components/src/List/utils/getAriaProps.ts
@@ -31,7 +31,9 @@
  * @param {Record<string, any>} props
  * @returns {Array} A tuple where the first object contains all aria related props and the second object contains the remaining props
  */
-export const getAriaProps = (props: Record<string, any>) => {
+export const partitionAriaProps = <T extends React.AriaAttributes>(
+  props: T
+) => {
   const aria = {}
   const remainder = {}
   Object.entries(props).forEach(([key, value]) =>


### PR DESCRIPTION
- Changed name to `partitionAriaProps` (after lodash's partition method)
- Updated props parameter type to use generic type that extends `React.AriaAttributes` type

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
