### PR TITLE
fix(InputColor): Call onChange if input value is cleared

### DIFF
--- a/packages/components/src/Form/Inputs/InputColor/InputColor.story.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.story.tsx
@@ -24,8 +24,11 @@
 
  */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { Story } from '@storybook/react/types-6-0'
+import { Select } from '../Select'
+import { Space } from '../../../Layout'
+import { Text } from '../../../Text'
 import { InputColor, InputColorProps } from './InputColor'
 
 const Template: Story<InputColorProps> = (args) => <InputColor {...args} />
@@ -55,29 +58,31 @@ ReadOnly.args = {
   readOnly: true,
 }
 
-// import React, { useState } from 'react'
+export const ControlledColor = () => {
+  const [color, setColor] = useState('red')
 
-// export default { title: 'Forms/Color' }
+  function handleChange(value: string) {
+    setColor(value)
+  }
 
-// export const ControlledColor = () => {
-//   const [color, setColor] = useState('red')
+  function handleColorChange(e: React.FormEvent<HTMLInputElement>) {
+    setColor(e.currentTarget.value)
+  }
 
-//   function handleChange(value: string) {
-//     setColor(value)
-//   }
+  return (
+    <Space>
+      <Select
+        options={[{ value: 'green' }, { value: 'purple' }, { value: 'red' }]}
+        value={color}
+        onChange={handleChange}
+        autoResize
+      />
+      <InputColor value={color} onChange={handleColorChange} />
+      <Text>{color}</Text>
+    </Space>
+  )
+}
 
-//   function handleColorChange(e: React.FormEvent<HTMLInputElement>) {
-//     setColor(e.currentTarget.value)
-//   }
-
-//   return (
-//     <>
-//       <FieldSelect
-//         options={[{ value: 'green' }, { value: 'purple' }, { value: 'red' }]}
-//         value={color}
-//         onChange={handleChange}
-//       />
-//       <FieldColor value={color} onChange={handleColorChange} />
-//     </>
-//   )
-// }
+ControlledColor.parameters = {
+  storyshots: { disable: true },
+}

--- a/packages/components/src/Form/Inputs/InputColor/InputColor.test.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.test.tsx
@@ -193,4 +193,26 @@ describe('InputColor', () => {
     fireEvent.click(screen.getByTestId('swatch'))
     expect(screen.queryByTestId('color-picker')).not.toBeInTheDocument()
   })
+
+  test('clear value', () => {
+    const onChangeMock = jest.fn()
+    renderWithTheme(<InputColor value="green" onChange={onChangeMock} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '' } })
+    expect(onChangeMock.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "currentTarget": Object {
+              "name": undefined,
+              "value": "",
+            },
+            "target": Object {
+              "name": undefined,
+              "value": "",
+            },
+          },
+        ],
+      ]
+    `)
+  })
 })

--- a/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
@@ -114,9 +114,8 @@ export const InputColorComponent = forwardRef(
       }
     }, [isFocused, value, inputTextValue])
 
-    const callOnChange = (newColor?: SimpleHSV | string) => {
-      if (!onChange || !newColor) return
-      onChange(createEventWithHSVValue(newColor, props.name))
+    const callOnChange = (newColor: SimpleHSV | string) => {
+      onChange?.(createEventWithHSVValue(newColor, props.name))
     }
 
     const setColorState = (newColor: SimpleHSV) => {
@@ -129,8 +128,10 @@ export const InputColorComponent = forwardRef(
       const newValue = event.currentTarget.value
       setInputTextValue(newValue)
 
-      const isValid = isValidColor(newValue)
-      callOnChange(isValid ? newValue : undefined)
+      const isValid = isValidColor(newValue) || newValue === ''
+      if (isValid) {
+        callOnChange(newValue)
+      }
       setColor(getColorFromText(event.currentTarget.value))
     }
 

--- a/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
@@ -77,7 +77,7 @@ function getColorFromText(text?: string) {
   return text && isValidColor(text) ? stringToSimpleHsv(text) : undefined
 }
 
-export const InputColorComponent = forwardRef(
+export const InputColorInternal = forwardRef(
   (
     {
       className,
@@ -176,9 +176,9 @@ export const InputColorComponent = forwardRef(
   }
 )
 
-InputColorComponent.displayName = 'InputColorComponent'
+InputColorInternal.displayName = 'InputColorInternal'
 
-export const InputColor = styled(InputColorComponent)`
+export const InputColor = styled(InputColorInternal)`
   display: flex;
 
   ${Swatch} {


### PR DESCRIPTION
This PR updates `InputColor` to call `onChange` if the input's new value is an empty string. Before it was only calling it if the value was a valid color, which an empty string is not.