### PR TITLE
feat(PopoverContent): new component to enhance Popover layout

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.story.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.story.tsx
@@ -24,7 +24,30 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+import React from 'react'
+import { Story } from '@storybook/react/types-6-0'
+import { Box, Paragraph } from '../../..'
+import { DialogContent, DialogContentProps } from './DialogContent'
+
+const Template: Story<DialogContentProps> = (args) => (
+  <DialogContent {...args} />
+)
+
+export const Basic = Template.bind({})
+Basic.args = {
+  children: <Box height="2rem" bg="rebeccapurple" />,
+}
+
+export const Overflow = () => (
+  <Box height="10rem" display="flex" bg="white" p="large">
+    <DialogContent>
+      <Paragraph>Scroll down here...</Paragraph>
+      <Box height="12rem" bg="rebeccapurple" />
+    </DialogContent>
+  </Box>
+)
+
+export default {
+  component: DialogContent,
+  title: 'DialogContent',
+}

--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.story.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.story.tsx
@@ -25,18 +25,14 @@
  */
 
 import React from 'react'
-import { Story } from '@storybook/react/types-6-0'
 import { Box, Paragraph } from '../../..'
-import { DialogContent, DialogContentProps } from './DialogContent'
+import { DialogContent } from './DialogContent'
 
-const Template: Story<DialogContentProps> = (args) => (
-  <DialogContent {...args} />
+export const Basic = () => (
+  <DialogContent>
+    <Box height="2rem" bg="rebeccapurple" />
+  </DialogContent>
 )
-
-export const Basic = Template.bind({})
-Basic.args = {
-  children: <Box height="2rem" bg="rebeccapurple" />,
-}
 
 export const Overflow = () => (
   <Box height="10rem" display="flex" bg="white" p="large">

--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.test.tsx
@@ -34,4 +34,30 @@ describe('DialogContent', () => {
     renderWithTheme(<DialogContent>Dialog Content</DialogContent>)
     expect(screen.getByText('Dialog Content')).toBeInTheDocument()
   })
+  test('display correct padding if hasFooter', () => {
+    renderWithTheme(<DialogContent hasFooter>Stuff</DialogContent>)
+
+    expect(screen.getByText('Stuff')).toHaveStyleRule(
+      'padding-bottom',
+      '1.25rem'
+    )
+  })
+  test('display correct padding if hasHeader', () => {
+    renderWithTheme(<DialogContent hasHeader>Stuff</DialogContent>)
+
+    expect(screen.getByText('Stuff')).toHaveStyleRule('padding-top', '1.25rem')
+  })
+  test('display correct padding if both  hasFooter & hasHeader', () => {
+    renderWithTheme(
+      <DialogContent hasFooter hasHeader>
+        Stuff
+      </DialogContent>
+    )
+
+    expect(screen.getByText('Stuff')).toHaveStyleRule(
+      'padding-bottom',
+      '1.25rem'
+    )
+    expect(screen.getByText('Stuff')).toHaveStyleRule('padding-top', '1.25rem')
+  })
 })

--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.test.tsx
@@ -25,29 +25,13 @@
  */
 
 import React from 'react'
-import { Story } from '@storybook/react/types-6-0'
-import { Box, Paragraph } from '../..'
-import { DialogContent, DialogContentProps } from './DialogContent'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { screen } from '@testing-library/react'
+import { DialogContent } from './DialogContent'
 
