### PR TITLE
feat(Tree): Add virtualization support

### DIFF
--- a/config/i18nIgnoredProps.js
+++ b/config/i18nIgnoredProps.js
@@ -34,7 +34,6 @@ const ours = [
   'iconVerticalAlign',
   'iconViewBox',
   'textDecoration',
-  'windowing',
   'layout',
   'indexBy',
   'indicatorPosition',

--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -78,6 +78,12 @@ export interface AccordionProps
    */
   renderAsLi?: boolean
   /**
+   * Used for virtualization when the disclosure is above the window
+   * @default false
+   * @private This feature may be removed without a breaking change. We STRONGLY discourage the direct use of this property.
+   */
+  hideDisclosure?: boolean
+  /**
    * We currently support two different compositions for Accordion:
    *  - `Accordion`'s children will act as the "trigger" element (i.e. children always visible, clicking children toggles whether content is visible or not)
    *  - Legacy: `<Accordion>` wrapped around an `<AccordionDisclosure>` and `<AccordionContent>` (NOTE: This composition will be deprecated in a future MAJOR release)
@@ -102,6 +108,7 @@ const AccordionLayout: FC<AccordionProps> = ({
   children,
   className,
   content,
+  hideDisclosure,
   id,
   indicatorGap = accordionDefaults.indicatorGap,
   indicatorSize = accordionDefaults.indicatorSize,
@@ -208,9 +215,11 @@ const AccordionLayout: FC<AccordionProps> = ({
   if (children) {
     return (
       <div className={className} id={accordionId}>
-        <AccordionDisclosure {...accordionDisclosureProps}>
-          {children}
-        </AccordionDisclosure>
+        {!hideDisclosure && (
+          <AccordionDisclosure {...accordionDisclosureProps}>
+            {children}
+          </AccordionDisclosure>
+        )}
         <AccordionContent {...accordionContentProps}>
           {content}
         </AccordionContent>
@@ -231,6 +240,7 @@ export const Accordion = styled(AccordionLayout)
       [
         ...AccordionIndicatorPropKeys,
         ...AccordionControlPropKeys,
+        'hideDisclosure',
         'renderAsLi',
       ].includes(prop)
         ? true

--- a/packages/components/src/Accordion/types.ts
+++ b/packages/components/src/Accordion/types.ts
@@ -71,7 +71,6 @@ export interface AccordionControlProps {
   /**
    * Use this property (alongside toggleOpen) if you wish to use the component in a `controlled` manner.
    * isOpen determines whether the Accordion is currently open or closed
-   * @default false
    **/
   isOpen?: boolean
   /**

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -44,20 +44,14 @@ import { HeightProps, fontFamily } from 'styled-system'
 import styled from 'styled-components'
 import { useArrowKeyNav, useWindow } from '../utils'
 import { ListItemContext } from './ListItemContext'
-import { DensityRamp, ListColorProps } from './types'
+import { DensityProps, ListColorProps } from './types'
 import { listItemDimensions } from './utils'
 
 export type ListProps = ListColorProps &
   HeightProps &
   WidthProps &
-  Omit<CompatibleHTMLProps<HTMLUListElement>, 'label'> & {
-    /**
-     * Determines how dense a list should be by affecting child ListItem
-     * size and spacing.
-     * @default 0
-     */
-    density?: DensityRamp
-
+  Omit<CompatibleHTMLProps<HTMLUListElement>, 'label'> &
+  DensityProps & {
     /**
      * Disables the nested List's keyboard nav capabilities
      * @private

--- a/packages/components/src/List/types.ts
+++ b/packages/components/src/List/types.ts
@@ -36,6 +36,14 @@ import { TruncateConfigProp } from '../Truncate'
 
 export type DensityRamp = -3 | -2 | -1 | 0 | 1
 
+export type DensityProps = {
+  /**
+   * Determines how dense a list should be by affecting child item size and spacing.
+   * @default 0
+   */
+  density?: DensityRamp
+}
+
 export interface ListItemDimensions {
   descriptionFontSize: FontSizes
   descriptionLineHeight: LineHeights

--- a/packages/components/src/Tree/TreeCollection.tsx
+++ b/packages/components/src/Tree/TreeCollection.tsx
@@ -24,49 +24,43 @@
 
  */
 
-import React, { FC, KeyboardEvent, ReactNode, useRef } from 'react'
+import { CompatibleHTMLProps } from '@looker/design-tokens'
+import React, { forwardRef, KeyboardEvent, Ref, useRef } from 'react'
 import styled from 'styled-components'
-import { useArrowKeyNav } from '../utils'
+import { useArrowKeyNav, useForkedRef } from '../utils'
 import { getNextTreeFocus, getTreeItems } from './utils'
 
-export type TreeCollectionProps = {
-  children?: ReactNode
-  className?: string
-}
+export type TreeCollectionProps = CompatibleHTMLProps<HTMLUListElement>
 
-const TreeCollectionLayout: FC<TreeCollectionProps> = ({
-  children,
-  className,
-}) => {
-  const ref = useRef<HTMLUListElement>(null)
+const TreeCollectionInternal = forwardRef(
+  (props: TreeCollectionProps, forwardedRef: Ref<HTMLUListElement>) => {
+    const internalRef = useRef<HTMLUListElement>(null)
 
-  // Additional key shortcuts
-  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-    const treeItems = getTreeItems(ref.current as HTMLElement)
-    if (event.key === 'Home') {
-      const firstItem = treeItems[0]
-      firstItem && firstItem.focus()
-    } else if (event.key === 'End') {
-      const lastItem = treeItems[treeItems.length - 1]
-      lastItem && lastItem.focus()
+    // Additional key shortcuts
+    const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+      const treeItems = getTreeItems(internalRef.current as HTMLElement)
+      if (event.key === 'Home') {
+        const firstItem = treeItems[0]
+        firstItem && firstItem.focus()
+      } else if (event.key === 'End') {
+        const lastItem = treeItems[treeItems.length - 1]
+        lastItem && lastItem.focus()
+      }
     }
+
+    const navProps = useArrowKeyNav<HTMLUListElement>({
+      axis: 'both',
+      getNextFocus: getNextTreeFocus,
+      onKeyDown: handleKeyDown,
+      ref: useForkedRef(internalRef, forwardedRef),
+    })
+
+    return <ul role="tree" {...props} {...navProps} />
   }
+)
 
-  const navProps = useArrowKeyNav<HTMLUListElement>({
-    axis: 'both',
-    getNextFocus: getNextTreeFocus,
-    onKeyDown: handleKeyDown,
-    ref,
-  })
-
-  return (
-    <ul className={className} role="tree" {...navProps}>
-      {children}
-    </ul>
-  )
-}
-
-export const TreeCollection = styled(TreeCollectionLayout)`
+export const TreeCollection = styled(TreeCollectionInternal)`
+  list-style-type: none;
   margin: 0;
   padding: 0;
 `

--- a/packages/components/src/Tree/TreeCollectionContext.ts
+++ b/packages/components/src/Tree/TreeCollectionContext.ts
@@ -24,10 +24,20 @@
 
  */
 
-export * from './Tree'
-export * from './TreeItem'
-export * from './TreeBranch'
-export * from './TreeCollection'
-export * from './WindowedTreeCollection'
-export * from './types'
-export { generateBorderRadius } from './utils'
+import { createContext } from 'react'
+import { DensityProps } from '../List/types'
+import { ToggleStateMap } from './types'
+
+export type TreeCollectionContextProps = DensityProps & {
+  /** @private */
+  toggleNode?: (id: number, isOpen: boolean) => void
+  /** @private */
+  toggleStateMap?: ToggleStateMap
+}
+
+/**
+ * Manage the opened / closed state of sub-trees for windowing purposes
+ */
+export const TreeCollectionContext = createContext<TreeCollectionContextProps>(
+  {}
+)

--- a/packages/components/src/Tree/TreeContext.tsx
+++ b/packages/components/src/Tree/TreeContext.tsx
@@ -25,12 +25,11 @@
  */
 
 import { createContext } from 'react'
-import { DensityRamp, ListColor } from '../List/types'
+import { DensityProps, ListColor } from '../List/types'
 
-export interface TreeContextProps {
+export type TreeContextProps = DensityProps & {
   border?: boolean
   color?: ListColor
-  density: DensityRamp
   depth?: number
   labelBackgroundOnly?: boolean
 }

--- a/packages/components/src/Tree/WindowedTreeCollection.test.tsx
+++ b/packages/components/src/Tree/WindowedTreeCollection.test.tsx
@@ -34,7 +34,6 @@ const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
 
 describe('WindowedTreeCollection', () => {
   beforeEach(() => {
-    jest.useFakeTimers()
     /* eslint-disable-next-line @typescript-eslint/unbound-method */
     Element.prototype.getBoundingClientRect = jest.fn(() => {
       return {
@@ -52,9 +51,6 @@ describe('WindowedTreeCollection', () => {
   })
 
   afterEach(() => {
-    jest.runOnlyPendingTimers()
-    jest.useRealTimers()
-    jest.resetAllMocks()
     /* eslint-disable-next-line @typescript-eslint/unbound-method */
     Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
   })
@@ -67,10 +63,8 @@ describe('WindowedTreeCollection', () => {
 
   test('windowing for over 100 visible items', () => {
     renderWithTheme(<Windowing noText />)
-    const button = screen.getByRole('button')
-    fireEvent.click(button)
-
-    jest.runOnlyPendingTimers()
+    const openAllButton = screen.getByText('Toggle all open')
+    fireEvent.click(openAllButton)
 
     expect(screen.getByText('0')).toBeVisible()
     // Visible nested tree item

--- a/packages/components/src/Tree/WindowedTreeCollection.test.tsx
+++ b/packages/components/src/Tree/WindowedTreeCollection.test.tsx
@@ -1,0 +1,91 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React from 'react'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { fireEvent, screen } from '@testing-library/react'
+import { Windowing } from './stories/Windowing.story'
+
+/* eslint-disable-next-line @typescript-eslint/unbound-method */
+const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+describe('WindowedTreeCollection', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    /* eslint-disable-next-line @typescript-eslint/unbound-method */
+    Element.prototype.getBoundingClientRect = jest.fn(() => {
+      return {
+        bottom: 0,
+        height: 342,
+        left: 0,
+        right: 0,
+        toJSON: jest.fn(),
+        top: 0,
+        width: 260,
+        x: 0,
+        y: 0,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    jest.resetAllMocks()
+    /* eslint-disable-next-line @typescript-eslint/unbound-method */
+    Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
+  })
+
+  test('no windowing for 100 or fewer visible items', () => {
+    renderWithTheme(<Windowing noText />)
+    expect(screen.getByText('0')).toBeVisible()
+    expect(screen.getByText('99')).toBeVisible()
+  })
+
+  test('windowing for over 100 visible items', () => {
+    renderWithTheme(<Windowing noText />)
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    jest.runOnlyPendingTimers()
+
+    expect(screen.getByText('0')).toBeVisible()
+    // Visible nested tree item
+    expect(screen.getByText('0-5-3')).toBeVisible()
+    // Not-visible nested tree item
+    expect(screen.queryByText('0-5-4')).not.toBeInTheDocument()
+    expect(screen.queryByText('99')).not.toBeInTheDocument()
+
+    // Collapse one of the trees
+    const tree02 = screen.getByText('0-2')
+    fireEvent.click(tree02)
+    // In-window nested tree items
+    expect(screen.getByText('0-5-4')).toBeVisible()
+    expect(screen.getByText('0-8-0')).toBeVisible()
+    // Below-window nested tree item
+    expect(screen.queryByText('0-8-1')).not.toBeInTheDocument()
+  })
+})

--- a/packages/components/src/Tree/WindowedTreeCollection.tsx
+++ b/packages/components/src/Tree/WindowedTreeCollection.tsx
@@ -58,13 +58,13 @@ const WindowedTreeCollectionInternal = ({
   trees,
   ...props
 }: WindowedTreeCollectionProps) => {
-  const { value, content, ref } = useWindowedTree({
+  const { content, contextValue, ref } = useWindowedTree({
     density,
     trees,
   })
 
   return (
-    <TreeCollectionContext.Provider value={value}>
+    <TreeCollectionContext.Provider value={contextValue}>
       <TreeCollection {...omitStyledProps(props)} ref={ref}>
         {content}
       </TreeCollection>

--- a/packages/components/src/Tree/WindowedTreeCollection.tsx
+++ b/packages/components/src/Tree/WindowedTreeCollection.tsx
@@ -1,0 +1,81 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import {
+  height,
+  HeightProps,
+  omitStyledProps,
+  width,
+  WidthProps,
+} from '@looker/design-tokens'
+import React from 'react'
+import styled from 'styled-components'
+import { DensityProps } from '../List/types'
+import { useWindowedTree } from './utils/useWindowedTree'
+import { WindowedTreeNodeProps } from './types'
+import { TreeCollectionContext } from './TreeCollectionContext'
+import { TreeCollection, TreeCollectionProps } from './TreeCollection'
+
+export type WindowedTreeCollectionProps = Omit<
+  TreeCollectionProps,
+  'children'
+> &
+  DensityProps &
+  HeightProps &
+  WidthProps & {
+    /**
+     * Use this array of objects representing the tree(s) instead of children
+     * in order to support windowing of long trees
+     */
+    trees: WindowedTreeNodeProps[]
+  }
+
+const WindowedTreeCollectionInternal = ({
+  density,
+  trees,
+  ...props
+}: WindowedTreeCollectionProps) => {
+  const { value, content, ref } = useWindowedTree({
+    density,
+    trees,
+  })
+
+  return (
+    <TreeCollectionContext.Provider value={value}>
+      <TreeCollection {...omitStyledProps(props)} ref={ref}>
+        {content}
+      </TreeCollection>
+    </TreeCollectionContext.Provider>
+  )
+}
+
+export const WindowedTreeCollection = styled(
+  WindowedTreeCollectionInternal
+)<TreeCollectionProps>`
+  ${height}
+  ${width}
+  overflow: auto;
+`

--- a/packages/components/src/Tree/WindowedTreeNode.tsx
+++ b/packages/components/src/Tree/WindowedTreeNode.tsx
@@ -1,0 +1,88 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, {
+  cloneElement,
+  createContext,
+  isValidElement,
+  useCallback,
+  useContext,
+} from 'react'
+import { DensityProps } from '../List/types'
+import { TreeCollectionContext } from './TreeCollectionContext'
+import { WindowedTreeNodeIDProps } from './types'
+
+export type WindowedTreeContextProps = DensityProps & {
+  isOpen?: boolean
+  partialRender: boolean
+  toggleNode?: (isOpen: boolean) => void
+}
+
+export const WindowedTreeContext = createContext<WindowedTreeContextProps>({
+  partialRender: false,
+})
+
+export const WindowedTreeNode = ({
+  content,
+  firstID,
+  id,
+  items,
+}: WindowedTreeNodeIDProps & {
+  firstID?: number
+}) => {
+  // Update state for which tree nodes are opened / closed
+  const context = useContext(TreeCollectionContext)
+  const toggleNode = useCallback(
+    (isOpen: boolean) => {
+      context.toggleNode?.(id, isOpen)
+    },
+    [context, id]
+  )
+
+  if (items && isValidElement(content)) {
+    // insert the items as children
+    const props = {
+      children: items.map((item) => (
+        <WindowedTreeNode firstID={firstID} {...item} key={item.id} />
+      )),
+    }
+    const isOpen = context.toggleStateMap?.[id]?.isOpen
+
+    return (
+      <WindowedTreeContext.Provider
+        value={{
+          density: context.density,
+          isOpen,
+          partialRender: firstID ? id < firstID : false,
+          toggleNode,
+        }}
+      >
+        {cloneElement(content, props)}
+      </WindowedTreeContext.Provider>
+    )
+  }
+  return content
+}

--- a/packages/components/src/Tree/WindowedTreeNode.tsx
+++ b/packages/components/src/Tree/WindowedTreeNode.tsx
@@ -47,11 +47,11 @@ export const WindowedTreeContext = createContext<WindowedTreeContextProps>({
 
 export const WindowedTreeNode = ({
   content,
-  firstID,
+  firstIDinWindow,
   id,
   items,
 }: WindowedTreeNodeIDProps & {
-  firstID?: number
+  firstIDinWindow?: number
 }) => {
   // Update state for which tree nodes are opened / closed
   const context = useContext(TreeCollectionContext)
@@ -66,7 +66,11 @@ export const WindowedTreeNode = ({
     // insert the items as children
     const props = {
       children: items.map((item) => (
-        <WindowedTreeNode firstID={firstID} {...item} key={item.id} />
+        <WindowedTreeNode
+          firstIDinWindow={firstIDinWindow}
+          {...item}
+          key={item.id}
+        />
       )),
     }
     const isOpen = context.toggleStateMap?.[id]?.isOpen
@@ -76,7 +80,7 @@ export const WindowedTreeNode = ({
         value={{
           density: context.density,
           isOpen,
-          partialRender: firstID ? id < firstID : false,
+          partialRender: firstIDinWindow ? id < firstIDinWindow : false,
           toggleNode,
         }}
       >

--- a/packages/components/src/Tree/stories/FieldItem.tsx
+++ b/packages/components/src/Tree/stories/FieldItem.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, useState } from 'react'
+import React, { createContext, FC, useContext, useState } from 'react'
 import { FilterList } from '@styled-icons/material/FilterList'
 import { MoreVert } from '@styled-icons/material/MoreVert'
 import { SubdirectoryArrowLeft } from '@styled-icons/material/SubdirectoryArrowLeft'
@@ -41,6 +41,9 @@ import {
 import { TreeItem } from '..'
 import { HoverDisclosure } from '../../utils'
 import { listItemDimensions } from '../../List'
+import { ReplaceText, Span } from '../../Text'
+
+export const HighlightContext = createContext({ term: '' })
 
 type FieldItemProps = {
   color?: ToggleColor
@@ -57,6 +60,7 @@ export const FieldItem: FC<FieldItemProps> = ({
   selected = false,
 }) => {
   const [isFieldMenuOpen, setIsFieldMenuOpen] = useState<boolean>(false)
+  const { term } = useContext(HighlightContext)
 
   const [isFilter, setIsFilter] = useState(filter)
   const [isPivot, setIsPivot] = useState(pivot)
@@ -128,7 +132,22 @@ export const FieldItem: FC<FieldItemProps> = ({
           overflow="hidden"
           width="100%"
         >
-          <Truncate>{children}</Truncate>
+          <Truncate>
+            <ReplaceText
+              match={term}
+              replace={(str, index) => (
+                <Span
+                  fontWeight="semiBold"
+                  textDecoration="underline"
+                  key={index}
+                >
+                  {str}
+                </Span>
+              )}
+            >
+              {children}
+            </ReplaceText>
+          </Truncate>
         </Flex>
         <HoverDisclosure visible={isPivot} strategy="display">
           <IconButton

--- a/packages/components/src/Tree/stories/Tree.story.tsx
+++ b/packages/components/src/Tree/stories/Tree.story.tsx
@@ -41,6 +41,7 @@ export * from './FileTree.story'
 export * from './ForceLabelPadding.story'
 export * from './LabelBackgroundOnly.story'
 export * from './LongLabels.story'
+export * from './Windowing.story'
 
 export default {
   component: Tree,

--- a/packages/components/src/Tree/stories/Windowing.story.tsx
+++ b/packages/components/src/Tree/stories/Windowing.story.tsx
@@ -1,0 +1,151 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, { FormEvent, useMemo, useState } from 'react'
+import styled from 'styled-components'
+import { Button } from '../../Button'
+import { InputText } from '../../Form'
+import { Space, SpaceVertical } from '../../Layout'
+import { useToggle } from '../../utils'
+import { WindowedTreeNodeProps, WindowedTreeCollection, Tree } from '..'
+import { generateBorderRadius } from '../utils/generateBorderRadius'
+import { FieldItem, HighlightContext } from './FieldItem'
+
+const BorderRadiusOverrideTree = styled(Tree)`
+  ${({ theme }) => generateBorderRadius('medium', theme)}
+`
+
+const getRandomInteger = (limit: number) => Math.floor(Math.random() * limit)
+
+const preamble = `We the People of the United States, in Order to form a more perfect Union,
+establish Justice, insure domestic Tranquility, provide for the common
+defense, promote the general Welfare, and secure the Blessings of Liberty
+to ourselves and our Posterity, do ordain and establish this Constitution
+for the United States of America.`
+
+const getString = (lengthLimit = 30) => {
+  const startLimit = preamble.length - 50
+  const length = getRandomInteger(lengthLimit)
+  const startIndex = getRandomInteger(startLimit)
+  return preamble.substr(startIndex, length)
+}
+
+const getItems = (
+  prefix: string,
+  labelLength: number,
+  canNest = false
+): WindowedTreeNodeProps[] => {
+  // const num = getRandomInteger(8)
+  // const itemsLength = Math.pow(num, 2)
+  return Array.from(Array(10), (_, i) => {
+    if (canNest && i % 3 === 2) {
+      const labelText = labelLength ? `: ${getString()}` : ''
+      return {
+        content: (
+          <BorderRadiusOverrideTree
+            labelBackgroundOnly
+            label={`${prefix}-${i}${labelText}`}
+          />
+        ),
+        isOpen: true,
+        items: getItems(`${prefix}-${i}`, labelLength),
+      }
+    }
+    const itemText = labelLength ? `: ${getString(labelLength)}` : ''
+    return {
+      content: (
+        <FieldItem>
+          {prefix}-{i}
+          {itemText}
+        </FieldItem>
+      ),
+    }
+  })
+}
+
+const getGroups = (labelLength: number): WindowedTreeNodeProps[] =>
+  Array.from(Array(100), (_, i) => {
+    const labelText = labelLength ? `: ${getString()}` : ''
+    return {
+      content: (
+        <BorderRadiusOverrideTree
+          labelBackgroundOnly
+          label={`${i}${labelText}`}
+        />
+      ),
+      isOpen: true,
+      items: getItems(String(i), labelLength, true),
+    }
+  })
+
+const groupsRandomText = getGroups(50)
+const groupsNoText = getGroups(0)
+
+const getUpdater =
+  (isOpen: boolean) =>
+  (tree: WindowedTreeNodeProps): WindowedTreeNodeProps => {
+    if (tree.items) {
+      return { ...tree, isOpen, items: tree.items.map(getUpdater(isOpen)) }
+    }
+    return { ...tree, isOpen }
+  }
+
+export const Windowing = ({ noText }: { noText?: boolean }) => {
+  const { value, toggle, setOn } = useToggle()
+  const [term, setTerm] = useState('')
+  const handleChange = (e: FormEvent<HTMLInputElement>) => {
+    setTerm(e.currentTarget.value)
+    if (term === '' && e.currentTarget.value !== '') {
+      setOn()
+    }
+  }
+  const treesUpdated = useMemo(() => {
+    const groups = noText ? groupsNoText : groupsRandomText
+    return groups.map(getUpdater(value))
+  }, [noText, value])
+
+  return (
+    <SpaceVertical height="100vh">
+      <Space>
+        <Button onClick={toggle}>Toggle all {value ? 'closed' : 'open'}</Button>
+        <InputText value={term} onChange={handleChange} />
+      </Space>
+      <HighlightContext.Provider value={{ term }}>
+        <WindowedTreeCollection
+          density={-3}
+          height="100%"
+          width="450px"
+          trees={treesUpdated}
+        />
+      </HighlightContext.Provider>
+    </SpaceVertical>
+  )
+}
+
+Windowing.parameters = {
+  docs: { disable: true },
+  storyshots: { disable: true },
+}

--- a/packages/components/src/Tree/stories/Windowing.story.tsx
+++ b/packages/components/src/Tree/stories/Windowing.story.tsx
@@ -58,8 +58,6 @@ const getItems = (
   labelLength: number,
   canNest = false
 ): WindowedTreeNodeProps[] => {
-  // const num = getRandomInteger(8)
-  // const itemsLength = Math.pow(num, 2)
   return Array.from(Array(10), (_, i) => {
     if (canNest && i % 3 === 2) {
       const labelText = labelLength ? `: ${getString()}` : ''
@@ -86,7 +84,7 @@ const getItems = (
   })
 }
 
-const getGroups = (labelLength: number): WindowedTreeNodeProps[] =>
+const getTrees = (labelLength: number): WindowedTreeNodeProps[] =>
   Array.from(Array(100), (_, i) => {
     const labelText = labelLength ? `: ${getString()}` : ''
     return {
@@ -101,8 +99,8 @@ const getGroups = (labelLength: number): WindowedTreeNodeProps[] =>
     }
   })
 
-const groupsRandomText = getGroups(50)
-const groupsNoText = getGroups(0)
+const treesRandomText = getTrees(50)
+const treesNoText = getTrees(0)
 
 const getUpdater =
   (isOpen: boolean) =>
@@ -123,8 +121,8 @@ export const Windowing = ({ noText }: { noText?: boolean }) => {
     }
   }
   const treesUpdated = useMemo(() => {
-    const groups = noText ? groupsNoText : groupsRandomText
-    return groups.map(getUpdater(value))
+    const trees = noText ? treesNoText : treesRandomText
+    return trees.map(getUpdater(value))
   }, [noText, value])
 
   return (

--- a/packages/components/src/Tree/types.ts
+++ b/packages/components/src/Tree/types.ts
@@ -112,3 +112,31 @@ export type TreeProps = Omit<
      */
     labelBackgroundOnly?: boolean
   }
+
+export type WindowedTreeNodeProps = {
+  /**
+   * The JSX to render for the current node.
+   * If this node is a tree, use `items` instead of children.
+   */
+  content: JSX.Element
+  /**
+   * Use to control the opened / closed state of the tree instead of
+   * props on the Tree component itself (necessary for windowing)
+   */
+  isOpen?: boolean
+  /**
+   * An array of objects representing the tree items and nested trees
+   * to be rendered as children of the element in `content`
+   */
+  items?: WindowedTreeNodeProps[]
+}
+
+export type WindowedTreeNodeIDProps = Omit<WindowedTreeNodeProps, 'items'> & {
+  content: JSX.Element
+  id: number
+  items?: WindowedTreeNodeIDProps[]
+}
+
+export type ToggleStateMap = {
+  [id: number]: { isOpen: boolean; length: number }
+}

--- a/packages/components/src/Tree/utils/getWindowedTreeNodeFilterer.ts
+++ b/packages/components/src/Tree/utils/getWindowedTreeNodeFilterer.ts
@@ -1,0 +1,79 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { WindowedTreeNodeIDProps } from '../types'
+
+const getTreeWindowIntersection = (
+  list: WindowedTreeNodeIDProps[],
+  index: number,
+  firstID: number,
+  lastID: number
+) => {
+  const tree = list[index]
+  if (tree.id > lastID) return 'after'
+
+  const nextTree = list[index + 1]
+  if (tree.id < firstID) {
+    if (nextTree && nextTree.id > firstID) {
+      return 'intersects'
+    }
+  } else if (tree.id <= lastID) {
+    return 'intersects'
+  }
+  return 'before'
+}
+
+export const getWindowedTreeNodeFilterer =
+  (filteredList: WindowedTreeNodeIDProps[], firstID: number, lastID: number) =>
+  (
+    node: WindowedTreeNodeIDProps,
+    index: number,
+    list: WindowedTreeNodeIDProps[]
+  ) => {
+    const intersection = getTreeWindowIntersection(list, index, firstID, lastID)
+    // If the node is after the window, stop looping
+    if (intersection === 'after') return false
+
+    if (intersection === 'intersects') {
+      const treeItems = node.items
+      if (treeItems) {
+        // Recursively filter the tree's items
+        const filteredItems: WindowedTreeNodeIDProps[] = []
+        treeItems.every(
+          getWindowedTreeNodeFilterer(filteredItems, firstID, lastID)
+        )
+        const treeWithFilteredItems = { ...node, items: filteredItems }
+        filteredList.push(treeWithFilteredItems)
+      } else {
+        // This is an item (not a tree) within the window
+        filteredList.push(node)
+      }
+    }
+    // Return true to keep looping for either 'before' or 'intersects'
+    // 'before': we need to keep checking to find the first intersecting tree
+    // 'intersects': the next tree may also intersect the window
+    return true
+  }

--- a/packages/components/src/Tree/utils/getWindowedTreeNodeFilterer.ts
+++ b/packages/components/src/Tree/utils/getWindowedTreeNodeFilterer.ts
@@ -29,31 +29,40 @@ import { WindowedTreeNodeIDProps } from '../types'
 const getTreeWindowIntersection = (
   list: WindowedTreeNodeIDProps[],
   index: number,
-  firstID: number,
-  lastID: number
+  firstIDinWindow: number,
+  lastIDinWindow: number
 ) => {
   const tree = list[index]
-  if (tree.id > lastID) return 'after'
+  if (tree.id > lastIDinWindow) return 'after'
 
   const nextTree = list[index + 1]
-  if (tree.id < firstID) {
-    if (nextTree && nextTree.id > firstID) {
+  if (tree.id < firstIDinWindow) {
+    if (nextTree && nextTree.id > firstIDinWindow) {
       return 'intersects'
     }
-  } else if (tree.id <= lastID) {
+  } else if (tree.id <= lastIDinWindow) {
     return 'intersects'
   }
   return 'before'
 }
 
 export const getWindowedTreeNodeFilterer =
-  (filteredList: WindowedTreeNodeIDProps[], firstID: number, lastID: number) =>
+  (
+    filteredList: WindowedTreeNodeIDProps[],
+    firstIDinWindow: number,
+    lastIDinWindow: number
+  ) =>
   (
     node: WindowedTreeNodeIDProps,
     index: number,
     list: WindowedTreeNodeIDProps[]
   ) => {
-    const intersection = getTreeWindowIntersection(list, index, firstID, lastID)
+    const intersection = getTreeWindowIntersection(
+      list,
+      index,
+      firstIDinWindow,
+      lastIDinWindow
+    )
     // If the node is after the window, stop looping
     if (intersection === 'after') return false
 
@@ -63,7 +72,11 @@ export const getWindowedTreeNodeFilterer =
         // Recursively filter the tree's items
         const filteredItems: WindowedTreeNodeIDProps[] = []
         treeItems.every(
-          getWindowedTreeNodeFilterer(filteredItems, firstID, lastID)
+          getWindowedTreeNodeFilterer(
+            filteredItems,
+            firstIDinWindow,
+            lastIDinWindow
+          )
         )
         const treeWithFilteredItems = { ...node, items: filteredItems }
         filteredList.push(treeWithFilteredItems)

--- a/packages/components/src/Tree/utils/useWindowedTree.tsx
+++ b/packages/components/src/Tree/utils/useWindowedTree.tsx
@@ -1,0 +1,107 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React, { Ref, useCallback, useEffect, useReducer } from 'react'
+import { listItemDimensions } from '../../List'
+import { DensityProps } from '../../List/types'
+import { useWindowBase } from '../../utils'
+import { WindowedTreeNodeProps, WindowedTreeNodeIDProps } from '../types'
+import { WindowedTreeNode } from '../WindowedTreeNode'
+import { windowedTreeReducer } from './windowedTreeReducer'
+import { getWindowedTreeNodeFilterer } from './getWindowedTreeNodeFilterer'
+
+export type UseWindowedTreeNodeProps = DensityProps & {
+  ref?: Ref<HTMLUListElement>
+  trees: WindowedTreeNodeProps[]
+}
+
+export const useWindowedTree = ({
+  density,
+  trees,
+}: UseWindowedTreeNodeProps) => {
+  // Keep track of the sub-trees opened / closed state by ID and
+  // the total number of SHOWN items(i.e.no ancestor is closed)
+  const [{ map, shownIDs, treesWithIDs }, dispatch] = useReducer(
+    windowedTreeReducer,
+    {
+      map: {},
+      shownIDs: [],
+      treesWithIDs: [],
+    }
+  )
+
+  useEffect(() => {
+    // If the trees prop has changed, need to reset all state
+    dispatch({ payload: trees, type: 'RESET' })
+  }, [trees])
+
+  const toggleNode = useCallback((id: number, isOpen: boolean) => {
+    if (isOpen) {
+      dispatch({ payload: id, type: 'OPEN' })
+    } else {
+      dispatch({ payload: id, type: 'CLOSE' })
+    }
+  }, [])
+
+  // Get item height from density
+  const { height } = listItemDimensions(density || 0)
+
+  // Get the windowing properties
+  const { after, before, end, ref, start } = useWindowBase({
+    childHeight: height,
+    enabled: shownIDs.length > 100,
+    length: shownIDs.length,
+  })
+
+  let content = null
+
+  if (treesWithIDs) {
+    // Find the tree nodes that are within the window
+    const firstID = shownIDs[start]
+    const lastID = shownIDs[end]
+    const nodesInWindow: WindowedTreeNodeIDProps[] = []
+    treesWithIDs.every(
+      getWindowedTreeNodeFilterer(nodesInWindow, firstID, lastID)
+    )
+
+    content = (
+      <>
+        {before}
+        {nodesInWindow.map((tree) => (
+          <WindowedTreeNode {...tree} firstID={firstID} key={tree.id} />
+        ))}
+        {after}
+      </>
+    )
+  }
+
+  return {
+    content,
+    ref,
+    shownIDs,
+    value: { density, toggleNode, toggleStateMap: map },
+  }
+}

--- a/packages/components/src/Tree/utils/useWindowedTree.tsx
+++ b/packages/components/src/Tree/utils/useWindowedTree.tsx
@@ -27,7 +27,7 @@
 import React, { Ref, useCallback, useEffect, useReducer } from 'react'
 import { listItemDimensions } from '../../List'
 import { DensityProps } from '../../List/types'
-import { useWindowBase } from '../../utils'
+import { useWindow } from '../../utils'
 import { WindowedTreeNodeProps, WindowedTreeNodeIDProps } from '../types'
 import { WindowedTreeNode } from '../WindowedTreeNode'
 import { windowedTreeReducer } from './windowedTreeReducer'
@@ -70,10 +70,10 @@ export const useWindowedTree = ({
   const { height } = listItemDimensions(density || 0)
 
   // Get the windowing properties
-  const { after, before, end, ref, start } = useWindowBase({
-    childHeight: height,
+  const { after, before, end, ref, start } = useWindow({
     enabled: shownIDs.length > 100,
-    length: shownIDs.length,
+    itemCount: shownIDs.length,
+    itemHeight: height,
   })
 
   let content = null

--- a/packages/components/src/Tree/utils/useWindowedTree.tsx
+++ b/packages/components/src/Tree/utils/useWindowedTree.tsx
@@ -80,18 +80,26 @@ export const useWindowedTree = ({
 
   if (treesWithIDs) {
     // Find the tree nodes that are within the window
-    const firstID = shownIDs[start]
-    const lastID = shownIDs[end]
+    const firstIDinWindow = shownIDs[start]
+    const lastIDinWindow = shownIDs[end]
     const nodesInWindow: WindowedTreeNodeIDProps[] = []
     treesWithIDs.every(
-      getWindowedTreeNodeFilterer(nodesInWindow, firstID, lastID)
+      getWindowedTreeNodeFilterer(
+        nodesInWindow,
+        firstIDinWindow,
+        lastIDinWindow
+      )
     )
 
     content = (
       <>
         {before}
         {nodesInWindow.map((tree) => (
-          <WindowedTreeNode {...tree} firstID={firstID} key={tree.id} />
+          <WindowedTreeNode
+            {...tree}
+            firstIDinWindow={firstIDinWindow}
+            key={tree.id}
+          />
         ))}
         {after}
       </>
@@ -100,8 +108,7 @@ export const useWindowedTree = ({
 
   return {
     content,
+    contextValue: { density, toggleNode, toggleStateMap: map },
     ref,
-    shownIDs,
-    value: { density, toggleNode, toggleStateMap: map },
   }
 }

--- a/packages/components/src/Tree/utils/useWindowedTree.tsx
+++ b/packages/components/src/Tree/utils/useWindowedTree.tsx
@@ -43,7 +43,7 @@ export const useWindowedTree = ({
   trees,
 }: UseWindowedTreeNodeProps) => {
   // Keep track of the sub-trees opened / closed state by ID and
-  // the total number of SHOWN items(i.e.no ancestor is closed)
+  // the total number of SHOWN items (i.e. no ancestor is closed)
   const [{ map, shownIDs, treesWithIDs }, dispatch] = useReducer(
     windowedTreeReducer,
     {

--- a/packages/components/src/Tree/utils/windowedTreeReducer.ts
+++ b/packages/components/src/Tree/utils/windowedTreeReducer.ts
@@ -1,0 +1,115 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { Reducer } from 'react'
+import {
+  ToggleStateMap,
+  WindowedTreeNodeProps,
+  WindowedTreeNodeIDProps,
+} from '../types'
+
+type WindowedTreeState = {
+  map: ToggleStateMap
+  shownIDs: number[]
+  treesWithIDs: WindowedTreeNodeIDProps[]
+}
+type WindowedTreeAction = {
+  type: 'OPEN' | 'CLOSE' | 'RESET'
+  payload: number | WindowedTreeNodeProps[]
+}
+
+const updateCount = (state: WindowedTreeState, id: number, isOpen: boolean) => {
+  // Get the updated count after a tree has been toggled
+  const shownIDs: number[] = []
+
+  const { map, treesWithIDs } = state
+  const node = map[id]
+  node.isOpen = isOpen
+
+  const countTree =
+    (parentOpen?: boolean) => (tree: WindowedTreeNodeIDProps) => {
+      if (parentOpen) {
+        shownIDs.push(tree.id)
+      }
+      if (tree.items) {
+        const treeIsOpen = map[tree.id].isOpen
+        tree.items.forEach(countTree(parentOpen ? treeIsOpen : false))
+      }
+    }
+  treesWithIDs?.forEach(countTree(true))
+  return { ...state, shownIDs }
+}
+
+export const windowedTreeReducer: Reducer<
+  WindowedTreeState,
+  WindowedTreeAction
+> = (state, action) => {
+  switch (action.type) {
+    case 'RESET': {
+      const trees = action.payload as WindowedTreeNodeProps[]
+      // 1. get the initial count,
+      // 2. generate toggleStateMap for future count updates
+      // 3. add an index-like ID to each tree/item
+      const map: ToggleStateMap = {}
+      const shownIDs: number[] = []
+      // auto-increment-style ID for each item
+      let id = 0
+
+      const processTree =
+        (parentOpen?: boolean) =>
+        (tree: WindowedTreeNodeProps): WindowedTreeNodeIDProps => {
+          id++
+          if (parentOpen) {
+            shownIDs.push(id)
+          }
+          if (tree.items) {
+            map[id] = {
+              isOpen: tree.isOpen || false,
+              length: tree.items.length,
+            }
+            return {
+              ...tree,
+              id,
+              items: tree.items.map(
+                processTree(parentOpen ? tree.isOpen : false)
+              ),
+            }
+          }
+          return { content: tree.content, id }
+        }
+
+      const treesWithIDs = trees.map(processTree(true))
+
+      return { map, shownIDs, treesWithIDs }
+    }
+    case 'OPEN': {
+      return updateCount(state, action.payload as number, true)
+    }
+    case 'CLOSE': {
+      return updateCount(state, action.payload as number, false)
+    }
+  }
+}

--- a/packages/components/src/Tree/utils/windowedTreeReducer.ts
+++ b/packages/components/src/Tree/utils/windowedTreeReducer.ts
@@ -44,23 +44,19 @@ type WindowedTreeAction = {
 const updateCount = (state: WindowedTreeState, id: number, isOpen: boolean) => {
   // Get the updated count after a tree has been toggled
   const shownIDs: number[] = []
+  const map = { ...state.map, [id]: { ...state.map[id], isOpen } }
 
-  const { map, treesWithIDs } = state
-  const node = map[id]
-  node.isOpen = isOpen
-
-  const countTree =
-    (parentOpen?: boolean) => (tree: WindowedTreeNodeIDProps) => {
-      if (parentOpen) {
-        shownIDs.push(tree.id)
-      }
-      if (tree.items) {
-        const treeIsOpen = map[tree.id].isOpen
-        tree.items.forEach(countTree(parentOpen ? treeIsOpen : false))
+  const countTree = (tree: WindowedTreeNodeIDProps) => {
+    shownIDs.push(tree.id)
+    if (tree.items) {
+      const treeIsOpen = map[tree.id].isOpen
+      if (treeIsOpen) {
+        tree.items.forEach(countTree)
       }
     }
-  treesWithIDs?.forEach(countTree(true))
-  return { ...state, shownIDs }
+  }
+  state.treesWithIDs?.forEach(countTree)
+  return { ...state, map, shownIDs }
 }
 
 export const windowedTreeReducer: Reducer<

--- a/packages/components/src/utils/useArrowKeyNav.ts
+++ b/packages/components/src/utils/useArrowKeyNav.ts
@@ -139,7 +139,11 @@ export const useArrowKeyNav = <E extends HTMLElement = HTMLElement>({
     if (internalRef.current) {
       const toFocus = getNextFocus(1, internalRef.current)
       if (toFocus) {
-        toFocus.focus()
+        // Since this is called when the user is scrolling a windowed list and
+        // the focused element is removed because it leaves the window,
+        // we preventScroll to avoid jumpiness
+        // (getNextFocus should return an element that is inside the visible window)
+        toFocus.focus({ preventScroll: true })
       }
     }
   }, [getNextFocus])

--- a/packages/design-tokens/src/system/index.ts
+++ b/packages/design-tokens/src/system/index.ts
@@ -50,6 +50,7 @@ export type {
   BoxShadowProps,
   DisplayProps,
   FlexboxProps,
+  HeightProps,
   LayoutProps,
   OverflowProps,
   PaddingProps,

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -26,12 +26,12 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { ComponentsProvider } from '@looker/components'
-import { LongMenus } from '@looker/components/src/Menu/Menu.story'
+import { Windowing } from '@looker/components/src/Tree/stories/Windowing.story'
 
 const App = () => {
   return (
     <ComponentsProvider loadGoogleFonts>
-      <LongMenus />
+      <Windowing />
     </ComponentsProvider>
   )
 }

--- a/www/src/MDX/Pre/allComponents.ts
+++ b/www/src/MDX/Pre/allComponents.ts
@@ -167,6 +167,7 @@ import {
   useTabs,
   useToggle,
   VisuallyHidden,
+  WindowedTreeCollection,
   i18nResources,
 } from '@looker/components'
 import {
@@ -362,5 +363,6 @@ export const allComponents = {
   Truncate,
   UnorderedList,
   VisuallyHidden,
+  WindowedTreeCollection,
   i18nResources,
 }

--- a/www/src/documentation/components/content/tree.mdx
+++ b/www/src/documentation/components/content/tree.mdx
@@ -384,3 +384,61 @@ Enabling the `accessory` option will render the detail element outside of the la
   </Tree>
 </TreeCollection>
 ```
+
+## Windowing
+
+If a `TreeCollection` contains more than 100 visible descendants (trees, items, and nested trees) at a given time, performance will begin to degrade.
+Use `WindowedTreeCollection` instead, with the following differences:
+
+- The `trees` prop replaces `children`
+- `trees` accepts an array of nestable objects where:
+  - `content` is a `<Tree>`, `<TreeItem>`, or other JSX element that renders either
+  - `items` are any nested tree/items (replaces `Tree` children)
+  - `isOpen` (optional) controls the state of each tree, rather than the
+    `isOpen` or `defaultOpen` props on the `Tree` component itself
+
+**Note:** `WindowedTreeCollection` should be rendered inside an element with a specified height
+or add a `height` prop to the component directly.
+
+```jsx
+;() => {
+  const { value, toggle } = useToggle()
+
+  const trees = React.useMemo(
+    () =>
+      Array.from(Array(200), (_, treeIndex) => ({
+        content: <Tree label={`Tree ${treeIndex}`} />,
+        isOpen: value,
+        items: Array.from(Array(10), (_, itemIndex) => {
+          if (itemIndex === 2) {
+            return {
+              content: <Tree label={`Nested Tree ${treeIndex}-${itemIndex}`} />,
+              isOpen: value,
+              items: Array.from(Array(4), (_, nestedItemIdex) => ({
+                content: (
+                  <TreeItem>
+                    Nested TreeItem {treeIndex}-{itemIndex}-{nestedItemIdex}
+                  </TreeItem>
+                ),
+              })),
+            }
+          }
+          return {
+            content: (
+              <TreeItem>
+                TreeItem {treeIndex}-{itemIndex}
+              </TreeItem>
+            ),
+          }
+        }),
+      })),
+    [value]
+  )
+  return (
+    <SpaceVertical>
+      <Button onClick={toggle}>Toggle all {value ? 'closed' : 'open'}</Button>
+      <WindowedTreeCollection height={300} width={500} trees={trees} />
+    </SpaceVertical>
+  )
+}
+```


### PR DESCRIPTION
1. Add `WindowedTreeCollection` – so much needs to be different in order to support virtualization (`trees` prop vs children, no internal state allowed, including the toggle state, and density needs to be defined at the top level) that I think a separate component will be less confusing.
2. Add internal-only `useWindowedTree` and `WindowedTreeNode` to make windowing work
3. ~~Refactor `useWindow` to support `useWindowedTree` and remove support for variable windowing, since it's not being used and it would've complicated the refactor.~~ Moving this to a separate PR: https://github.com/looker-open-source/components/pull/2485

**NOTE:** The Windowing story has some storybook-docs-related bottleneck (I tried disabling docs but it didn't seem to help) so it's pretty slow. Check it out with `yarn playground` for a more realistic test.

- [x] ♿️ Accessibility addressed
- [x] 📚 Documentation updated
- [x] 🏁 Performance impacts addressed
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11
