### PR TITLE
fix(CardContent): Properly absorb padding (pN) values

### DIFF
--- a/packages/components/src/Card/CardContent.tsx
+++ b/packages/components/src/Card/CardContent.tsx
@@ -29,6 +29,7 @@ import {
   CompatibleHTMLProps,
   FlexboxProps,
   flexbox,
+  paddingDefaultsHelper,
   shouldForwardProp,
 } from '@looker/design-tokens'
 import { ComplexLayoutProps, complexLayoutCSS } from '../Layout/utils/complex'
@@ -40,7 +41,9 @@ export interface CardContentProps
 
 export const CardContent = styled.div
   .withConfig({ shouldForwardProp })
-  .attrs<CardContentProps>(({ p = 'medium' }) => ({ p }))<CardContentProps>`
+  .attrs<CardContentProps>((p) => ({
+    ...paddingDefaultsHelper(p, { p: 'medium' }),
+  }))<CardContentProps>`
   ${complexLayoutCSS}
   ${flexbox}
 `

--- a/packages/design-tokens/src/utils/index.ts
+++ b/packages/design-tokens/src/utils/index.ts
@@ -27,6 +27,7 @@
 export * from './animations'
 export * from './convertRemToPx'
 export * from './omit'
+export * from './paddingDefaultsHelper'
 export * from './pick'
 export * from './helpers'
 export * from './typography'

--- a/packages/design-tokens/src/utils/paddingDefaultsHelper.test.ts
+++ b/packages/design-tokens/src/utils/paddingDefaultsHelper.test.ts
@@ -1,0 +1,129 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { paddingDefaultsHelper } from './paddingDefaultsHelper'
+
+describe('paddingDefaultsHelper', () => {
+  test('p', () => {
+    expect(
+      paddingDefaultsHelper({ p: 'small' }, { p: 'medium' })
+    ).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "p": "small",
+      }
+    `
+    )
+  })
+
+  test('pl', () => {
+    expect(
+      paddingDefaultsHelper({ pl: 'small' }, { p: 'medium' })
+    ).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "pl": "small",
+        "pr": "medium",
+        "py": "medium",
+      }
+    `
+    )
+  })
+
+  test('py', () => {
+    expect(
+      paddingDefaultsHelper({ py: 'small' }, { px: 'medium' })
+    ).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "px": "medium",
+        "py": "small",
+      }
+    `
+    )
+  })
+
+  test('pl vs px', () => {
+    expect(
+      paddingDefaultsHelper({ pl: 'small' }, { px: 'medium' })
+    ).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "pl": "small",
+        "pr": "medium",
+      }
+    `
+    )
+  })
+
+  test('none', () => {
+    expect(paddingDefaultsHelper({}, { p: 'medium' })).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "p": "medium",
+      }
+    `
+    )
+  })
+
+  test('no defaults', () => {
+    expect(
+      paddingDefaultsHelper({ pl: 'medium', px: 'small' }, {})
+    ).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "pl": "medium",
+        "pr": "small",
+      }
+    `
+    )
+  })
+
+  test('compass points', () => {
+    expect(
+      paddingDefaultsHelper(
+        { pb: 'xsmall', pl: 'small', pr: 'medium', pt: 'large', px: 'xlarge' },
+        { p: 'xxlarge' }
+      )
+    ).toMatchInlineSnapshot(
+      {},
+      `
+      Object {
+        "pb": "xsmall",
+        "pl": "small",
+        "pr": "medium",
+        "pt": "large",
+      }
+    `
+    )
+  })
+})

--- a/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
+++ b/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
@@ -55,21 +55,18 @@ export const paddingDefaultsHelper = (
 
   p = px && px === py ? px : undefined
 
-  if (py) {
-    pt = undefined
-    pb = undefined
-  }
-
-  if (px) {
-    pr = undefined
-    pl = undefined
-  }
-
   if (p) {
     return { p }
   }
 
-  const response = { p, pb, pl, pr, pt, px, py }
+  const response = {
+    pb: py ? undefined : pb,
+    pt: py ? undefined : pt,
+    pl: px ? undefined : pl,
+    pr: px ? undefined : pr,
+    px,
+    py,
+  }
 
   /* Remove undefined values */
   Object.keys(response).forEach((key) => {

--- a/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
+++ b/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
@@ -53,7 +53,7 @@ export const paddingDefaultsHelper = (
   pl = pl || px || p
   px = pr === pl ? pr : undefined
 
-  if (px === py) {
+  if (px && px === py) {
     return { p }
   } else {
     p = undefined

--- a/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
+++ b/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
@@ -53,10 +53,10 @@ export const paddingDefaultsHelper = (
   pl = pl || px || p
   px = pr === pl ? pr : undefined
 
-  p = px && px === py ? px : undefined
-
-  if (p) {
+  if (px === py) {
     return { p }
+  } else {
+    p = undefined
   }
 
   const response = {

--- a/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
+++ b/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
@@ -61,9 +61,9 @@ export const paddingDefaultsHelper = (
 
   const response = {
     pb: py ? undefined : pb,
-    pt: py ? undefined : pt,
     pl: px ? undefined : pl,
     pr: px ? undefined : pr,
+    pt: py ? undefined : pt,
     px,
     py,
   }

--- a/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
+++ b/packages/design-tokens/src/utils/paddingDefaultsHelper.ts
@@ -1,0 +1,82 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { PaddingProps } from '../system'
+
+/**
+ * This function should repeat values specified in "defaults"  from the least
+ * specific (p, px, py) to the most (pr, pr, pl, pb) without overriding any
+ * explicit values specified in "props"
+ *
+ * Test scenarios:
+ * ({ p: 'small' }, { p: 'medium' }) => { p: 'small' }
+ * ({ pl: 'small' }, { p: 'medium' }) => { pl: 'small', pr: 'medium', py: 'medium'}
+ * ({ pl: 'small' }, { px: 'medium' }) => { pl: 'small', pr: 'medium' }
+ * ({ py: 'small' }, { p: 'medium' }) => { py: 'small', px: 'medium'}
+ */
+export const paddingDefaultsHelper = (
+  props: PaddingProps,
+  defaults: PaddingProps
+) => {
+  const merged = { ...defaults, ...props }
+  let { p, px, py, pt, pr, pb, pl } = merged
+
+  // Fill in gaps in directional sizes
+  pt = pt || py || p
+  pb = pb || py || p
+  py = pb === pt ? pb : undefined
+
+  pr = pr || px || p
+  pl = pl || px || p
+  px = pr === pl ? pr : undefined
+
+  p = px && px === py ? px : undefined
+
+  if (py) {
+    pt = undefined
+    pb = undefined
+  }
+
+  if (px) {
+    pr = undefined
+    pl = undefined
+  }
+
+  if (p) {
+    return { p }
+  }
+
+  const response = { p, pb, pl, pr, pt, px, py }
+
+  /* Remove undefined values */
+  Object.keys(response).forEach((key) => {
+    if (typeof response[key] === 'undefined') {
+      delete response[key]
+    }
+  })
+
+  return response
+}


### PR DESCRIPTION
This PR introduces a helper to make sure that padding values specified on the CardContent component are properly interleaved with the default values (`p: medium`)

This doesn't feel like the most efficient solution to the problem but it does get the rest results. 

Would love thoughts on a more clever / efficient ways to solve this 