### PR TITLE
chore: Format jsx in jsDoc with backticks

### DIFF
--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -80,14 +80,14 @@ export interface AccordionProps
   /**
    * We currently support two different compositions for Accordion:
    *  - `Accordion`'s children will act as the "trigger" element (i.e. children always visible, clicking children toggles whether content is visible or not)
-   *  - Legacy: <Accordion> wrapped around an <AccordionDisclosure> and <AccordionContent> (NOTE: This composition will be deprecated in a future MAJOR release)
+   *  - Legacy: `<Accordion>` wrapped around an `<AccordionDisclosure>` and `<AccordionContent>` (NOTE: This composition will be deprecated in a future MAJOR release)
    * @TODO Deprecate legacy format in 2.x
    */
   children: ReactNode
   className?: string
   /**
-   * Determines the content shown or hidden by the <Accordion>'s open state.
-   * Note: If using the "Legacy" <Accordion> composition, provide an <AccordionContent> child instead of using the content prop.
+   * Determines the content shown or hidden by the Accordion's open state.
+   * Note: If using the "Legacy" Accordion composition, provide an `<AccordionContent>` child instead of using the content prop.
    * @TODO Going to be required in 2.x
    */
   content?: ReactNode

--- a/packages/components/src/Avatar/AvatarIcon.tsx
+++ b/packages/components/src/Avatar/AvatarIcon.tsx
@@ -35,7 +35,7 @@ import { avatarCSS, AvatarProps } from './Avatar'
 
 export interface AvatarIconProps extends AvatarProps {
   /**
-   * Icon to display. If not sent will default to <PersonOutline /> from Material Icons
+   * Icon to display. If not sent will default to `<PersonOutline />` from Material Icons
    */
   icon?: IconType
 

--- a/packages/components/src/Dialog/Layout/DialogLayout.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.tsx
@@ -43,7 +43,7 @@ export interface DialogLayoutProps {
   footerSecondary?: ReactNode
 
   /**
-   * Content in header. If a `string` is supplied the content will be placed in a <Header />
+   * Content in header. If a `string` is supplied the content will be placed in a `<Header />`
    */
   header?: ReactChild
   /**

--- a/packages/components/src/Layout/Semantics/Aside/Aside.tsx
+++ b/packages/components/src/Layout/Semantics/Aside/Aside.tsx
@@ -43,7 +43,7 @@ export interface AsideProps extends SemanticLayoutBase, SemanticBorderProps {
    */
   collapse?: boolean
   /**
-   * To be used within the context of <Page fixed> container.
+   * To be used within the context of `<Page fixed>` container.
    * When true, this removes the inner overflow-y scrolling
    * and allows content within a Layout group to scroll together.
    * @default false

--- a/packages/components/src/List/types.ts
+++ b/packages/components/src/List/types.ts
@@ -191,7 +191,7 @@ export type ListItemProps = CompatibleHTMLProps<HTMLElement> &
      * Sets the correct accessible role for the ListItem:
      * - Use **'link'** for items that navigation to another page
      * - Use **'button'** for items that trigger in page interactions, like displaying a dialog
-     * - Use **'none'** when including buttons as children in the label container (i.e. the label container will be a <div>).
+     * - Use **'none'** when including buttons as children in the label container (i.e. the label container will be a `<div>`).
      *     - Height when using an item with a description and role='none' does not auto abide the @looker/components
      *     density scale. Use 'button' or 'link' whenever possible to avoid space inconsistencies.
      *     - If supporting keyboard navigation, make sure to add key handlers to items


### PR DESCRIPTION
Fixes Storybook docs tab throwing a React error when it sees jsx inside a jsDoc comment:
![image](https://user-images.githubusercontent.com/53451193/121092041-d3ad2780-c79f-11eb-9c1e-c80477ea5453.png)
