### PR TITLE
fix(Grid): IE11 warning on grid documentation

### DIFF
--- a/www/src/documentation/components/layout/grid.mdx
+++ b/www/src/documentation/components/layout/grid.mdx
@@ -4,6 +4,18 @@ github: Layout/Grid
 storybook: true
 ---
 
+import { Paragraph, MessageBar, Code, Link } from '@looker/components'
+
+<MessageBar intent="warn" noActions mb="large">
+  <Paragraph>
+    <strong>CAUTION:</strong> Grid component does not render correctly on IE11,
+    and all grid styles will be discarded. If a consistent layout on legacy
+    browsers is important, we recommend <Link href="flex">Flex</Link> for
+    horizontal layouts and <Link href="space">SpaceVertical</Link> to render a
+    single width grid.
+  </Paragraph>
+</MessageBar>
+
 `<Grid />` provides a simple implementation of the CSS Grid.
 
 ## Default

--- a/www/src/documentation/components/layout/grid.mdx
+++ b/www/src/documentation/components/layout/grid.mdx
@@ -4,7 +4,7 @@ github: Layout/Grid
 storybook: true
 ---
 
-import { Paragraph, MessageBar, Code, Link } from '@looker/components'
+import { Paragraph, MessageBar, Link } from '@looker/components'
 
 <MessageBar intent="warn" noActions mb="large">
   <Paragraph>


### PR DESCRIPTION
## 👋👋 Thank you for contributing to Looker Components (⚡️🍣)

Update grid documentation to include a warning for IE11 and link to suggested alternatives. 

<img width="838" alt="Screen Shot 2021-06-03 at 2 32 38 PM" src="https://user-images.githubusercontent.com/238293/120715003-d266bc80-c478-11eb-903c-fc47beac8945.png">

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
