### PR TITLE
fix(Tooltip): Performance improvement

### DIFF
--- a/packages/components/src/Button/IconButton.tsx
+++ b/packages/components/src/Button/IconButton.tsx
@@ -31,7 +31,7 @@ import { reset, space } from '@looker/design-tokens'
 import React, { forwardRef, Ref } from 'react'
 import { Icon } from '../Icon'
 import { useTooltip } from '../Tooltip'
-import { useForkedRef, useWrapEvent } from '../utils'
+import { useWrapEvent } from '../utils'
 import { VisuallyHidden } from '../VisuallyHidden'
 import { GenericButtonBase } from './ButtonBase'
 import { iconButtonColor, ICON_BUTTON_DEFAULT_COLOR } from './iconButtonColor'
@@ -39,7 +39,7 @@ import { iconButtonIconSizeMap, buttonSizeMap } from './size'
 import { IconButtonProps } from './iconButtonTypes'
 
 const IconButtonComponent = forwardRef(
-  (props: IconButtonProps, forwardRef: Ref<HTMLButtonElement>) => {
+  (props: IconButtonProps, ref: Ref<HTMLButtonElement>) => {
     const {
       'aria-expanded': ariaExpanded,
       className,
@@ -71,7 +71,6 @@ const IconButtonComponent = forwardRef(
       domProps: {
         'aria-describedby': ariaDescribedBy,
         className: tooltipClassName = '',
-        ref,
         onFocus,
         onBlur,
         onMouseOver,
@@ -95,14 +94,12 @@ const IconButtonComponent = forwardRef(
       onMouseOver: useWrapEvent(onMouseOver, propsOnMouseOver),
     }
 
-    const actualRef = useForkedRef<HTMLButtonElement>(forwardRef, ref)
-
     return (
       <GenericButtonBase
         aria-describedby={ariaDescribedBy}
         aria-expanded={ariaExpanded}
         aria-pressed={toggle ? true : undefined}
-        ref={actualRef}
+        ref={ref}
         p="none"
         size={size}
         width={buttonSizeMap[size]}

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -31,7 +31,6 @@ import React, {
   ReactNode,
   Ref,
 } from 'react'
-import { useForkedRef } from '../utils'
 import { mergeHandlers } from '../utils/mergeHandlers'
 import { TooltipProps, TooltipRenderProp } from './types'
 import { useTooltip } from './useTooltip'
@@ -70,11 +69,8 @@ export const Tooltip = forwardRef(
       onFocus,
       onMouseOut,
       onMouseOver,
-      ref: tooltipRef,
       ...restDomProps
     } = domProps
-
-    const ref = useForkedRef(tooltipRef, forwardedRef)
 
     let target: ReactNode = children
 
@@ -109,7 +105,7 @@ export const Tooltip = forwardRef(
         className: className
           ? `${children.props.className || ''} ${className}`.trim()
           : children.props.className,
-        ref,
+        ref: forwardedRef,
       })
     } else if (isRenderProp(children)) {
       target = children(domProps)

--- a/packages/components/src/Tooltip/types.ts
+++ b/packages/components/src/Tooltip/types.ts
@@ -24,10 +24,10 @@
 
  */
 
-import { Transitions } from '@looker/design-tokens'
+import { CompatibleHTMLProps, Transitions } from '@looker/design-tokens'
 import { Placement } from '@popperjs/core'
 import { Property } from 'csstype'
-import { MouseEvent, ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { MenuDomProps } from '../Menu'
 
 // import { UsePopoverResponseDom } from '../Popover'
@@ -99,18 +99,15 @@ export interface UseTooltipProps {
   delay?: Transitions
 }
 
-export interface UseTooltipResponseDom {
-  'aria-describedby'?: string
-  className?: string
-  onBlur: () => void
-  onFocus: () => void
-  onMouseOut: (event: MouseEvent<HTMLElement>) => void
-  onMouseOver: () => void
-  /**
-   * Used by popper.js to position the OverlaySurface relative to the trigger
-   */
-  ref: (node: HTMLElement | null) => void
-}
+type UseTooltipCallbacks = Required<
+  Pick<
+    CompatibleHTMLProps<HTMLElement>,
+    'onBlur' | 'onFocus' | 'onMouseOut' | 'onMouseOver'
+  >
+>
+
+export type UseTooltipResponseDom = UseTooltipCallbacks &
+  Pick<CompatibleHTMLProps<HTMLElement>, 'aria-describedby' | 'className'>
 export interface TooltipProps extends UseTooltipProps, Partial<MenuDomProps> {
   content: ReactNode
   /**


### PR DESCRIPTION
Eliminate one `useCallbackRef`(for the trigger element) since it causes a "double render".

The `useCallbackRef` for the surface element "shouldn't" be causing much of a performance issue (on huge FieldPicker's, for example) since the state doesn't get updated till the tooltip renders.

Unfortunately, I tested this locally in a huge FieldPicker and didn't see a significant improvement – _maybe_ about 20%.