### PR TITLE
fix(useTooltip): Don't include `aria-describedby` on target when Tooltip disabled

### DIFF
--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -70,7 +70,7 @@ const IconButtonComponent = forwardRef(
     const {
       domProps: {
         'aria-describedby': ariaDescribedBy,
-        className: tooltipClassName,
+        className: tooltipClassName = '',
         ref,
         onFocus,
         onBlur,

--- a/packages/components/src/Tooltip/types.ts
+++ b/packages/components/src/Tooltip/types.ts
@@ -100,8 +100,8 @@ export interface UseTooltipProps {
 }
 
 export interface UseTooltipResponseDom {
-  'aria-describedby': string
-  className: string
+  'aria-describedby'?: string
+  className?: string
   onBlur: () => void
   onFocus: () => void
   onMouseOut: (event: MouseEvent<HTMLElement>) => void

--- a/packages/components/src/Tooltip/useTooltip.tsx
+++ b/packages/components/src/Tooltip/useTooltip.tsx
@@ -147,10 +147,16 @@ export function useTooltip({
       </Portal>
     ) : null
 
+  const enabledDomProps = disabled
+    ? undefined
+    : {
+        'aria-describedby': guaranteedId,
+        className: renderDOM ? 'hover' : undefined,
+      }
+
   return {
     domProps: {
-      'aria-describedby': guaranteedId,
-      className: renderDOM ? 'hover' : '',
+      ...enabledDomProps,
       onBlur: handleClose,
       onFocus: handleOpen,
       onMouseOut: handleMouseOut,


### PR DESCRIPTION
## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [ ] 🖼 Image Snapshot coverage
