### PR TITLE
fix(DialogLayout): `footerSecondary` is only valid if `footer` is also specified

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogLayout.story.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.story.tsx
@@ -29,7 +29,7 @@ import { ConstitutionShort } from '../../__mocks__/Constitution'
 import { Box } from '../../Layout'
 import { DialogContent, DialogLayout, DialogLayoutProps } from '.'
 
-const Template: Story<Partial<DialogLayoutProps>> = (args) => (
+const Template: Story<DialogLayoutProps> = (args) => (
   <Box bg="ui1">
     <DialogLayout {...args}>
       <ConstitutionShort />

--- a/packages/components/src/Dialog/Layout/DialogLayout.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.test.tsx
@@ -27,35 +27,49 @@
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { render, screen } from '@testing-library/react'
-import {
-  Basic,
-  HeaderDetail,
-  HeaderCloseButton,
-  FooterSecondary,
-} from './DialogLayout.story'
+import { ConstitutionShort } from '../../__mocks__/Constitution'
+import { Basic, HeaderDetail, HeaderCloseButton } from './DialogLayout.story'
+import { DialogLayout, DialogLayoutProps } from './DialogLayout'
+
+const removeFooterSecondary = (
+  props?: Partial<DialogLayoutProps>
+): DialogLayoutProps => ({ ...props, children: '', footerSecondary: undefined })
 
 describe('DialogLayout', () => {
   test('Basic ', () => {
-    render(<Basic {...Basic.args} />)
+    render(<Basic {...removeFooterSecondary(Basic.args)} />)
     expect(
       screen.getByText(/We the People of the United States/)
     ).toBeInTheDocument()
   })
 
   test('Replaces the built-in `IconButton` with an arbitrary ReactNode', () => {
-    renderWithTheme(<HeaderDetail {...HeaderDetail.args} />)
+    renderWithTheme(
+      <HeaderDetail {...removeFooterSecondary(HeaderDetail.args)} />
+    )
     expect(screen.queryByText('Header text')).toBeInTheDocument()
     expect(screen.getByText('Cancel')).toBeInTheDocument()
   })
 
   test('HeaderCloseButton ', () => {
-    renderWithTheme(<HeaderCloseButton {...HeaderCloseButton.args} />)
+    renderWithTheme(
+      <HeaderCloseButton {...removeFooterSecondary(HeaderCloseButton.args)} />
+    )
     expect(screen.getByText('Close')).toBeInTheDocument()
   })
 
   test('FooterSecondary ', () => {
-    renderWithTheme(<FooterSecondary {...FooterSecondary.args} />)
+    renderWithTheme(
+      <DialogLayout footerSecondary="Cancel" footer="Footer text">
+        <ConstitutionShort />
+      </DialogLayout>
+    )
     expect(screen.getByText('Footer text')).toBeInTheDocument()
     expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  test('FooterSecondary without footer causes TS Exception', () => {
+    // @ts-expect-error footerSecondary must be paired with footer
+    renderWithTheme(<DialogLayout footerSecondary="problem" />)
   })
 })

--- a/packages/components/src/Dialog/Layout/DialogLayout.test.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.test.tsx
@@ -33,7 +33,11 @@ import { DialogLayout, DialogLayoutProps } from './DialogLayout'
 
 const removeFooterSecondary = (
   props?: Partial<DialogLayoutProps>
-): DialogLayoutProps => ({ ...props, children: '', footerSecondary: undefined })
+): DialogLayoutProps => ({
+  children: '',
+  ...props,
+  footerSecondary: undefined,
+})
 
 describe('DialogLayout', () => {
   test('Basic ', () => {

--- a/packages/components/src/Dialog/Layout/DialogLayout.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.tsx
@@ -58,6 +58,7 @@ type FooterOptions = WithFooter | WithoutFooter
 
 export type DialogLayoutProps = FooterOptions &
   ModalLayoutProps & {
+    children?: ReactNode
     /**
      * Content in header. If a `string` is supplied the content will be placed in a `<Header />`
      */

--- a/packages/components/src/Dialog/Layout/DialogLayout.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.tsx
@@ -35,30 +35,45 @@ import { DialogContent } from './DialogContent'
 import { DialogFooter } from './DialogFooter'
 import { DialogHeader, DialogHeaderProps } from './DialogHeader'
 
-export interface DialogLayoutProps extends ModalLayoutProps {
+type WithFooter = {
+  /**
+   * displays content on the right-side of the DialogFooter, uses
+   * Space to add whitespace between each element.
+   */
+  footer: ModalLayoutProps['footer']
   /**
    * Secondary content to place in the footer
    * NOTE: `footer` property must be supplied for footer to be displayed. Supplying
    * only `footerSecondary` will prevent `DialogFooter` from being displayed.
    */
   footerSecondary?: ReactNode
-
-  /**
-   * Content in header. If a `string` is supplied the content will be placed in a `<Header />`
-   */
-  header?: ReactNode
-
-  /**
-   * Replaces the built-in `IconButton` (generally used for close) with an arbitrary ReactNode
-   */
-  headerDetail?: ModalHeaderProps['detail']
-
-  /**
-   * Display "Close" IconButton in the DialogHeader.
-   * NOTE: `true` if no footer is supplied and `headerClose` is not explicitly specified.
-   */
-  headerCloseButton?: boolean
 }
+
+type WithoutFooter = {
+  footer?: undefined
+  footerSecondary?: never
+}
+
+type FooterOptions = WithFooter | WithoutFooter
+
+export type DialogLayoutProps = FooterOptions &
+  ModalLayoutProps & {
+    /**
+     * Content in header. If a `string` is supplied the content will be placed in a `<Header />`
+     */
+    header?: ReactNode
+
+    /**
+     * Replaces the built-in `IconButton` (generally used for close) with an arbitrary ReactNode
+     */
+    headerDetail?: ModalHeaderProps['detail']
+
+    /**
+     * Display "Close" IconButton in the DialogHeader.
+     * NOTE: `true` if no footer is supplied and `headerClose` is not explicitly specified.
+     */
+    headerCloseButton?: boolean
+  }
 
 const constructDialogHeader = (
   children?: ReactNode,
@@ -88,9 +103,9 @@ export const DialogLayout: FC<DialogLayoutProps> = ({
   headerDetail,
   isLoading,
 }) => {
-  const dialogFooter = (footer || footerSecondary) && (
+  const dialogFooter = footer ? (
     <DialogFooter secondary={footerSecondary}>{footer}</DialogFooter>
-  )
+  ) : null
   const dialogHeader = constructDialogHeader(
     header,
     headerCloseButton,


### PR DESCRIPTION
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11
