### PR TITLE
feat(palette): No longer export palette, mark all as deprecated

### DIFF
--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -35,9 +35,6 @@ export * from './color'
 export * from './theme'
 export * from './system'
 
-// Provided for legacy color implementations
-export { palette } from './legacy'
-
 // Useful external utilities
 export { transitions } from './tokens/transitions'
 export * from './tokens/breakpoints'

--- a/packages/design-tokens/src/legacy/index.ts
+++ b/packages/design-tokens/src/legacy/index.ts
@@ -25,4 +25,9 @@
  */
 
 import * as palette from './palette'
+
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export { palette }

--- a/packages/design-tokens/src/legacy/palette.ts
+++ b/packages/design-tokens/src/legacy/palette.ts
@@ -24,64 +24,308 @@
 
  */
 
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const white = '#FFFFFF'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal000 = '#FBFBFC'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal100 = '#F5F6F7'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal200 = '#DEE1E5'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal300 = '#C1C6CC'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal400 = '#939BA5'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal500 = '#707781'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal600 = '#4C535B'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal700 = '#343C42'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal800 = '#262D33'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const charcoal900 = '#262D33'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple000 = '#F3F2FF'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple100 = '#E8E5FF'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple200 = '#BFB2FF'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple300 = '#9785F2'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple400 = '#6C43E0'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple500 = '#4F2ABA'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple600 = '#412399'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple700 = '#341C7A'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple800 = '#291661'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const purple900 = '#1E1047'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue000 = '#f7fcff'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue100 = '#e0f2ff'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue200 = '#bfe3ff'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue300 = '#6fbcf7'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue400 = '#49a9f2'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue500 = '#0087e1'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue600 = '#0059b2'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue700 = '#00418c'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue800 = '#0f2f66'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const blue900 = '#08284d'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green000 = '#f2fff5'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green100 = '#e0ffe7'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green200 = '#b4fac2'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green300 = '#67e591'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green400 = '#33cc73'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green500 = '#24b25f'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green600 = '#0e8c42'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green700 = '#0b6b38'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green800 = '#08522d'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const green900 = '#06381f'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow000 = '#FFF7E8'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow100 = '#FFEBC4'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow200 = '#FFDB96'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow300 = '#FFCA62'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow400 = '#FFB72B'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow500 = '#FFA800'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow600 = '#EF9E00'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow700 = '#CC8600'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow800 = '#A56D00'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const yellow900 = '#724B00'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red000 = '#FFF2F4'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red100 = '#FFE5E9'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red200 = '#FFB8C1'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red300 = '#FF667A'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red400 = '#ED3B53'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red500 = '#CC1F36'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red600 = '#B2121F'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red700 = '#990F14'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red800 = '#730B0F'
+/**
+ * @todo - remove in 3.x
+ * @deprecated Palette support is now deprecated and will be removed in 3.x release
+ */
 export const red900 = '#52080B'

--- a/www/src/MDX/Pre/prismTheme.ts
+++ b/www/src/MDX/Pre/prismTheme.ts
@@ -25,9 +25,8 @@
  */
 
 import { PrismTheme } from 'prism-react-renderer'
-import { palette, theme } from '@looker/design-tokens'
-
-const {
+import { theme } from '@looker/design-tokens'
+import {
   blue200,
   blue400,
   green300,
@@ -35,7 +34,8 @@ const {
   red300,
   yellow200,
   yellow300,
-} = palette
+} from '@looker/design-tokens/src/legacy/palette'
+
 const { inverse, text1 } = theme.colors
 
 export const prismTheme: PrismTheme = {


### PR DESCRIPTION
Palette can be deep-imported during 2.x series but may be removed entirely in 3.x
```import { palette} from '@looker/design-tokens/lib/legacy'```

BREAKING CHANGE: Design-tokens `palette` is no longer exported from root, deprecated for 3.x