### PR TITLE
chore(lint): Disable prettier in oss-compat

### DIFF
--- a/packages/eslint-config/oss-compat.js
+++ b/packages/eslint-config/oss-compat.js
@@ -29,6 +29,7 @@ module.exports = {
   rules: {
     camelcase: 'off',
     'import/order': 'off',
+    'prettier/prettier': 'off',
     'sort-keys-fix/sort-keys-fix': 'off',
   },
 }


### PR DESCRIPTION
Workaround for discrepancies between the prettier version in this repo (`2.3.1`) and the core product repo (`2.2.1`) that interfere with the OSS sync process.