### PR TITLE
fix(IconButton): Properly use toggleColor for :active psuedo states

### DIFF
--- a/packages/components/src/Button/IconButton.test.tsx
+++ b/packages/components/src/Button/IconButton.test.tsx
@@ -221,4 +221,18 @@ describe('IconButton', () => {
     expect(button).toHaveStyle('background-color: #eaf4e8;')
     expect(button).toHaveStyle('color: #319220;')
   })
+
+  test('toggleColor + :active', () => {
+    renderWithTheme(
+      <IconButton
+        className="active"
+        icon={<Favorite />}
+        label="Test"
+        toggle
+        toggleColor="calculation"
+      />
+    )
+    const button = screen.getByRole('button')
+    expect(button).toHaveStyle('color: #319220')
+  })
 })

--- a/packages/components/src/Button/iconButtonColor.ts
+++ b/packages/components/src/Button/iconButtonColor.ts
@@ -46,8 +46,10 @@ export const iconButtonColor = css<
   &[aria-expanded='true'],
   &:active,
   &.active {
-    color: ${({ theme, toggle }) =>
-      toggle !== undefined ? theme.colors.key : theme.colors.neutralPressed};
+    color: ${({ theme, toggle, toggleColor }) =>
+      toggle !== undefined
+        ? theme.colors[toggleColor || ICON_BUTTON_DEFAULT_COLOR]
+        : theme.colors.neutralPressed};
   }
 
   &[aria-pressed='true'] {


### PR DESCRIPTION
Correct issue where `key` color was used in `:active` pseudo state for `IconButton` with `toggleColor`

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari