### PR TITLE
fix(Panel): Render properly in a Drawer or Dialog

### DIFF
--- a/packages/components/src/Panel/Panel.story.tsx
+++ b/packages/components/src/Panel/Panel.story.tsx
@@ -28,6 +28,7 @@ import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { Done } from '@styled-icons/material/Done'
 import { Button } from '../Button'
+import { Drawer } from '../Drawer'
 import { List, ListItem } from '../List'
 import { Aside, Layout, Page, Section, SpaceVertical } from '../Layout'
 import { Paragraph } from '../Text'
@@ -235,4 +236,40 @@ export const WithTree = () => (
     </Aside>
     <Section>Main content</Section>
   </Page>
+)
+
+export const WithDrawer = () => (
+  <Drawer
+    placement="left"
+    content={
+      <Panels>
+        <SpaceVertical>
+          <Panel
+            direction="right"
+            title="Some title"
+            content="Tree should be hidden"
+          >
+            <Button>Open Panel</Button>
+          </Panel>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+        </SpaceVertical>
+      </Panels>
+    }
+  >
+    <Button>Open Drawer</Button>
+  </Drawer>
 )

--- a/packages/components/src/Panel/Panel.story.tsx
+++ b/packages/components/src/Panel/Panel.story.tsx
@@ -273,3 +273,7 @@ export const WithDrawer = () => (
     <Button>Open Drawer</Button>
   </Drawer>
 )
+
+WithDrawer.parameters = {
+  storyshots: { disable: true },
+}


### PR DESCRIPTION
`Panels` uses `useMeasuredElement` (which relies on `ResizeObserver`) to determine dimensions and position. Since `ResizeObserver` does not detect changes to position, when rendering inside a `Drawer`, the position gets stuck off the page, where the `Drawer` animation begins.

I added a `useEffect` to `Panels` that manually updates the dom rect after a delay, if `DialogContext` is present.

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11
