### PR TITLE
chore: Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,103 +2404,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@looker/components-providers@*", "@looker/components-providers@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-1.3.1.tgz#213b76a82598b629d3a168a0cceeb98e58ae6534"
-  integrity sha512-mYibs/P9nf5NURUInriIECcfBhGTf2c1y7XAgfDZf+MphVPDR39pNLSKgwnmgzQwyIE2JnnGKtZ1A1t6PGdrpQ==
-  dependencies:
-    "@looker/design-tokens" "^1.3.1"
-    i18next "20.2.2"
-    lodash "^4.17.20"
-    react-helmet-async "^1.0.9"
-    react-i18next "11.8.15"
-    tabbable "^5.2.0"
-
-"@looker/components-test-utils@*":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@looker/components-test-utils/-/components-test-utils-1.3.1.tgz#493c87bd42c8f9b841029ffa5fa3fbcb065607a3"
-  integrity sha512-1bSSA+ZGLLYV4f2yImwNZwYefmWo5S27cB2LyT7uuSBQIezIYD93N2ypkEJA4MkLm4hE1JQzfyNpZOnnS1b1YQ==
-
-"@looker/components@*":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@looker/components/-/components-1.4.1.tgz#1f5d86b29e65d09e7a668d0f7a0cfd97a4c560ff"
-  integrity sha512-5XqZMICTxayGo7uiZNcAWbTV2gE9oO41puP76+ppHjQdbjcKcZk83N/if+KGCsfV8j9Ky0DHIEzSAjeTVboyCw==
-  dependencies:
-    "@looker/components-providers" "^1.3.1"
-    "@looker/design-tokens" "^1.3.1"
-    "@popperjs/core" "^2.6.0"
-    "@styled-icons/material" "^10.28.0"
-    "@styled-icons/material-outlined" "^10.28.0"
-    "@styled-icons/material-rounded" "^10.28.0"
-    "@styled-icons/styled-icon" "^10.6.3"
-    d3-color "^2.0.0"
-    d3-hsv "^0.1.0"
-    date-fns "^2.21.1"
-    date-fns-tz "^1.0.12"
-    hotkeys-js "^3.8.3"
-    i18next "20.2.2"
-    lodash "^4.17.20"
-    react-day-picker "^7.4.8"
-    react-hotkeys-hook "2.3.1"
-    react-i18next "11.8.15"
-    resize-observer-polyfill "^1.5.1"
-    styled-system "^5.1.5"
-    uuid "^8.3.2"
-
-"@looker/design-tokens@*", "@looker/design-tokens@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-1.3.1.tgz#5f3b210df85a4ac3eb0c29694c9b9a851e3b221c"
-  integrity sha512-SQUXHeh/tax1db6TfDO/6XNcYFZATkrGkcg+tFf7GaZn8GBXovTAMoIyt7WxcKVr1wvMKz9KtLUs+GbKfoSaTg==
-  dependencies:
-    "@styled-system/props" "^5.1.5"
-    "@styled-system/should-forward-prop" "5.1.5"
-    lodash "^4.17.20"
-    polished "^4.1.2"
-    styled-system "^5.1.5"
-
-"@looker/eslint-config@*":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@looker/eslint-config/-/eslint-config-1.4.0.tgz#2fef391a5717c1106e6dd99e489b79d60e82c0c1"
-  integrity sha512-vvQIjq4JSW9rYHBKcD6us5veoqOz4G2xEwxjEuj0eahvvPVTx0frSJNJxi2JzQI3LY1VGbYFbQJvTrFHN/fXjQ==
-  dependencies:
-    "@types/vfile-message" "^2.0.0"
-    "@typescript-eslint/eslint-plugin" "^4.22.0"
-    "@typescript-eslint/parser" "^4.23.0"
-    eslint "^7.27.0"
-    eslint-config-prettier "8.2.0"
-    eslint-config-standard "16.0.2"
-    eslint-import-resolver-typescript "^2.4.0"
-    eslint-import-resolver-webpack "^0.13.0"
-    eslint-plugin-header "^3.1.1"
-    eslint-plugin-i18next "^5.1.1"
-    eslint-plugin-import "^2.22.1"
-    eslint-plugin-jest-dom "3.8.0"
-    eslint-plugin-mdx "^1.12.0"
-    eslint-plugin-node "^11.1.0"
-    eslint-plugin-prettier "3.4.0"
-    eslint-plugin-promise "^5.1.0"
-    eslint-plugin-react "^7.23.2"
-    eslint-plugin-react-hooks "^4.2.0"
-    eslint-plugin-sort-keys-fix "^1.1.1"
-    eslint-plugin-standard "5.0.0"
-    eslint-plugin-testing-library "4.1.1"
-    prettier "^2.2.1"
-    typescript "4.2.4"
-
-"@looker/icons@*":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@looker/icons/-/icons-1.3.0.tgz#60dd6213f5784e9e5160458934913c31e483d0a1"
-  integrity sha512-YFshUK+JQB/Vz+Fi7imX/9QAz9SMN12G1cjrs5IbFTRrlRV4JmPjJIMTO7JNxFiP11xDxSO71z3KO6qRyda96A==
-  dependencies:
-    "@styled-icons/styled-icon" "^10.6.3"
-
-"@looker/prettier-config@*":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@looker/prettier-config/-/prettier-config-1.3.0.tgz#22178b6186436856608c48e9408391694bd0d4e5"
-  integrity sha512-IEqBf6OwmVGfJEPlJQR6fPaAE67XWKZOVpX/q47ddHXnCGKuzJXa44ceRXyIvhV+SgSqXQzseD5HN1NV92ht+Q==
-  dependencies:
-    prettier ">=2.2.1"
-
 "@looker/sdk-rtl@^21.0.13":
   version "21.0.13"
   resolved "https://registry.yarnpkg.com/@looker/sdk-rtl/-/sdk-rtl-21.0.13.tgz#1ee9fd344c5146025b42fce1b3940758bb463b64"
