### PR TITLE
fix(DialogHeader): Properly interpret `detail={null}` (still don't show close option)

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.test.tsx
@@ -49,7 +49,7 @@ describe('DialogHeader', () => {
 
   test('hideClose', () => {
     renderWithTheme(<HideClose />)
-    expect(screen.queryByLabelText('Close')).not.toBeInTheDocument()
+    expect(screen.queryByText('Close')).not.toBeInTheDocument()
   })
 
   test('aria-label', () => {
@@ -57,5 +57,10 @@ describe('DialogHeader', () => {
       <DialogHeader aria-label="label test">Hello World</DialogHeader>
     )
     expect(screen.getByLabelText('label test')).toBeInTheDocument()
+  })
+
+  test('detail = null, no close option', () => {
+    renderWithTheme(<DialogHeader detail={null}>Hello World</DialogHeader>)
+    expect(screen.queryByText('Close')).not.toBeInTheDocument()
   })
 })

--- a/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.tsx
+++ b/packages/components/src/Dialog/Layout/DialogHeader/DialogHeader.tsx
@@ -49,16 +49,19 @@ export type DialogHeaderProps = DetailOptions & Omit<ModalHeaderProps, 'detail'>
 
 const DialogHeaderLayout: FC<DialogHeaderProps> = ({
   children,
-  hideClose = false,
+  hideClose,
   detail,
   ...props
 }) => {
   const { id: dialogId } = useContext(DialogContext)
   const headingId = dialogId ? `${dialogId}-heading` : undefined
 
+  const detailContent =
+    detail || (detail === undefined && !hideClose && <ModalHeaderCloseButton />)
+
   return (
     <ModalHeader
-      detail={detail || (!hideClose && <ModalHeaderCloseButton />)}
+      detail={detailContent}
       id={headingId}
       px="xlarge"
       py="large"


### PR DESCRIPTION
## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [ ] 🖼 Image Snapshot coverage