-const Template: Story<DialogContentProps> = (args) => (
-  <DialogContent {...args} />
-)
-
-export const Basic = Template.bind({})
-Basic.args = {
-  children: <Box height="2rem" bg="rebeccapurple" />,
-}
-
-export const Overflow = () => (
-  <Box height="10rem" display="flex" bg="white" p="large">
-    <DialogContent>
-      <Paragraph>Scroll down here...</Paragraph>
-      <Box height="12rem" bg="rebeccapurple" />
-    </DialogContent>
-  </Box>
-)
-
-export default {
-  component: DialogContent,
-  title: 'DialogContent',
-}
+describe('DialogContent', () => {
+  test('basic', () => {
+    renderWithTheme(<DialogContent>Dialog Content</DialogContent>)
+    expect(screen.getByText('Dialog Content')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.tsx
@@ -24,7 +24,13 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+import styled from 'styled-components'
+import { ModalContent, ModalContentProps } from '../../../Modal/ModalContent'
+
+export type DialogContentProps = ModalContentProps
+
+export const DialogContent = styled(ModalContent).attrs(
+  ({ px = 'xlarge' }) => ({
+    px,
+  })
+)<DialogContentProps>``

--- a/packages/components/src/Dialog/Layout/DialogContent/index.ts
+++ b/packages/components/src/Dialog/Layout/DialogContent/index.ts
@@ -24,7 +24,4 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+export * from './DialogContent'

--- a/packages/components/src/Layout/Semantics/Aside/Aside.test.tsx
+++ b/packages/components/src/Layout/Semantics/Aside/Aside.test.tsx
@@ -81,7 +81,7 @@ describe('Aside', () => {
       getComputedStyle(screen.getByText('Aside content')).getPropertyValue(
         'box-shadow'
       )
-    ).toEqual('0 -4px 4px -4px #DEE1E5,inset 0 -4px 4px -4px #DEE1E5')
+    ).toEqual('inset 0 -4px 4px -4px #DEE1E5')
   })
 
   test('render border properly', () => {

--- a/packages/components/src/Layout/Semantics/Section/Section.test.tsx
+++ b/packages/components/src/Layout/Semantics/Section/Section.test.tsx
@@ -75,6 +75,6 @@ describe('Section', () => {
       getComputedStyle(screen.getByText('Section content')).getPropertyValue(
         'box-shadow'
       )
-    ).toEqual('0 -4px 4px -4px #DEE1E5,inset 0 -4px 4px -4px #DEE1E5')
+    ).toEqual('inset 0 -4px 4px -4px #DEE1E5')
   })
 })

--- a/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
@@ -60,114 +60,25 @@ afterAll(() => {
 describe('ModalContent', () => {
   test('basic', () => {
     renderWithTheme(<ModalContent>Stuff</ModalContent>)
-    expect(screen.getByText('Stuff')).toBeInTheDocument()
+    const modalContent = screen.getByText('Stuff')
+
+    expect(modalContent).toBeInTheDocument()
+    expect(modalContent).toHaveStyleRule('padding-top', '0.125rem')
+    expect(modalContent).toHaveStyleRule('padding-bottom', '0.125rem')
   })
 
-  test('hasHeader & hasFooter', () => {
-    renderWithTheme(
-      <ModalContent hasHeader hasFooter>
-        Stuff
-      </ModalContent>
-    )
-    expect(screen.getByText('Stuff')).toBeInTheDocument()
-  })
-
-  xtest('display correct padding if hasFooter', () => {
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-      configurable: true,
-      value: 500,
-    })
-
-    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-      configurable: true,
-      value: 0,
-    })
-
-    renderWithTheme(<ModalContent hasFooter>Stuff</ModalContent>)
-
-    expect(
-      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
-        'padding-bottom'
-      )
-    ).toEqual('1.25rem')
-  })
-
-  xtest('display correct padding if hasHeader', () => {
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-      configurable: true,
-      value: 500,
-    })
-
-    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-      configurable: true,
-      value: 0,
-    })
-
-    renderWithTheme(<ModalContent hasHeader>Stuff</ModalContent>)
-
-    expect(
-      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
-        'padding-top'
-      )
-    ).toEqual('1.25rem')
-  })
-
-  xtest('display correct padding if both hasHeader & hasFooter', () => {
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-      configurable: true,
-      value: 500,
-    })
-
-    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-      configurable: true,
-      value: 0,
-    })
-
+  test('display undefined padding if both hasHeader & hasFooter', () => {
     renderWithTheme(
       <ModalContent hasHeader hasFooter>
         Stuff
       </ModalContent>
     )
 
-    expect(
-      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
-        'padding-bottom'
-      )
-    ).toEqual('1.25rem')
-    expect(
-      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
-        'padding-top'
-      )
-    ).toEqual('1.25rem')
-  })
-
-  xtest('display correct padding if hasHeader & hasFooter are false', () => {
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-      configurable: true,
-      value: 0,
-    })
-
-    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-      configurable: true,
-      value: 500,
-    })
-
-    renderWithTheme(
-      <ModalContent hasHeader hasFooter>
-        Stuff
-      </ModalContent>
+    expect(screen.getByText('Stuff')).toHaveStyleRule(
+      'padding-bottom',
+      undefined
     )
-
-    expect(
-      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
-        'padding-bottom'
-      )
-    ).toEqual('0.125rem')
-    expect(
-      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
-        'padding-top'
-      )
-    ).toEqual('0.125rem')
+    expect(screen.getByText('Stuff')).toHaveStyleRule('padding-top', undefined)
   })
 
   test('has no box shadow when it does not overflow', () => {

--- a/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
@@ -72,15 +72,38 @@ describe('ModalContent', () => {
     expect(screen.getByText('Stuff')).toBeInTheDocument()
   })
 
+  xtest('display correct padding if hasHeader & hasFooter are true', () => {
+    renderWithTheme(
+      <ModalContent hasHeader={true} hasFooter={true}>
+        Stuff
+      </ModalContent>
+    )
+
+    expect(screen.getByText('Stuff')).toHaveStyle('padding-bottom: 1.25rem;')
+    expect(screen.getByText('Stuff')).toHaveStyle('padding-top: 1.25rem;')
+  })
+
+  xtest('display correct padding if hasHeader & hasFooter are false', () => {
+    renderWithTheme(
+      <ModalContent hasHeader={false} hasFooter={false}>
+        Stuff
+      </ModalContent>
+    )
+    expect(screen.getByText('Stuff')).toHaveStyle('padding-bottom: 0.125rem;')
+    expect(screen.getByText('Stuff')).toHaveStyle('padding-top: 0.125rem;')
+  })
+
   test('has no box shadow when it does not overflow', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
       configurable: true,
       value: 0,
     })
+
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
       configurable: true,
       value: 500,
     })
