### PR TITLE
fix(ListItem): Moved cursor styling up to ListItemWrapper

### DIFF
--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -190,6 +190,7 @@ const ListItemInternal = forwardRef(
     const renderedDetail = detail && (
       <HoverDisclosure visible={!hoverDisclosure}>
         <ListItemDetail
+          cursor={accessory ? 'default' : 'pointer'}
           pl={padding ? 'xsmall' : '0'}
           pr={accessory && padding ? itemDimensions.px : '0'}
         >

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -190,7 +190,7 @@ const ListItemInternal = forwardRef(
     const renderedDetail = detail && (
       <HoverDisclosure visible={!hoverDisclosure}>
         <ListItemDetail
-          cursor={accessory ? 'default' : 'pointer'}
+          cursorPointer={!accessory}
           pl={padding ? 'xsmall' : '0'}
           pr={accessory && padding ? itemDimensions.px : '0'}
         >
@@ -216,6 +216,7 @@ const ListItemInternal = forwardRef(
         itemRole={itemRole}
         aria-selected={selected}
         className={className}
+        cursorPointer={!!(href || onClick)}
         focusVisible={focusVisible}
         height={itemDimensions.height}
         href={href}
@@ -287,6 +288,7 @@ const ListItemInternal = forwardRef(
         <ListItemWrapper
           className={className}
           color={listItemLabelColor(color, disabled)}
+          cursorPointer={!!onClickWhitespace}
           description={description}
           disabled={disabled}
           onBlur={handleWrapperBlur}

--- a/packages/components/src/List/ListItemDetail.tsx
+++ b/packages/components/src/List/ListItemDetail.tsx
@@ -34,6 +34,7 @@ export type ListItemDetailProps = PaddingProps & {
 export const ListItemDetail = styled.div.attrs<ListItemDetailProps>(
   (props) => ({
     ...props,
+    cursor: props.cursor || 'default',
     pl: props.pl || 'xsmall',
   })
 )<ListItemDetailProps>`

--- a/packages/components/src/List/ListItemDetail.tsx
+++ b/packages/components/src/List/ListItemDetail.tsx
@@ -28,20 +28,19 @@ import { padding, PaddingProps } from '@looker/design-tokens'
 import styled from 'styled-components'
 
 export type ListItemDetailProps = PaddingProps & {
-  cursor?: string
+  cursorPointer?: boolean
 }
 
 export const ListItemDetail = styled.div.attrs<ListItemDetailProps>(
   (props) => ({
     ...props,
-    cursor: props.cursor || 'default',
     pl: props.pl || 'xsmall',
   })
 )<ListItemDetailProps>`
   ${padding}
   align-items: center;
   color: ${({ theme: { colors } }) => colors.text2};
-  cursor: ${({ cursor }) => cursor};
+  cursor: ${({ cursorPointer }) => (cursorPointer ? 'pointer' : undefined)};
   display: flex;
   font-size: ${({ theme }) => theme.fontSizes.xsmall};
   margin-left: auto;

--- a/packages/components/src/List/ListItemDetail.tsx
+++ b/packages/components/src/List/ListItemDetail.tsx
@@ -27,13 +27,20 @@
 import { padding, PaddingProps } from '@looker/design-tokens'
 import styled from 'styled-components'
 
-export const ListItemDetail = styled.div.attrs<PaddingProps>((props) => ({
-  ...props,
-  pl: props.pl || 'xsmall',
-}))<PaddingProps>`
+export type ListItemDetailProps = PaddingProps & {
+  cursor?: string
+}
+
+export const ListItemDetail = styled.div.attrs<ListItemDetailProps>(
+  (props) => ({
+    ...props,
+    pl: props.pl || 'xsmall',
+  })
+)<ListItemDetailProps>`
   ${padding}
   align-items: center;
   color: ${({ theme: { colors } }) => colors.text2};
+  cursor: ${({ cursor }) => cursor};
   display: flex;
   font-size: ${({ theme }) => theme.fontSizes.xsmall};
   margin-left: auto;

--- a/packages/components/src/List/ListItemLabel.tsx
+++ b/packages/components/src/List/ListItemLabel.tsx
@@ -76,6 +76,7 @@ type ListItemLabelProps = CompatibleHTMLProps<HTMLElement> &
   ListItemStatefulProps &
   FlexibleColor &
   FocusVisibleProps & {
+    cursorPointer?: boolean
     disabled?: boolean
     height?: number
     itemRole?: ListItemRole
@@ -95,6 +96,7 @@ export const ListItemLabel = styled(ListItemLabelLayout).withConfig({
   align-items: center;
   border: none;
   color: inherit;
+  cursor: ${({ cursorPointer }) => (cursorPointer ? 'pointer' : undefined)};
   display: flex;
   flex: 1;
   font-size: inherit;

--- a/packages/components/src/List/ListItemLabel.tsx
+++ b/packages/components/src/List/ListItemLabel.tsx
@@ -95,7 +95,6 @@ export const ListItemLabel = styled(ListItemLabelLayout).withConfig({
   align-items: center;
   border: none;
   color: inherit;
-  cursor: pointer;
   display: flex;
   flex: 1;
   font-size: inherit;

--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -36,6 +36,7 @@ export interface ListItemWrapperProps
   extends CompatibleHTMLProps<HTMLElement>,
     ListItemDimensions {
   color: ListColor
+  cursorPointer?: boolean
   description?: ReactNode // Should be eventually deleted because the CSS could be handled in layout pieces
   renderAsDiv?: boolean
 }
@@ -68,7 +69,7 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)
   })
   .attrs(({ color = 'text5' }) => ({ color }))`
   align-items: center;
-  cursor: pointer;
+  cursor: ${({ cursorPointer }) => (cursorPointer ? 'pointer' : undefined)};
   display: flex;
   font-size: ${({ theme: { fontSizes } }) => fontSizes.small};
   font-weight: ${({ theme: { fontWeights } }) => fontWeights.normal};

--- a/packages/components/src/List/ListItemWrapper.tsx
+++ b/packages/components/src/List/ListItemWrapper.tsx
@@ -68,6 +68,7 @@ export const ListItemWrapper = styled(ListItemWrapperInternal)
   })
   .attrs(({ color = 'text5' }) => ({ color }))`
   align-items: center;
+  cursor: pointer;
   display: flex;
   font-size: ${({ theme: { fontSizes } }) => fontSizes.small};
   font-weight: ${({ theme: { fontWeights } }) => fontWeights.normal};


### PR DESCRIPTION
This allows `TreeItem`s that are in `labelBackgroundOnly` mode have `cursor: pointer` when users hover over the indent whitespace (previously the cursor would switch to the default cursor when hovering over the indent whitespace).

**QUESTION:** Not sure if we should only apply `cursor: pointer` if an `onClick` or `onWhitespaceClick` is provided. If we're assuming that `ListItem`s should always be clickable elements like a button / link, I think it makes sense to always apply this style to the wrapper container (rather than conditionally when one of X props is provided).

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
