### PR TITLE
fix(useWindow): Simplify windowing for long lists

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxContext.ts
@@ -65,7 +65,7 @@ export interface ComboboxContextProps<
   persistSelectionPropRef?: MutableRefObject<boolean>
   closeOnSelectPropRef?: MutableRefObject<boolean>
   inputReadOnlyPropRef?: MutableRefObject<boolean>
-  windowedOptionsPropRef?: MutableRefObject<boolean>
+  windowingPropRef?: MutableRefObject<boolean>
   freeInputPropRef?: MutableRefObject<boolean>
   isScrollingRef?: MutableRefObject<boolean>
   indicatorPropRef?: MutableRefObject<ComboboxOptionIndicatorProps['indicator']>

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxList.tsx
@@ -88,7 +88,7 @@ export interface ComboboxListProps
    * list of options in order for keyboard navigation to work properly
    * @default false
    */
-  windowedOptions?: boolean
+  windowing?: boolean
   /**
    * Whether to honor the first click outside the popover
    * @default false
@@ -109,7 +109,7 @@ const ComboboxListInternal = forwardRef(
       // closes the list after an option is selected
       closeOnSelect = true,
       // disables the optionsRef behavior, to be handled externally (support keyboard nav in long lists)
-      windowedOptions = false,
+      windowing = false,
       // passed to usePopover – when false, allows first outside click to be honored
       // generally should be false except for when closely mimicking native browser select
       cancelClickOutside = false,
@@ -129,7 +129,7 @@ const ComboboxListInternal = forwardRef(
     const {
       persistSelectionPropRef,
       closeOnSelectPropRef,
-      windowedOptionsPropRef,
+      windowingPropRef,
       indicatorPropRef,
       wrapperElement,
       isVisible,
@@ -152,15 +152,14 @@ const ComboboxListInternal = forwardRef(
     // effect to schedule this effect before the ComboboxOptions push into
     // the array
     useLayoutEffect(() => {
-      if (windowedOptionsPropRef)
-        windowedOptionsPropRef.current = windowedOptions
+      if (windowingPropRef) windowingPropRef.current = windowing
       if (optionsRef) optionsRef.current = []
       return () => {
         if (optionsRef) optionsRef.current = []
       }
       // Without isVisible in the dependency array,
       // updated options won't go into the optionsRef array
-    }, [optionsRef, isVisible, windowedOptions, windowedOptionsPropRef])
+    }, [optionsRef, isVisible, windowing, windowingPropRef])
 
     const handleKeyDown = useKeyDown()
     const useBlurSingle = useBlur(ComboboxContext)

--- a/packages/components/src/Form/Inputs/Combobox/utils/useAddOptionToContext.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useAddOptionToContext.ts
@@ -38,15 +38,14 @@ export function useAddOptionToContext<
   label?: string,
   scrollIntoView?: boolean
 ) {
-  const { optionsRef, windowedOptionsPropRef } = useContext(context)
+  const { optionsRef, windowingPropRef } = useContext(context)
   const indexRef = useRef<number>(-1)
 
   useEffect(() => {
     const option = { label, scrollIntoView, value }
     const optionsRefCurrent = optionsRef && optionsRef.current
-    const windowedOptions =
-      windowedOptionsPropRef && windowedOptionsPropRef.current
-    if (optionsRefCurrent && !windowedOptions) {
+    const windowing = windowingPropRef && windowingPropRef.current
+    if (optionsRefCurrent && !windowing) {
       // Was this option already in the list?
       // If so, re-insert it at the same spot
       if (indexRef.current > -1) {
@@ -57,11 +56,11 @@ export function useAddOptionToContext<
     }
     return () => {
       // Delete option from the array but save the index so it can be re-inserted there
-      if (optionsRefCurrent && !windowedOptions) {
+      if (optionsRefCurrent && !windowing) {
         const index = optionsRefCurrent.indexOf(option)
         indexRef.current = index
         optionsRefCurrent.splice(index, 1)
       }
     }
-  }, [value, label, optionsRef, scrollIntoView, windowedOptionsPropRef])
+  }, [value, label, optionsRef, scrollIntoView, windowingPropRef])
 }

--- a/packages/components/src/Form/Inputs/Combobox/utils/useComboboxRefs.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useComboboxRefs.ts
@@ -52,7 +52,7 @@ export function useComboboxRefs(forwardedRef: Ref<HTMLDivElement>) {
 
   const persistSelectionPropRef = useRef(false)
   const closeOnSelectPropRef = useRef(true)
-  const windowedOptionsPropRef = useRef(false)
+  const windowingPropRef = useRef(false)
   const isScrollingRef = useRef(false)
   const indicatorPropRef = useRef(false)
   const freeInputPropRef = useRef(false)
@@ -68,7 +68,7 @@ export function useComboboxRefs(forwardedRef: Ref<HTMLDivElement>) {
     optionsRef,
     persistSelectionPropRef,
     ref,
-    windowedOptionsPropRef,
+    windowingPropRef,
     wrapperElement,
   }
 }

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.tsx
@@ -116,7 +116,7 @@ const InputSearchLayout = forwardRef(
       readOnly,
       summary,
       value: controlledValue,
-      windowedOptions: windowedOptionsProp,
+      windowing: windowingProp,
       ...props
     }: InputSearchProps,
     ref: Ref<HTMLInputElement>
@@ -162,10 +162,7 @@ const InputSearchLayout = forwardRef(
 
     const ariaProps = pickAriaAndValidationProps(props)
 
-    const windowedOptions = useShouldWindowOptions(
-      flatOptions,
-      windowedOptionsProp
-    )
+    const windowing = useShouldWindowOptions(flatOptions, windowingProp)
 
     return (
       <Combobox
@@ -201,7 +198,7 @@ const InputSearchLayout = forwardRef(
         {!disabled && (options?.length || noOptionsLabel) && (
           <ComboboxList
             persistSelection
-            windowedOptions={windowedOptions}
+            windowing={windowing}
             indicator={indicator}
             width={autoResize ? 'auto' : undefined}
             aria-busy={isLoading}
@@ -211,7 +208,7 @@ const InputSearchLayout = forwardRef(
             <SelectOptions
               flatOptions={flatOptions}
               navigationOptions={navigationOptions}
-              windowedOptions={windowedOptions}
+              windowing={windowing}
               isFilterable
               noOptionsLabel={noOptionsLabel}
               isLoading={isLoading}

--- a/packages/components/src/Form/Inputs/Select/Select.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.tsx
@@ -75,7 +75,7 @@ export interface SelectBaseProps
    * Render only the options visible in the scroll window
    * defaults to false for <100 options, true for >=100 options
    */
