### PR TITLE
fix(Panel): Render properly in Drawer or Dialog

### DIFF
--- a/packages/components/src/Panel/Panel.story.tsx
+++ b/packages/components/src/Panel/Panel.story.tsx
@@ -28,6 +28,7 @@ import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
 import { Done } from '@styled-icons/material/Done'
 import { Button } from '../Button'
+import { Drawer } from '../Drawer'
 import { List, ListItem } from '../List'
 import { Aside, Layout, Page, Section, SpaceVertical } from '../Layout'
 import { Paragraph } from '../Text'
@@ -236,3 +237,44 @@ export const WithTree = () => (
     <Section>Main content</Section>
   </Page>
 )
+
+export const WithDrawer = () => (
+  <Drawer
+    placement="left"
+    content={
+      <Panels>
+        <SpaceVertical>
+          <Panel
+            defaultOpen
+            direction="right"
+            title="Some title"
+            content="Tree should be hidden"
+          >
+            <Button>Open Panel</Button>
+          </Panel>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+          <Paragraph>Some text</Paragraph>
+        </SpaceVertical>
+      </Panels>
+    }
+  >
+    <Button>Open Drawer</Button>
+  </Drawer>
+)
+
+WithDrawer.parameters = {
+  storyshots: { disable: true },
+}

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -32,8 +32,6 @@ import { renderWithTheme } from '@looker/components-test-utils'
 import { Panel, Panels, usePanel } from './'
 
 const globalConsole = global.console
-/* eslint-disable-next-line @typescript-eslint/unbound-method */
-const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
 
 beforeEach(() => {
   global.console = {
@@ -41,27 +39,11 @@ beforeEach(() => {
     error: jest.fn(),
     warn: jest.fn(),
   }
-  /* eslint-disable-next-line @typescript-eslint/unbound-method */
-  Element.prototype.getBoundingClientRect = jest.fn(() => {
-    return {
-      bottom: 0,
-      height: 30,
-      left: 0,
-      right: 0,
-      toJSON: jest.fn(),
-      top: 0,
-      width: 360,
-      x: 0,
-      y: 0,
-    }
-  })
 })
 
 afterEach(() => {
   jest.resetAllMocks()
   global.console = globalConsole
-  /* eslint-disable-next-line @typescript-eslint/unbound-method */
-  Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
 })
 
 describe('Panel', () => {

--- a/packages/components/src/Panel/PanelWindow.tsx
+++ b/packages/components/src/Panel/PanelWindow.tsx
@@ -25,28 +25,14 @@
  */
 
 import styled from 'styled-components'
-import {
-  height,
-  HeightProps,
-  position,
-  PositionProps,
-  width,
-  WidthProps,
-} from 'styled-system'
 
-export type PanelWindowProps = HeightProps & PositionProps & WidthProps
-
-export const PanelWindow = styled.div.attrs<PanelWindowProps>(
-  ({ height = '100%', left = 0, top = 0, width = '100%' }) => ({
-    height,
-    left,
-    top,
-    width,
-  })
-)<PanelWindowProps>`
-  ${height}
-  ${width}
-  ${position}
+export const PanelWindow = styled.div`
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  margin-top: 0;
   overflow: hidden;
   position: absolute;
+  width: 100%;
+  z-index: ${({ theme: { zIndexFloor } }) => zIndexFloor};
 `

--- a/packages/components/src/Panel/Panels.tsx
+++ b/packages/components/src/Panel/Panels.tsx
@@ -24,31 +24,10 @@
 
  */
 
-import { CompatibleHTMLProps } from '@looker/design-tokens'
-import React, { createContext, forwardRef, Ref } from 'react'
 import styled from 'styled-components'
-import { useCallbackRef, useMeasuredElement } from '../utils'
 
-export const PanelsContext = createContext<ClientRect | null>(null)
-
-const PanelsLayout = forwardRef(
-  (
-    props: CompatibleHTMLProps<HTMLDivElement>,
-    forwardedRef: Ref<HTMLDivElement>
-  ) => {
-    const [element, ref] = useCallbackRef(forwardedRef)
-    const [rect] = useMeasuredElement(element)
-    return (
-      <PanelsContext.Provider value={rect}>
-        <div ref={ref} {...props} />
-      </PanelsContext.Provider>
-    )
-  }
-)
-
-PanelsLayout.displayName = 'PanelsLayout'
-
-export const Panels = styled(PanelsLayout)`
+export const Panels = styled.div`
   height: 100%;
+  position: relative;
   width: 100%;
 `

--- a/packages/components/src/Panel/usePanel.tsx
+++ b/packages/components/src/Panel/usePanel.tsx
@@ -24,12 +24,10 @@
 
  */
 
-import React, { useContext, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import styled from 'styled-components'
-import { Portal } from '../Portal'
 import { useAnimationState, useControlWarn } from '../utils'
 import { PanelHeader } from './PanelHeader'
-import { PanelsContext } from './Panels'
 import { PanelSurface } from './PanelSurface'
 import { PanelWindow } from './PanelWindow'
 import { UsePanelProps, UsePanelResponse } from './types'
@@ -44,7 +42,6 @@ export const usePanel = ({
   setOpen: controlledSetOpen,
   ...headerProps
 }: UsePanelProps): UsePanelResponse => {
-  const rect = useContext(PanelsContext)
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(defaultOpen)
   const isControlled = useControlWarn({
     controllingProps: ['setOpen'],
@@ -82,23 +79,16 @@ export const usePanel = ({
   }
 
   const panel = renderDOM && (
-    <Portal fixed={false}>
-      <PanelWindow
-        width={rect?.width}
-        height={rect?.height}
-        left={rect?.left}
-        top={rect?.top}
+    <PanelWindow>
+      <PanelSurface
+        aria-busy={busy ? true : undefined}
+        className={className}
+        direction={direction}
       >
-        <PanelSurface
-          aria-busy={busy ? true : undefined}
-          className={className}
-          direction={direction}
-        >
-          <PanelHeader onClose={handleClose} {...headerProps} />
-          <PanelContent>{content}</PanelContent>
-        </PanelSurface>
-      </PanelWindow>
-    </Portal>
+        <PanelHeader onClose={handleClose} {...headerProps} />
+        <PanelContent>{content}</PanelContent>
+      </PanelSurface>
+    </PanelWindow>
   )
 
   return {


### PR DESCRIPTION
Get rid of `Portal` in `Panel` because the positioning is buggy. Use `zIndexFloor` to resolve the stacking issue with `Tree`.