+
     renderWithTheme(
       <ModalContent hasHeader hasFooter>
         Stuff

--- a/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
@@ -57,7 +57,7 @@ afterAll(() => {
     )
 })
 
-describe('DialogContent', () => {
+describe('ModalContent', () => {
   test('basic', () => {
     renderWithTheme(<ModalContent>Stuff</ModalContent>)
     expect(screen.getByText('Stuff')).toBeInTheDocument()
@@ -111,6 +111,6 @@ describe('DialogContent', () => {
 
     expect(
       getComputedStyle(screen.getByText('Stuff')).getPropertyValue('box-shadow')
-    ).toEqual('inset 0 -4px 4px -4px #DEE1E5')
+    ).toEqual('0 -4px 4px -4px #DEE1E5,inset 0 -4px 4px -4px #DEE1E5')
   })
 })

--- a/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
@@ -122,6 +122,6 @@ describe('ModalContent', () => {
 
     expect(
       getComputedStyle(screen.getByText('Stuff')).getPropertyValue('box-shadow')
-    ).toEqual('0 -4px 4px -4px #DEE1E5,inset 0 -4px 4px -4px #DEE1E5')
+    ).toEqual('inset 0 -4px 4px -4px #DEE1E5')
   })
 })

--- a/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.test.tsx
@@ -72,25 +72,102 @@ describe('ModalContent', () => {
     expect(screen.getByText('Stuff')).toBeInTheDocument()
   })
 
-  xtest('display correct padding if hasHeader & hasFooter are true', () => {
+  xtest('display correct padding if hasFooter', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 500,
+    })
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 0,
+    })
+
+    renderWithTheme(<ModalContent hasFooter>Stuff</ModalContent>)
+
+    expect(
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
+        'padding-bottom'
+      )
+    ).toEqual('1.25rem')
+  })
+
+  xtest('display correct padding if hasHeader', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 500,
+    })
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 0,
+    })
+
+    renderWithTheme(<ModalContent hasHeader>Stuff</ModalContent>)
+
+    expect(
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
+        'padding-top'
+      )
+    ).toEqual('1.25rem')
+  })
+
+  xtest('display correct padding if both hasHeader & hasFooter', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 500,
+    })
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 0,
+    })
+
     renderWithTheme(
-      <ModalContent hasHeader={true} hasFooter={true}>
+      <ModalContent hasHeader hasFooter>
         Stuff
       </ModalContent>
     )
 
-    expect(screen.getByText('Stuff')).toHaveStyle('padding-bottom: 1.25rem;')
-    expect(screen.getByText('Stuff')).toHaveStyle('padding-top: 1.25rem;')
+    expect(
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
+        'padding-bottom'
+      )
+    ).toEqual('1.25rem')
+    expect(
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
+        'padding-top'
+      )
+    ).toEqual('1.25rem')
   })
 
   xtest('display correct padding if hasHeader & hasFooter are false', () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 0,
+    })
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 500,
+    })
+
     renderWithTheme(
-      <ModalContent hasHeader={false} hasFooter={false}>
+      <ModalContent hasHeader hasFooter>
         Stuff
       </ModalContent>
     )
-    expect(screen.getByText('Stuff')).toHaveStyle('padding-bottom: 0.125rem;')
-    expect(screen.getByText('Stuff')).toHaveStyle('padding-top: 0.125rem;')
+
+    expect(
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
+        'padding-bottom'
+      )
+    ).toEqual('0.125rem')
+    expect(
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue(
+        'padding-top'
+      )
+    ).toEqual('0.125rem')
   })
 
   test('has no box shadow when it does not overflow', () => {

--- a/packages/components/src/Modal/ModalContent/ModalContent.text.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.text.tsx
@@ -24,10 +24,12 @@
 
  */
 
+/* eslint-disable i18next/no-literal-string */
+
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
-import { DialogContent } from './DialogContent'
+import { ModalContent } from './ModalContent'
 
 const originalScrollHeight = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
@@ -57,20 +59,20 @@ afterAll(() => {
 
 describe('DialogContent', () => {
   test('basic', () => {
-    renderWithTheme(<DialogContent>Stuff</DialogContent>)
+    renderWithTheme(<ModalContent>Stuff</ModalContent>)
     expect(screen.getByText('Stuff')).toBeInTheDocument()
   })
 
   test('hasHeader & hasFooter', () => {
     renderWithTheme(
-      <DialogContent hasHeader hasFooter>
+      <ModalContent hasHeader hasFooter>
         Stuff
-      </DialogContent>
+      </ModalContent>
     )
     expect(screen.getByText('Stuff')).toBeInTheDocument()
   })
 
-  test('content does not have a box shadow when content does not overflow', () => {
+  test('has no box shadow when it does not overflow', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
       configurable: true,
       value: 0,
@@ -80,19 +82,17 @@ describe('DialogContent', () => {
       value: 500,
     })
     renderWithTheme(
-      <DialogContent hasHeader hasFooter>
+      <ModalContent hasHeader hasFooter>
         Stuff
-      </DialogContent>
+      </ModalContent>
     )
 
     expect(
-      getComputedStyle(screen.getByTestId('dialog-content')).getPropertyValue(
-        'box-shadow'
-      )
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue('box-shadow')
     ).toEqual('')
   })
 
-  test('content has a box shadow when content overflows', () => {
+  test('has a box shadow when it overflows', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
       configurable: true,
       value: 500,
@@ -104,15 +104,13 @@ describe('DialogContent', () => {
     })
 
     renderWithTheme(
-      <DialogContent hasHeader hasFooter>
+      <ModalContent hasHeader hasFooter>
         Stuff
-      </DialogContent>
+      </ModalContent>
     )
 
     expect(
-      getComputedStyle(screen.getByTestId('dialog-content')).getPropertyValue(
-        'box-shadow'
-      )
+      getComputedStyle(screen.getByText('Stuff')).getPropertyValue('box-shadow')
     ).toEqual('inset 0 -4px 4px -4px #DEE1E5')
   })
 })

--- a/packages/components/src/Modal/ModalContent/ModalContent.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.tsx
@@ -24,65 +24,41 @@
 
  */
 
-import {
-  CompatibleHTMLProps,
-  padding,
-  reset,
-  LayoutProps,
-  layout,
-  pickStyledProps,
-} from '@looker/design-tokens'
+import { CompatibleHTMLProps, PaddingProps } from '@looker/design-tokens'
 import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import { OverflowShadow, useOverflow } from '../../utils'
-import { SpaceHelperProps } from '../../Layout/Space'
 
-interface ModalStyleProps
-  extends LayoutProps,
-    CompatibleHTMLProps<HTMLDivElement> {}
-
-export interface ModalContentProps extends ModalStyleProps, SpaceHelperProps {
-  /**
-   * If the Modal does not have a footer use this property to manually render padding
-   * at the bottom of the ModalContent. (`hasFooter={false}`)
-   * @default true
-   */
-  hasFooter?: boolean
-  /**
-   * If the Modal does not have a header use this property to manually render padding
-   * at the top of the ModalContent. (`hasHeader={false}`)
-   * @default true
-   */
-  hasHeader?: boolean
-  /**
-   * this is an internal prop to display correct padding numbers.
-   */
-  isPopover?: boolean
-}
+export type ModalContentProps = CompatibleHTMLProps<HTMLDivElement> &
+  PaddingProps & {
+    /**
+     * If the Modal does not have a footer use this property to manually render padding
+     * at the bottom of the ModalContent. (`hasFooter={false}`)
+     * @default true
+     */
+    hasFooter?: boolean
+    /**
+     * If the Modal does not have a header use this property to manually render padding
+     * at the top of the ModalContent. (`hasHeader={false}`)
+     * @default true
+     */
+    hasHeader?: boolean
+  }
 
 const ModalContentLayout = forwardRef(
   (
-    {
-      children,
-      className,
-      hasFooter,
-      hasHeader,
-      isPopover = false,
-      ...props
-    }: ModalContentProps,
+    { children, hasFooter, hasHeader, pb, pt, ...props }: ModalContentProps,
     forwardedRef: Ref<HTMLDivElement>
   ) => {
     const [hasOverflow, ref] = useOverflow(forwardedRef)
-    const pbValue = isPopover ? 'medium' : 'large'
-    const ptValue = isPopover ? 'xsmall' : 'xsmall'
 
     return (
       <OverflowShadow
         hasOverflow={hasOverflow}
         ref={ref}
-        pb={hasOverflow || !!hasHeader ? pbValue : 'xxxsmall'}
-        pt={hasOverflow || !!hasHeader ? ptValue : 'xxxsmall'}
-        {...pickStyledProps(props)}
+        pb={hasOverflow || !!hasFooter ? pb : 'xxxsmall'}
+        pt={hasOverflow || !!hasHeader ? pt : 'xxxsmall'}
+        {...props}
       >
         {children}
       </OverflowShadow>
@@ -93,9 +69,6 @@ const ModalContentLayout = forwardRef(
 ModalContentLayout.displayName = 'ModalContentLayout'
 
 export const ModalContent = styled(ModalContentLayout)<ModalContentProps>`
-  ${reset}
-  ${layout}
-  ${padding}
   flex: 1 1 auto;
   overflow: auto;
 `

--- a/packages/components/src/Modal/ModalContent/ModalContent.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.tsx
@@ -36,27 +36,28 @@ import {
 import React, { FC, useRef, useState, useEffect } from 'react'
 import styled, { css } from 'styled-components'
 import { useResize } from '../../utils'
+import { SpaceHelperProps } from '../../Layout/Space'
 
-interface DialogStyleProps
+interface ModalStyleProps
   extends LayoutProps,
     CompatibleHTMLProps<HTMLDivElement> {}
 
-export interface DialogContentProps extends DialogStyleProps {
+export interface ModalContentProps extends ModalStyleProps, SpaceHelperProps {
   /**
-   * If the Dialog does not have a footer use this property to manually render padding
-   * at the bottom of the DialogContent. (`hasFooter={false}`)
+   * If the Modal does not have a footer use this property to manually render padding
+   * at the bottom of the ModalContent. (`hasFooter={false}`)
    * @default true
    */
   hasFooter?: boolean
   /**
-   * If the Dialog does not have a header use this property to manually render padding
-   * at the top of the DialogContent. (`hasHeader={false}`)
+   * If the Modal does not have a header use this property to manually render padding
+   * at the top of the ModalContent. (`hasHeader={false}`)
    * @default true
    */
   hasHeader?: boolean
 }
 
-export const DialogContent: FC<DialogContentProps> = ({
+export const ModalContent: FC<ModalContentProps> = ({
   children,
   className,
   hasFooter,
@@ -81,34 +82,29 @@ export const DialogContent: FC<DialogContentProps> = ({
       setHasOverflow(container.offsetHeight < container.scrollHeight)
     }
   }, [height])
-
   return (
-    <InnerDialogContent
+    <InnerModalContent
       hasOverflow={hasOverflow}
       ref={internalRef}
-      px={['medium', 'xlarge']}
       pb={hasOverflow || !!hasFooter ? 'large' : 'xxxsmall'}
       pt={hasOverflow || !!hasHeader ? 'large' : 'xxxsmall'}
       {...pickStyledProps(props)}
-      data-testid="dialog-content"
     >
       {children}
-    </InnerDialogContent>
+    </InnerModalContent>
   )
 }
 
-interface InnerDialogContentProps extends DialogStyleProps, PaddingProps {
+interface InnerModalContentProps extends ModalStyleProps, PaddingProps {
   hasOverflow: boolean
 }
 
-const InnerDialogContent = styled.div<InnerDialogContentProps>`
+const InnerModalContent = styled.div<InnerModalContentProps>`
   ${reset}
   ${layout}
   ${padding}
-
   flex: 1 1 auto;
   overflow: auto;
-
   ${({ hasOverflow, theme }) =>
     hasOverflow &&
     css`

--- a/packages/components/src/Modal/ModalContent/ModalContent.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.tsx
@@ -54,21 +54,34 @@ export interface ModalContentProps extends ModalStyleProps, SpaceHelperProps {
    * @default true
    */
   hasHeader?: boolean
+  /**
+   * this is an internal prop to display correct padding numbers.
+   */
+  isPopover?: boolean
 }
 
 const ModalContentLayout = forwardRef(
   (
-    { children, hasFooter, hasHeader, ...props }: ModalContentProps,
+    {
+      children,
+      className,
+      hasFooter,
+      hasHeader,
+      isPopover = false,
+      ...props
+    }: ModalContentProps,
     forwardedRef: Ref<HTMLDivElement>
   ) => {
     const [hasOverflow, ref] = useOverflow(forwardedRef)
+    const pbValue = isPopover ? 'medium' : 'large'
+    const ptValue = isPopover ? 'xsmall' : 'xsmall'
 
     return (
       <OverflowShadow
         hasOverflow={hasOverflow}
         ref={ref}
-        pt={hasOverflow || !!hasHeader ? 'large' : 'xxxsmall'}
-        pb={hasOverflow || !!hasHeader ? 'large' : 'xxxsmall'}
+        pb={hasOverflow || !!hasHeader ? pbValue : 'xxxsmall'}
+        pt={hasOverflow || !!hasHeader ? ptValue : 'xxxsmall'}
         {...pickStyledProps(props)}
       >
         {children}
@@ -79,7 +92,7 @@ const ModalContentLayout = forwardRef(
 
 ModalContentLayout.displayName = 'ModalContentLayout'
 
-export const ModalContent = styled(ModalContentLayout)`
+export const ModalContent = styled(ModalContentLayout)<ModalContentProps>`
   ${reset}
   ${layout}
   ${padding}

--- a/packages/components/src/Modal/ModalContent/index.ts
+++ b/packages/components/src/Modal/ModalContent/index.ts
@@ -24,7 +24,4 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
 export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.story.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.story.tsx
@@ -24,7 +24,17 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+import React from 'react'
+import { PopoverContent } from './PopoverContent'
+
+export default {
+  component: PopoverContent,
+  title: 'PopoverContent',
+}
+
+export const Basic = () => <PopoverContent>Content Text</PopoverContent>
+Basic.parameters = {
+  storyshots: {
+    disable: true,
+  },
+}

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.test.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.test.tsx
@@ -30,8 +30,8 @@ import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
 import { Basic } from './PopoverContent.story'
 
-describe('PopoverHeader', () => {
-  test('Close visible by default', () => {
+describe('PopoverContent', () => {
+  test('Basic', () => {
     renderWithTheme(<Basic />)
     expect(screen.queryByText('Content Text')).toBeInTheDocument()
   })

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.test.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.test.tsx
@@ -24,7 +24,15 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+import 'jest-styled-components'
+import React from 'react'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { screen } from '@testing-library/react'
+import { Basic } from './PopoverContent.story'
+
+describe('PopoverHeader', () => {
+  test('Close visible by default', () => {
+    renderWithTheme(<Basic />)
+    expect(screen.queryByText('Content Text')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
@@ -33,13 +33,7 @@ const PopoverContentLayout: FC<ModalContentProps> = ({
   ...props
 }) => {
   return (
-    <ModalContent
-      pb="medium"
-      pt="xsmall"
-      px="large"
-      isPopover={true}
-      {...props}
-    >
+    <ModalContent pb="medium" pt="xsmall" px="large" {...props}>
       {children}
     </ModalContent>
   )

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
@@ -24,7 +24,19 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+import React, { FC } from 'react'
+import styled from 'styled-components'
+import { ModalContent, ModalContentProps } from '../../../Modal/ModalContent'
+
+const PopoverContentLayout: FC<ModalContentProps> = ({
+  children,
+  ...props
+}) => {
+  return (
+    <ModalContent pb="medium" pt="xsmall" px="large" {...props}>
+      {children}
+    </ModalContent>
+  )
+}
+
+export const PopoverContent = styled(PopoverContentLayout)<ModalContentProps>``

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
@@ -33,7 +33,13 @@ const PopoverContentLayout: FC<ModalContentProps> = ({
   ...props
 }) => {
   return (
-    <ModalContent pb="medium" pt="xsmall" px="large" {...props}>
+    <ModalContent
+      pb="medium"
+      pt="xsmall"
+      px="large"
+      isPopover={true}
+      {...props}
+    >
       {children}
     </ModalContent>
   )

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
@@ -26,9 +26,12 @@
 
 import React, { FC } from 'react'
 import styled from 'styled-components'
+import { LayoutProps } from 'styled-system'
 import { ModalContent, ModalContentProps } from '../../../Modal/ModalContent'
 
-const PopoverContentLayout: FC<ModalContentProps> = ({
+type PopoverContentProps = ModalContentProps & LayoutProps
+
+const PopoverContentLayout: FC<PopoverContentProps> = ({
   children,
   ...props
 }) => {
@@ -39,4 +42,6 @@ const PopoverContentLayout: FC<ModalContentProps> = ({
   )
 }
 
-export const PopoverContent = styled(PopoverContentLayout)<ModalContentProps>``
+export const PopoverContent = styled(
+  PopoverContentLayout
+)<PopoverContentProps>``

--- a/packages/components/src/Popover/Layout/PopoverContent/index.ts
+++ b/packages/components/src/Popover/Layout/PopoverContent/index.ts
@@ -24,7 +24,4 @@
 
  */
 
-export * from './ModalHeaderCloseButton'
-export * from './ModalContent'
-export * from './ModalHeader'
-export * from './ModalFooter'
+export * from './PopoverContent'

--- a/packages/components/src/Popover/Layout/index.ts
+++ b/packages/components/src/Popover/Layout/index.ts
@@ -24,5 +24,6 @@
 
  */
 
+export * from './PopoverContent'
 export * from './PopoverHeader'
 export * from './PopoverFooter'

--- a/packages/components/src/Popover/index.ts
+++ b/packages/components/src/Popover/index.ts
@@ -26,5 +26,4 @@
 
 export * from './Layout'
 export * from './Popover'
-export * from './PopoverContent'
 export * from './usePopover'

--- a/packages/components/src/utils/useOverflow.tsx
+++ b/packages/components/src/utils/useOverflow.tsx
@@ -26,10 +26,11 @@
 
 import { useEffect, useState, Ref } from 'react'
 import styled, { css } from 'styled-components'
+import { PaddingProps } from '@looker/design-tokens'
 import { useResize } from './useResize'
 import { useCallbackRef } from './useCallbackRef'
 
-interface UseOverflowProps {
+interface UseOverflowProps extends PaddingProps {
   hasOverflow: boolean
 }
 

--- a/packages/components/src/utils/useOverflow/OverflowShadow.tsx
+++ b/packages/components/src/utils/useOverflow/OverflowShadow.tsx
@@ -24,18 +24,21 @@
 
  */
 
-import styled from 'styled-components'
-import { LayoutProps, layout } from '@looker/design-tokens'
-import { ModalContent, ModalContentProps } from '../../../Modal/ModalContent'
+import styled, { css } from 'styled-components'
+import { padding, PaddingProps, reset } from '@looker/design-tokens'
+import { UseOverflowProps } from './useOverflow'
 
-export type DialogContentProps = ModalContentProps & LayoutProps
+export type OverflowShadowProps = PaddingProps & UseOverflowProps
 
-export const DialogContent = styled(ModalContent).attrs(
-  ({ pb = 'large', pt = 'large', px = 'xlarge' }) => ({
-    pb,
-    pt,
-    px,
-  })
-)<DialogContentProps>`
-  ${layout}
+const OverflowShadowStyle = css`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
+  border-top: 1px solid ${({ theme }) => theme.colors.ui2};
+  box-shadow: 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2},
+    inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
+`
+
+export const OverflowShadow = styled.div<OverflowShadowProps>`
+  ${reset}
+  ${({ hasOverflow }) => hasOverflow && OverflowShadowStyle}
+  ${padding}
 `

--- a/packages/components/src/utils/useOverflow/OverflowShadow.tsx
+++ b/packages/components/src/utils/useOverflow/OverflowShadow.tsx
@@ -33,8 +33,7 @@ export type OverflowShadowProps = PaddingProps & UseOverflowProps
 const OverflowShadowStyle = css`
   border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
   border-top: 1px solid ${({ theme }) => theme.colors.ui2};
-  box-shadow: 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2},
-    inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
+  box-shadow: inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
 `
 
 export const OverflowShadow = styled.div<OverflowShadowProps>`

--- a/packages/components/src/utils/useOverflow/index.ts
+++ b/packages/components/src/utils/useOverflow/index.ts
@@ -24,18 +24,7 @@
 
  */
 
-import styled from 'styled-components'
-import { LayoutProps, layout } from '@looker/design-tokens'
-import { ModalContent, ModalContentProps } from '../../../Modal/ModalContent'
-
-export type DialogContentProps = ModalContentProps & LayoutProps
-
-export const DialogContent = styled(ModalContent).attrs(
-  ({ pb = 'large', pt = 'large', px = 'xlarge' }) => ({
-    pb,
-    pt,
-    px,
-  })
-)<DialogContentProps>`
-  ${layout}
-`
+export { OverflowShadow } from './OverflowShadow'
+export type { OverflowShadowProps } from './OverflowShadow'
+export { useOverflow } from './useOverflow'
+export type { UseOverflowProps } from './useOverflow'

--- a/packages/components/src/utils/useOverflow/useOverflow.ts
+++ b/packages/components/src/utils/useOverflow/useOverflow.ts
@@ -25,25 +25,12 @@
  */
 
 import { useEffect, useState, Ref } from 'react'
-import styled, { css } from 'styled-components'
-import { PaddingProps } from '@looker/design-tokens'
-import { useResize } from './useResize'
-import { useCallbackRef } from './useCallbackRef'
+import { useResize } from '../useResize'
+import { useCallbackRef } from '../useCallbackRef'
 
-interface UseOverflowProps extends PaddingProps {
+export type UseOverflowProps = {
   hasOverflow: boolean
 }
-
-const OverflowShadowStyle = css`
-  border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
-  border-top: 1px solid ${({ theme }) => theme.colors.ui2};
-  box-shadow: 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2},
-    inset 0 -4px 4px -4px ${({ theme }) => theme.colors.ui2};
-`
-
-export const OverflowShadow = styled.div<UseOverflowProps>`
-  ${({ hasOverflow }) => hasOverflow && OverflowShadowStyle}
-`
 
 export const useOverflow = (
   ref?: Ref<HTMLElement>


### PR DESCRIPTION
Work done:
- Created `ModalContent` a simplified version of `DialogContent` to be used on `PopoverContent` as well - DRY.
- Simplified the work done on `DialogContent` using now `Modal`.
- PopoverContent` was restructured to use `Modal`

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