-  windowedOptions?: boolean
+  windowing?: boolean
 }
 
 export interface SelectProps
@@ -118,7 +118,7 @@ const SelectComponent = forwardRef(
       indicator,
       listLayout,
       autoResize,
-      windowedOptions: windowedOptionsProp,
+      windowing: windowingProp,
       showCreate = false,
       formatCreateLabel,
       isLoading,
@@ -151,10 +151,7 @@ const SelectComponent = forwardRef(
 
     const ariaProps = pickAriaAndValidationProps(props)
 
-    const windowedOptions = useShouldWindowOptions(
-      flatOptions,
-      windowedOptionsProp
-    )
+    const windowing = useShouldWindowOptions(flatOptions, windowingProp)
 
     return (
       <Combobox
@@ -185,7 +182,7 @@ const SelectComponent = forwardRef(
         {!disabled && (
           <ComboboxList
             persistSelection
-            windowedOptions={windowedOptions}
+            windowing={windowing}
             indicator={indicator}
             width={autoResize ? 'auto' : undefined}
             aria-busy={isLoading}
@@ -195,7 +192,7 @@ const SelectComponent = forwardRef(
             <SelectOptions
               flatOptions={flatOptions}
               navigationOptions={navigationOptions}
-              windowedOptions={windowedOptions}
+              windowing={windowing}
               isFilterable={isFilterable}
               noOptionsLabel={noOptionsLabel}
               showCreate={showCreate}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -102,7 +102,7 @@ const SelectMultiComponent = forwardRef(
       showCreate = false,
       validate,
       values,
-      windowedOptions: windowedOptionsProp,
+      windowing: windowingProp,
       ...props
     }: SelectMultiProps,
     ref: Ref<HTMLInputElement>
@@ -122,10 +122,7 @@ const SelectMultiComponent = forwardRef(
 
     const ariaProps = pickAriaAndValidationProps(props)
 
-    const windowedOptions = useShouldWindowOptions(
-      flatOptions,
-      windowedOptionsProp
-    )
+    const windowing = useShouldWindowOptions(flatOptions, windowingProp)
 
     return (
       <ComboboxMulti
@@ -157,7 +154,7 @@ const SelectMultiComponent = forwardRef(
           <ComboboxMultiList
             persistSelection
             closeOnSelect={closeOnSelect}
-            windowedOptions={windowedOptions}
+            windowing={windowing}
             indicator={indicator}
             aria-busy={isLoading}
             {...ariaProps}
@@ -167,7 +164,7 @@ const SelectMultiComponent = forwardRef(
               isMulti
               flatOptions={flatOptions}
               navigationOptions={navigationOptions}
-              windowedOptions={windowedOptions}
+              windowing={windowing}
               isFilterable={isFilterable}
               noOptionsLabel={noOptionsLabel}
               showCreate={showCreate}

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -182,7 +182,7 @@ export interface SelectOptionsBaseProps {
   /**
    * Render only the options visible in the scroll window
    */
-  windowedOptions?: boolean
+  windowing?: boolean
   /**
    * Add an on-the-fly option mirroring the typed text (use when isFilterable = true)
    * When `true`, notInOptions is used to show/hide and can be included in a custom function
@@ -217,12 +217,12 @@ export const SelectOptions = (props: SelectOptionsProps) => {
     formatCreateLabel,
     isMulti,
     noOptionsLabel = noOptionsLabelText,
-    windowedOptions,
+    windowing,
     isLoading,
   } = props
 
   const { start, end, before, after, scrollToFirst, scrollToLast } =
-    useWindowedOptions(windowedOptions, flatOptions, navigationOptions, isMulti)
+    useWindowedOptions(windowing, flatOptions, navigationOptions, isMulti)
   const keyPrefix = useID(flatOptions?.length.toString())
 
   const hasIcons = useMemo(

--- a/packages/components/src/Form/Inputs/Select/utils/useWindowedOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/utils/useWindowedOptions.tsx
@@ -39,14 +39,14 @@ export function useShouldWindowOptions(
   return useMemo(() => {
     if (!flatOptions) return false
     if (propsWindowedOptions === false) return false
-    // Without windowedOptions prop, default is to turn it on at 100 options
+    // Without windowing prop, default is to turn it on at 100 options
     if (flatOptions.length < 100 && !propsWindowedOptions) return false
     return true
   }, [flatOptions, propsWindowedOptions])
 }
 
 export function useWindowedOptions(
-  windowedOptions?: boolean,
+  windowing?: boolean,
   flatOptions?: FlatOption[],
   navigationOptions?: SelectOptionObject[],
   isMulti?: boolean
@@ -62,12 +62,12 @@ export function useWindowedOptions(
     optionsRef,
   } = contextToUse
 
-  // windowedOptions prop on ComboboxList disables useAddOptionToContext,
+  // windowing prop on ComboboxList disables useAddOptionToContext,
   // so we need to add it here to support keyboard nav
 
   // add options to ComboboxContext.optionsRef
   useEffect(() => {
-    // optionsToWindow will be empty if windowedOptions is false, so no need to check windowedOptions as well
+    // optionsToWindow will be empty if windowing is false, so no need to check windowing as well
     if (navigationOptions?.length && optionsRef) {
       optionsRef.current = navigationOptions
     }
@@ -78,14 +78,14 @@ export function useWindowedOptions(
   let { start, end } = useMemo(
     () =>
       getWindowedListBoundaries({
-        enabled: windowedOptions,
+        enabled: windowing,
         height: containerHeight,
         itemHeight: optionHeight,
         // For groups, add 2 for divider & header
         length: flatOptions ? flatOptions.length : 0,
         scrollPosition: listScrollPosition,
       }),
-    [flatOptions, containerHeight, listScrollPosition, windowedOptions]
+    [flatOptions, containerHeight, listScrollPosition, windowing]
   )
 
   // The current value is highlighted when the menu first opens
@@ -94,7 +94,7 @@ export function useWindowedOptions(
   // also need to do this when the menu goes from un-windowed to windowed
   // (e.g. due to deleting characters when filtering)
   const previouslyWindowedRef = useRef<boolean>()
-  if (windowedOptions && !previouslyWindowedRef.current) {
+  if (windowing && !previouslyWindowedRef.current) {
     if (navigationOption) {
       const selectedIndex = findIndex(flatOptions, [
         'value',
@@ -106,7 +106,7 @@ export function useWindowedOptions(
       }
     }
   }
-  previouslyWindowedRef.current = windowedOptions
+  previouslyWindowedRef.current = windowing
 
   // If the user keyboard navigates "down" from the last option or "up" from the first option
   // we need to render the top or bottom of the list (which are outside our "window") and scroll there

--- a/packages/components/src/Form/Inputs/Select/utils/useWindowedOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/utils/useWindowedOptions.tsx
@@ -80,9 +80,8 @@ export function useWindowedOptions(
       getWindowedListBoundaries({
         enabled: windowing,
         height: containerHeight,
+        itemCount: flatOptions ? flatOptions.length : 0,
         itemHeight: optionHeight,
-        // For groups, add 2 for divider & header
-        length: flatOptions ? flatOptions.length : 0,
         scrollPosition: listScrollPosition,
       }),
     [flatOptions, containerHeight, listScrollPosition, windowing]

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -38,7 +38,6 @@ const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
 describe('List', () => {
   describe('windowing', () => {
     beforeEach(() => {
-      jest.useFakeTimers()
       /* eslint-disable-next-line @typescript-eslint/unbound-method */
       Element.prototype.getBoundingClientRect = jest.fn(() => {
         return {
@@ -56,14 +55,12 @@ describe('List', () => {
     })
 
     afterEach(() => {
-      jest.runOnlyPendingTimers()
-      jest.useRealTimers()
       jest.resetAllMocks()
       /* eslint-disable-next-line @typescript-eslint/unbound-method */
       Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
     })
 
-    test('fixed', () => {
+    test('windows a long list', () => {
       renderWithTheme(<LongList />)
 
       expect(screen.getByRole('list')).toHaveStyle('height: 100%')

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -79,10 +79,9 @@ export type ListProps = ListColorProps &
 
     /**
      * Use windowing for long lists (strongly recommended to also define a width on List or its container)
-     * 'none' - default with children are <= 100.
-     * 'fixed' - better performance, default when first child is a ListItem (height will default to 100%)
+     * Defaults to false with children <= 100 and true for > 100
      */
-    windowing?: 'fixed' | 'none'
+    windowing?: boolean
   }
 
 const getListItemHeight = (child: ReactChild, height: number) => {
@@ -118,14 +117,10 @@ export const ListInternal = forwardRef(
     )
 
     if (windowing === undefined) {
-      if (childArray.length > 100) {
-        windowing = 'fixed'
-      } else {
-        windowing = 'none'
-      }
+      windowing = childArray.length > 100
     }
 
-    if (height === undefined && windowing !== 'none') {
+    if (height === undefined && windowing) {
       // Need a height for windowing to work
       height = '100%'
     }
@@ -135,7 +130,7 @@ export const ListInternal = forwardRef(
         ? getListItemHeight(childArray[0] as ReactChild, itemDimensions.height)
         : 0,
       children: children as JSX.Element | JSX.Element[],
-      enabled: windowing !== 'none',
+      enabled: windowing,
       ref: forwardedRef,
       spacerTag: 'li',
     })
@@ -181,7 +176,7 @@ const ListStyle = styled.ul
 
   list-style: none;
   margin: 0;
-  ${({ windowing }) => windowing !== 'none' && 'overflow: auto;'}
+  ${({ windowing }) => windowing && 'overflow: auto;'}
   padding: 0;
 `
 

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -125,15 +125,24 @@ export const ListInternal = forwardRef(
       height = '100%'
     }
 
-    const { content, ref } = useWindow({
-      childHeight: childArray[0]
+    const { after, before, end, start, ref } = useWindow({
+      enabled: windowing,
+      itemCount: childArray.length,
+      itemHeight: childArray[0]
         ? getListItemHeight(childArray[0] as ReactChild, itemDimensions.height)
         : 0,
-      children: children as JSX.Element | JSX.Element[],
-      enabled: windowing,
       ref: forwardedRef,
       spacerTag: 'li',
     })
+    const content = windowing ? (
+      <>
+        {before}
+        {childArray.slice(start, end + 1)}
+        {after}
+      </>
+    ) : (
+      childArray
+    )
 
     const navProps = useArrowKeyNav({
       disabled: disableKeyboardNav,

--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -479,7 +479,7 @@ export const LongMenus = () => {
       <Space align="start">
         <Menu
           width={300}
-          windowing={!value ? 'none' : undefined}
+          windowing={!value ? false : undefined}
           content={array3000.map((item, i) => (
             <MenuItem key={i}>{item.label}</MenuItem>
           ))}
@@ -488,7 +488,7 @@ export const LongMenus = () => {
         </Menu>
         <Menu
           width={300}
-          windowing={!value ? 'none' : undefined}
+          windowing={!value ? false : undefined}
           content={array3000.map((item, i) => (
             <MenuItem key={i} description={item.description}>
               {item.label}
@@ -499,7 +499,7 @@ export const LongMenus = () => {
         </Menu>
         <Menu
           width={300}
-          windowing={!value ? 'none' : undefined}
+          windowing={!value ? false : undefined}
           content={groups.map(({ label, items }, index) => [
             <MenuDivider key={`${label}-${index}-divider`} />,
             <MenuHeading key={`${label}-${index}-heading`}>

--- a/packages/components/src/Menu/MenuList.test.tsx
+++ b/packages/components/src/Menu/MenuList.test.tsx
@@ -39,7 +39,6 @@ const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
 describe('MenuList', () => {
   describe('windowing', () => {
     beforeEach(() => {
-      jest.useFakeTimers()
       /* eslint-disable-next-line @typescript-eslint/unbound-method */
       Element.prototype.getBoundingClientRect = jest.fn(() => {
         return {
@@ -57,14 +56,12 @@ describe('MenuList', () => {
     })
 
     afterEach(() => {
-      jest.runOnlyPendingTimers()
-      jest.useRealTimers()
       jest.resetAllMocks()
       /* eslint-disable-next-line @typescript-eslint/unbound-method */
       Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
     })
 
-    test('fixed', () => {
+    test('windows a long list', () => {
       const arr3000 = Array.from(Array(3000), (_, i) => i)
       renderWithTheme(
         <MenuList>

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -171,7 +171,7 @@ const TreeLayout: FC<TreeProps> = ({
       renderAsLi
       aria-selected={selected}
       content={
-        <List disableKeyboardNav role="group" windowing="none">
+        <List disableKeyboardNav role="group" windowing={false}>
           {children}
         </List>
       }

--- a/packages/components/src/utils/getWindowedListBoundaries.test.ts
+++ b/packages/components/src/utils/getWindowedListBoundaries.test.ts
@@ -31,8 +31,8 @@ describe('getWindowedListBoundaries', () => {
     const result = getWindowedListBoundaries({
       enabled: false,
       height: 446,
+      itemCount: 129,
       itemHeight: 57,
-      length: 129,
       scrollPosition: 0,
     })
 
@@ -42,8 +42,8 @@ describe('getWindowedListBoundaries', () => {
 
   test('returns 0 0 if height and scrollPosition are missing', () => {
     const result = getWindowedListBoundaries({
+      itemCount: 98,
       itemHeight: 31,
-      length: 98,
     })
 
     expect(result.start).toEqual(0)
@@ -53,8 +53,8 @@ describe('getWindowedListBoundaries', () => {
   test('top of list', () => {
     const result = getWindowedListBoundaries({
       height: 1002,
+      itemCount: 873,
       itemHeight: 16,
-      length: 873,
       scrollPosition: 0,
     })
 
@@ -65,8 +65,8 @@ describe('getWindowedListBoundaries', () => {
   test('middle of list', () => {
     const result = getWindowedListBoundaries({
       height: 775,
+      itemCount: 1109,
       itemHeight: 26,
-      length: 1109,
       scrollPosition: 922,
     })
 
@@ -77,8 +77,8 @@ describe('getWindowedListBoundaries', () => {
   test('end of list', () => {
     const result = getWindowedListBoundaries({
       height: 300,
+      itemCount: 50,
       itemHeight: 30,
-      length: 50,
       scrollPosition: 1200,
     })
 
@@ -90,8 +90,8 @@ describe('getWindowedListBoundaries', () => {
     const result = getWindowedListBoundaries({
       buffer: 11,
       height: 1002,
+      itemCount: 873,
       itemHeight: 16,
-      length: 873,
       scrollPosition: 0,
     })
 
@@ -103,8 +103,8 @@ describe('getWindowedListBoundaries', () => {
     const result = getWindowedListBoundaries({
       buffer: 11,
       height: 775,
+      itemCount: 1109,
       itemHeight: 26,
-      length: 1109,
       scrollPosition: 922,
     })
 
@@ -116,8 +116,8 @@ describe('getWindowedListBoundaries', () => {
     const result = getWindowedListBoundaries({
       buffer: 11,
       height: 300,
+      itemCount: 50,
       itemHeight: 30,
-      length: 50,
       scrollPosition: 1200,
     })
 

--- a/packages/components/src/utils/getWindowedListBoundaries.ts
+++ b/packages/components/src/utils/getWindowedListBoundaries.ts
@@ -31,9 +31,9 @@ export interface GetWindowedListBoundaryProps {
    */
   enabled?: boolean
   /**
-   * The length of items in the list
+   * The total number of items in the list
    */
-  length: number
+  itemCount: number
   /**
    * The height of an individual item
    */
@@ -60,10 +60,10 @@ export function getWindowedListBoundaries({
   height,
   scrollPosition,
   enabled = true,
+  itemCount,
   itemHeight,
-  length,
 }: GetWindowedListBoundaryProps) {
-  if (!enabled) return { ...initialResult, end: length - 1 }
+  if (!enabled) return { ...initialResult, end: itemCount - 1 }
 
   if (scrollPosition === undefined || height === undefined)
     // scroll position and height probably undefined on initial render
@@ -74,8 +74,8 @@ export function getWindowedListBoundaries({
   const bottom = Math.ceil((height + scrollPosition) / itemHeight)
 
   const start = top - buffer < 0 ? 0 : top - buffer
-  const end = bottom + buffer > length - 1 ? length - 1 : bottom + buffer
-  const afterLength = length - 1 - end
+  const end = bottom + buffer > itemCount - 1 ? itemCount - 1 : bottom + buffer
+  const afterLength = itemCount - 1 - end
 
   return {
     afterHeight: afterLength * itemHeight,

--- a/packages/components/src/utils/useWindow.test.tsx
+++ b/packages/components/src/utils/useWindow.test.tsx
@@ -26,7 +26,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
-import { ChildHeightFunction, useWindow, useToggle } from './'
+import { useWindow, useToggle } from './'
 
 /* eslint-disable-next-line @typescript-eslint/unbound-method */
 const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
@@ -59,18 +59,11 @@ afterEach(() => {
 })
 
 const arr3000 = Array.from(Array(3000), (_, i) => i)
-const getChildHeight: ChildHeightFunction = (_, index) => 20 + (index % 200)
 
-const WindowedComponent = ({
-  children,
-  variable,
-}: {
-  children: JSX.Element[]
-  variable?: boolean
-}) => {
+const WindowedComponent = ({ children }: { children: JSX.Element[] }) => {
   const { value, toggle } = useToggle(true)
   const { content, ref } = useWindow({
-    childHeight: variable ? getChildHeight : 87,
+    childHeight: 87,
     children,
     enabled: value,
     spacerTag: 'li',
@@ -86,210 +79,101 @@ const WindowedComponent = ({
 }
 
 describe('useWindow', () => {
-  describe('fixed', () => {
-    test('returns placeholders and children in "window"', () => {
-      render(
-        <WindowedComponent>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      expect(screen.getByText('0')).toBeVisible()
-      expect(screen.getByText('9')).toBeVisible()
-      expect(screen.queryByText('10')).not.toBeInTheDocument()
+  test('returns placeholders and children in "window"', () => {
+    render(
+      <WindowedComponent>
+        {arr3000.map((num) => (
+          <li key={num}>{num}</li>
+        ))}
+      </WindowedComponent>
+    )
+    expect(screen.getByText('0')).toBeVisible()
+    expect(screen.getByText('9')).toBeVisible()
+    expect(screen.queryByText('10')).not.toBeInTheDocument()
 
-      expect(screen.queryByTestId('before')).not.toBeInTheDocument()
-      expect(screen.getByTestId('after')).toHaveStyle('height: 260130px;')
-    })
-
-    test('updates window on scroll', () => {
-      render(
-        <WindowedComponent>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      const list = screen.getByTestId('list')
-      // fireEvent.scroll won't update the scrollTop value, need to change it manually
-      Object.defineProperty(list, 'scrollTop', { value: 1514, writable: true })
-      // Needed do to throttle on scroll handler
-      jest.runAllTimers()
-      fireEvent.scroll(list)
-
-      expect(screen.queryByText('11')).not.toBeInTheDocument()
-      expect(screen.getByText('12')).toBeVisible()
-      expect(screen.getByText('27')).toBeVisible()
-      expect(screen.queryByText('28')).not.toBeInTheDocument()
-
-      expect(screen.getByTestId('before')).toHaveStyle('height: 1044px;')
-      expect(screen.getByTestId('after')).toHaveStyle('height: 258564px;')
-    })
-
-    test('updates window on scroll (to end)', () => {
-      render(
-        <WindowedComponent>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      const list = screen.getByTestId('list')
-      // fireEvent.scroll won't update the scrollTop value, need to change it manually
-      Object.defineProperty(list, 'scrollTop', {
-        value: 260658,
-        writable: true,
-      })
-      // Needed do to throttle on scroll handler
-      jest.runAllTimers()
-      fireEvent.scroll(list)
-
-      expect(screen.queryByText('2990')).not.toBeInTheDocument()
-      expect(screen.getByText('2991')).toBeVisible()
-      expect(screen.getByText('2999')).toBeVisible()
-
-      expect(screen.getByTestId('before')).toHaveStyle('height: 260217px;')
-      expect(screen.queryByTestId('after')).not.toBeInTheDocument()
-    })
-
-    test('updates window on resize', () => {
-      render(
-        <WindowedComponent>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      /* eslint-disable-next-line @typescript-eslint/unbound-method */
-      Element.prototype.getBoundingClientRect = jest.fn(() => {
-        return {
-          bottom: 0,
-          height: 873,
-          left: 0,
-          right: 0,
-          toJSON: jest.fn(),
-          top: 0,
-          width: 260,
-          x: 0,
-          y: 0,
-        }
-      })
-      fireEvent(window, new Event('resize'))
-
-      expect(screen.getByText('0')).toBeVisible()
-      expect(screen.getByText('16')).toBeVisible()
-      expect(screen.queryByText('17')).not.toBeInTheDocument()
-
-      expect(screen.queryByTestId('before')).not.toBeInTheDocument()
-      expect(screen.getByTestId('after')).toHaveStyle('height: 259521px;')
-    })
+    expect(screen.queryByTestId('before')).not.toBeInTheDocument()
+    expect(screen.getByTestId('after')).toHaveStyle('height: 260130px;')
   })
 
-  describe('variable', () => {
-    test('returns placeholders and children in "window"', () => {
-      const mockRef = jest.fn()
-      render(
-        <WindowedComponent variable>
-          {arr3000.map((num) => (
-            <li key={num} ref={mockRef}>
-              {num}
-            </li>
-          ))}
-        </WindowedComponent>
-      )
-      expect(screen.getByText('0')).toBeVisible()
-      expect(screen.getByText('35')).toBeVisible()
-      expect(screen.queryByText('36')).not.toBeInTheDocument()
+  test('updates window on scroll', () => {
+    render(
+      <WindowedComponent>
+        {arr3000.map((num) => (
+          <li key={num}>{num}</li>
+        ))}
+      </WindowedComponent>
+    )
+    const list = screen.getByTestId('list')
+    // fireEvent.scroll won't update the scrollTop value, need to change it manually
+    Object.defineProperty(list, 'scrollTop', { value: 1514, writable: true })
+    // Needed do to throttle on scroll handler
+    jest.runAllTimers()
+    fireEvent.scroll(list)
 
-      expect(screen.queryByTestId('before')).not.toBeInTheDocument()
-      expect(screen.getByTestId('after')).toHaveStyle('height: 357150px;')
+    expect(screen.queryByText('11')).not.toBeInTheDocument()
+    expect(screen.getByText('12')).toBeVisible()
+    expect(screen.getByText('27')).toBeVisible()
+    expect(screen.queryByText('28')).not.toBeInTheDocument()
 
-      // Tests for a bug where all list items are initially rendered
-      // before the container is measured and then only the necessary items are rendered
-      expect(mockRef).toHaveBeenCalledTimes(36)
+    expect(screen.getByTestId('before')).toHaveStyle('height: 1044px;')
+    expect(screen.getByTestId('after')).toHaveStyle('height: 258564px;')
+  })
+
+  test('updates window on scroll (to end)', () => {
+    render(
+      <WindowedComponent>
+        {arr3000.map((num) => (
+          <li key={num}>{num}</li>
+        ))}
+      </WindowedComponent>
+    )
+    const list = screen.getByTestId('list')
+    // fireEvent.scroll won't update the scrollTop value, need to change it manually
+    Object.defineProperty(list, 'scrollTop', {
+      value: 260658,
+      writable: true,
     })
+    // Needed do to throttle on scroll handler
+    jest.runAllTimers()
+    fireEvent.scroll(list)
 
-    test('updates window on scroll', () => {
-      render(
-        <WindowedComponent variable>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      const list = screen.getByTestId('list')
-      // fireEvent.scroll won't update the scrollTop value, need to change it manually
-      Object.defineProperty(list, 'scrollTop', { value: 1514, writable: true })
-      // Needed do to throttle on scroll handler
-      jest.runAllTimers()
-      fireEvent.scroll(list)
+    expect(screen.queryByText('2990')).not.toBeInTheDocument()
+    expect(screen.getByText('2991')).toBeVisible()
+    expect(screen.getByText('2999')).toBeVisible()
 
-      expect(screen.queryByText('17')).not.toBeInTheDocument()
-      expect(screen.getByText('18')).toBeVisible()
-      expect(screen.getByText('58')).toBeVisible()
-      expect(screen.queryByText('59')).not.toBeInTheDocument()
+    expect(screen.getByTestId('before')).toHaveStyle('height: 260217px;')
+    expect(screen.queryByTestId('after')).not.toBeInTheDocument()
+  })
 
-      expect(screen.getByTestId('before')).toHaveStyle('height: 513px;')
-      expect(screen.getByTestId('after')).toHaveStyle('height: 355609px;')
+  test('updates window on resize', () => {
+    render(
+      <WindowedComponent>
+        {arr3000.map((num) => (
+          <li key={num}>{num}</li>
+        ))}
+      </WindowedComponent>
+    )
+    /* eslint-disable-next-line @typescript-eslint/unbound-method */
+    Element.prototype.getBoundingClientRect = jest.fn(() => {
+      return {
+        bottom: 0,
+        height: 873,
+        left: 0,
+        right: 0,
+        toJSON: jest.fn(),
+        top: 0,
+        width: 260,
+        x: 0,
+        y: 0,
+      }
     })
+    fireEvent(window, new Event('resize'))
 
-    test('updates window on scroll (to end)', () => {
-      render(
-        <WindowedComponent variable>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      const list = screen.getByTestId('list')
-      // fireEvent.scroll won't update the scrollTop value, need to change it manually
-      Object.defineProperty(list, 'scrollTop', {
-        value: 358158,
-        writable: true,
-      })
-      // Needed do to throttle on scroll handler
-      jest.runAllTimers()
-      fireEvent.scroll(list)
+    expect(screen.getByText('0')).toBeVisible()
+    expect(screen.getByText('16')).toBeVisible()
+    expect(screen.queryByText('17')).not.toBeInTheDocument()
 
-      expect(screen.queryByText('2992')).not.toBeInTheDocument()
-      expect(screen.getByText('2993')).toBeVisible()
-      expect(screen.getByText('2999')).toBeVisible()
-
-      expect(screen.getByTestId('before')).toHaveStyle('height: 356988px;')
-      expect(screen.queryByTestId('after')).not.toBeInTheDocument()
-    })
-
-    test('updates window on resize', () => {
-      render(
-        <WindowedComponent variable>
-          {arr3000.map((num) => (
-            <li key={num}>{num}</li>
-          ))}
-        </WindowedComponent>
-      )
-      /* eslint-disable-next-line @typescript-eslint/unbound-method */
-      Element.prototype.getBoundingClientRect = jest.fn(() => {
-        return {
-          bottom: 0,
-          height: 873,
-          left: 0,
-          right: 0,
-          toJSON: jest.fn(),
-          top: 0,
-          width: 260,
-          x: 0,
-          y: 0,
-        }
-      })
-      fireEvent(window, new Event('resize'))
-
-      expect(screen.getByText('0')).toBeVisible()
-      expect(screen.getByText('44')).toBeVisible()
-      expect(screen.queryByText('45')).not.toBeInTheDocument()
-
-      expect(screen.queryByTestId('before')).not.toBeInTheDocument()
-      expect(screen.getByTestId('after')).toHaveStyle('height: 356610px;')
-    })
+    expect(screen.queryByTestId('before')).not.toBeInTheDocument()
+    expect(screen.getByTestId('after')).toHaveStyle('height: 259521px;')
   })
 })

--- a/packages/components/src/utils/useWindow.test.tsx
+++ b/packages/components/src/utils/useWindow.test.tsx
@@ -62,16 +62,18 @@ const arr3000 = Array.from(Array(3000), (_, i) => i)
 
 const WindowedComponent = ({ children }: { children: JSX.Element[] }) => {
   const { value, toggle } = useToggle(true)
-  const { content, ref } = useWindow({
-    childHeight: 87,
-    children,
+  const { after, before, end, start, ref } = useWindow({
     enabled: value,
+    itemCount: 3000,
+    itemHeight: 87,
     spacerTag: 'li',
   })
   return (
     <>
       <ul ref={ref} data-testid="list">
-        {content}
+        {before}
+        {children.slice(start, end + 1)}
+        {after}
       </ul>
       <button onClick={toggle}>toggle</button>
     </>

--- a/www/src/documentation/components/forms/input-select.mdx
+++ b/www/src/documentation/components/forms/input-select.mdx
@@ -278,10 +278,10 @@ When you open the following list, `Mascarpone` will be highlighted and visible a
 
 Another feature for long lists. Because rendering hundreds of options results in poor performance,
 if there are 100 or more options, the option list will be "windowed", (a.k.a. "virtualized") and only the
-options visibile in the scroll area will be rendered, plus a buffer of 5 above and below. The `windowedOptions`
+options visibile in the scroll area will be rendered, plus a buffer of 5 above and below. The `windowing`
 prop can be used to override this – either by setting it to `true` for under 100 or `false` for over 100.
 
-To observe the performance impact, add `windowedOptions={false}` after `options={options1k}` below:
+To observe the performance impact, add `windowing={false}` after `options={options1k}` below:
 
 ```jsx
 ;() => {


### PR DESCRIPTION
Refactors `useWindow` to support [`Tree` virtualization](https://github.com/looker-open-source/components/pull/2481).