### PR TITLE
fix(DialogHeader): Restore previous behavior for DialogHeader detail property

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.story.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.story.tsx
@@ -35,3 +35,10 @@ export default {
 export const Basic = () => <DialogHeader>Heading</DialogHeader>
 
 export const HideClose = () => <DialogHeader hideClose>Heading</DialogHeader>
+
+export const Detail = () => (
+  <DialogHeader detail="Detail text">Heading</DialogHeader>
+)
+Detail.parameters = {
+  storyshots: { disable: true },
+}

--- a/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.test.tsx
@@ -28,7 +28,7 @@ import 'jest-styled-components'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
-import { Basic, HideClose } from './DialogHeader.story'
+import { Basic, Detail, HideClose } from './DialogHeader.story'
 
 describe('DialogHeader', () => {
   test('basic', () => {
@@ -39,6 +39,11 @@ describe('DialogHeader', () => {
   test('Close visible by default', () => {
     renderWithTheme(<Basic />)
     expect(screen.getByText('Close')).toBeInTheDocument()
+  })
+
+  test('Detail text visible', () => {
+    renderWithTheme(<Detail />)
+    expect(screen.getByText('Detail text')).toBeInTheDocument()
   })
 
   test('hideClose', () => {

--- a/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.tsx
@@ -57,7 +57,7 @@ const DialogHeaderLayout: FC<DialogHeaderProps> = ({
 
   return (
     <ModalHeader
-      detail={hideClose ? detail : <ModalHeaderCloseButton />}
+      detail={detail || (!hideClose && <ModalHeaderCloseButton />)}
       id={headingId}
       px="xlarge"
       py="large"


### PR DESCRIPTION
During the recent refactor of the `DialogHeader` the behavior was changed so that the content `detail` property is not displayed when specified.

This PR restores the previous behavior and adds test coverage to validate that it is functional again.