### PR TITLE
fix: Include @types/styled-system in devDependencies to simplify installation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^16.9.56",
     "@types/react-dom": "^16.9.9",
     "@types/styled-components": "^5.1.9",
+    "@types/styled-system": "^5.1.11",
     "@types/uuid": "^8.3.0",
     "csstype": "^3.0.8",
     "jest-styled-components": "^7.0.4",

--- a/www/src/documentation/develop/index.mdx
+++ b/www/src/documentation/develop/index.mdx
@@ -19,7 +19,7 @@ npm install @looker/components styled-components
 If you're using Typescript you'll also need to add the type definitions for Styled Components.
 
 ```bash static
-yarn add --dev @types/styled-components @types/react @types/react-dom
+yarn add --dev @types/styled-components @types/react @types/react-dom @types/styled-system
 ```
 
 Unfortunately, due to [this issue with the type definitions for Styled Components](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) you'll need to apply a minor workaround if you're using ESLint along with Styled Component's Typescript definitions.


### PR DESCRIPTION
Adds @types/styled-system to `devDependencies` to remove the need for downstream consumers to also install that dependency within their own projects.