### PR TITLE
fix(ModalHeader): Lint errors in test file

### DIFF
--- a/packages/components/src/Modal/ModalHeader/ModalHeader.test.tsx
+++ b/packages/components/src/Modal/ModalHeader/ModalHeader.test.tsx
@@ -38,13 +38,13 @@ describe('ModalHeader', () => {
 
   test('has aria-label', async () => {
     renderWithTheme(<ModalHeader aria-label="ARIA label">Heading</ModalHeader>)
-    expect(await screen.findByLabelText('ARIA label')).toBeTruthy()
+    expect(await screen.findByLabelText('ARIA label')).toBeInTheDocument()
   })
 
   test(`detail as ReactNode`, () => {
     renderWithTheme(
       <ModalHeader detail={<button>x</button>}>Header</ModalHeader>
     )
-    expect(screen.queryByText('x')).toBeTruthy()
+    expect(screen.queryByText('x')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Fixes lint errors in `ModalHeader.test.tsx`. Not sure how these got through but they're causing my filters PR to fail CI.