@@ -2521,19 +2424,6 @@
     readable-stream "^3.4.0"
     request "^2.88.0"
     request-promise-native "^1.0.8"
-
-"@looker/stylelint-config@*":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@looker/stylelint-config/-/stylelint-config-1.3.0.tgz#a65337b8f76b32bf39323d3f1794885fd4cb9279"
-  integrity sha512-Z3MHVVT7vptyi2W6OmcDpwS4mZuzZ2C0olV523+Hp81WCW6gammBUcrlZIRKtN+XfNuiM1K/YxZXKUvzFdVEog==
-  dependencies:
-    prettier "2.2.1"
-    stylelint "^13.13.1"
-    stylelint-config-prettier "^8.0.2"
-    stylelint-config-recommended "^5.0.0"
-    stylelint-config-styled-components "^0.1.1"
-    stylelint-order "^4.1.0"
-    stylelint-prettier "^1.2.0"
 
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
@@ -3928,7 +3818,7 @@
     "@babel/runtime" "^7.12.13"
     "@styled-icons/styled-icon" "^10.6.0"
 
-"@styled-icons/material@^10.28.0", "@styled-icons/material@^10.34.0":
+"@styled-icons/material@^10.34.0":
   version "10.34.0"
   resolved "https://registry.yarnpkg.com/@styled-icons/material/-/material-10.34.0.tgz#479bd36834d26e2b8e2ed06813a141a578ea6008"
   integrity sha512-BQCyzAN0RhkpI6mpIP7RvUoZOZ15d5opKfQRqQXVOfKD3Dkyi26Uog1KTuaaa/MqtqrWaYXC6Y1ypanvfpyL2g==
@@ -9425,7 +9315,7 @@ eslint-plugin-i18next@*, eslint-plugin-i18next@^5.1.1:
   dependencies:
     requireindex "~1.1.0"
 
-eslint-plugin-import@^2.22.0, eslint-plugin-import@^2.22.1, eslint-plugin-import@^2.23.4:
+eslint-plugin-import@^2.22.0, eslint-plugin-import@^2.23.4:
   version "2.23.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz#8dceb1ed6b73e46e50ec9a5bb2411b645e7d3d97"
   integrity sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==
@@ -12224,13 +12114,6 @@ humanize-ms@^1.2.1:
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
   dependencies:
     ms "^2.0.0"
-
-i18next@20.2.2:
-  version "20.2.2"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.2.2.tgz#175644829dcf35546ba8c174583acfe449e4ef1a"
-  integrity sha512-uWCv9LzKpe+OwvnKKrb8CbJwgAhasQofD58cB0PQ6bTPXEl5PlItl5C4esmY8HtriLu9nrjc2Hi0IfYv3Fy8BQ==
-  dependencies:
-    "@babel/runtime" "^7.12.0"
 
 i18next@20.3.1:
   version "20.3.1"
@@ -17226,15 +17109,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.2.1, prettier@~2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-
-prettier@2.3.1, prettier@>=2.2.1, prettier@>=2.3.1, prettier@^2.0.5, prettier@^2.2.1, prettier@^2.3.1:
+prettier@2.3.1, prettier@>=2.3.1, prettier@^2.0.5, prettier@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
   integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
+
+prettier@~2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.4.1"


### PR DESCRIPTION
Getting a new `yarn.lock` when running `yarn` on main.

Seems to be identical to Meredith's previous PR:
https://github.com/looker-open-source/components/pull/2532/files

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
