### PR TITLE
chore: Move Lerna to independent mode

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "independent",
   "command": {
     "version": {
       "conventionalCommits": true


### PR DESCRIPTION
Switch Lerna to independent version mode to allow packages to have versions that reflect their readiness for production usage.