### PR TITLE
fix: Correct web site publishing to work with lerna independent versioning

### DIFF
--- a/config/website-latest.sh
+++ b/config/website-latest.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-PACKAGE_VERSION=v$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' lerna.json)
+PACKAGE_VERSION=v$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' packages/components/package.json)
 config/website.sh $PACKAGE_VERSION
 config/website.sh latest


### PR DESCRIPTION
This PR corrects a documentation web site deploy bug where `lerna.json` `version` key is still leveraged (it's now "independent"). Current each version of the site overwrites into a `vindependent` folder instead of `v1.1.1` 

`latest` which is the publicly visible version still works fine but it'd be ideal to straighten this out so we can keep collecting "historic" versions of the documentation site for easy reference.