### PR TITLE
chore: Quiet down babel complaints due to yarn-deduplicate

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -40,6 +40,8 @@ const ignore = [
 const plugins = [
   ['babel-plugin-styled-components', { pure: true }],
   ['@babel/plugin-proposal-class-properties', { loose: true }],
+  ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+  ['@babel/plugin-proposal-private-methods', { loose: true }],
   '@babel/plugin-proposal-object-rest-spread',
   '@babel/plugin-proposal-optional-chaining',
   '@babel/plugin-proposal-nullish-coalescing-operator',


### PR DESCRIPTION
Storybook's Babel got _really_ noisy after `yarn deduplicate` pass because its now consistently using a more modern version of Babel. These configuration tweaks quiet things back down.