### PR TITLE
chore(deps): bump @looker/sdk from 21.6.0 to 21.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.14.0",
     "@babel/runtime-corejs3": "^7.13.17",
-    "@looker/sdk": "^21.6.0",
+    "@looker/sdk": "^21.8.0",
     "@testing-library/jest-dom": "^5.12.0",
     "@types/jest-image-snapshot": "^4.3.0",
     "@types/node": "^15.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,6 +2425,17 @@
     request "^2.88.0"
     request-promise-native "^1.0.8"
 
+"@looker/sdk@^21.8.0":
+  version "21.8.0"
+  resolved "https://registry.yarnpkg.com/@looker/sdk/-/sdk-21.8.0.tgz#d3e95a2f90f604861220290612f36a154aa5e42b"
+  integrity sha512-sACoXEqShswHtxX5sBBVo7BUYM4u0iKmyZ+RZ8NiiDxYDzsRYfDfuFNAtfyh9WjOWMs35CWKfvsakZBcX+u35g==
+  dependencies:
+    "@looker/sdk-rtl" "^21.0.13"
+    ini "^1.3.8"
+    readable-stream "^3.4.0"
+    request "^2.88.0"
+    request-promise-native "^1.0.8"
+
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"


### PR DESCRIPTION
Upgrade necessary for filters release.