### PR TITLE
fix: Restore CI code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install
-      - run: yarn prebuild
       - uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           package-manager: yarn
-          skip: install
           threshold: 80
   build:
     name: "Build: ES & Typescript"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - run : yarn --silent
       - run: yarn test
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: coverage
           path: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,25 @@ jobs:
       - uses: c-hive/gha-yarn-cache@v1
       - run : yarn --silent
       - run: yarn test
-    env:
-      CI: true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: coverage
+          retention-days: 5
+  coverage:
+    name: "Coverage"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install
+      - run: yarn prebuild
+      - uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-manager: yarn
+          skip: install
+          threshold: 80
   build:
     name: "Build: ES & Typescript"
     runs-on: ubuntu-latest
@@ -54,7 +71,6 @@ jobs:
   gatsby:
     name: "Gatsby"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
       - uses: c-hive/gha-yarn-cache@v1
@@ -64,7 +80,6 @@ jobs:
   image-snapshots:
     name: "Image Snapshots"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
         with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,7 +38,7 @@ module.exports = {
     '!packages/**/index.ts',
     '!packages/**/types.ts',
   ],
-  coverageReporters: ['json', 'html', 'lcov'],
+  coverageReporters: ['json', 'html', 'lcov', 'text', 'text-summary'],
   moduleDirectories: ['./node_modules', './packages'],
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
   moduleNameMapper: {

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.test.tsx
@@ -33,6 +33,6 @@ test('VisuallyHiddenText default', () => {
   renderWithTheme(<VisuallyHidden>I am hidden</VisuallyHidden>)
   expect(screen.getByText('I am hidden')).toBeInTheDocument()
   expect(screen.getByText('I am hidden')).toHaveStyle(
-    'clip: rect(1px, 1px, 1px, 0px)'
+    'clip: rect(1px, 1px, 1px, 1px)'
   )
 })

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.test.tsx
@@ -33,6 +33,6 @@ test('VisuallyHiddenText default', () => {
   renderWithTheme(<VisuallyHidden>I am hidden</VisuallyHidden>)
   expect(screen.getByText('I am hidden')).toBeInTheDocument()
   expect(screen.getByText('I am hidden')).toHaveStyle(
-    'clip: rect(1px, 1px, 1px, 1px)'
+    'clip: rect(1px, 1px, 1px, 0px)'
   )
 })


### PR DESCRIPTION
The pull request re-enables coverage reporting on our code-base using a Github action and Jest's built-in reporter functionality and adds specific features detailed below.

*NOTE*: I haven't made this a blocking check as of yet and there's no threshold currently with that in mind. I'd like run this in production for a week or two and it seems to behave we can go from there.

## PR Comment

![image](https://user-images.githubusercontent.com/34253496/124035550-880e2800-d9b1-11eb-996a-b1d04720a400.png)

## Coverage Report Artifact

Uses [`upload-artifact`](https://github.com/actions/upload-artifact) to upload the entire coverage report for easy review

![image](https://user-images.githubusercontent.com/34253496/124035939-1c788a80-d9b2-11eb-9f8d-f751745100c6.png)


## Annotations

Automatically annotates coverage gaps and errors.

![image](https://user-images.githubusercontent.com/34253496/124035297-336aad00-d9b1-11eb-90aa-31eab08c9466.png)

### Errors
![image](https://user-images.githubusercontent.com/34253496/124035159-061dff00-d9b1-11eb-91b3-653a1e861cf1.png)

### Coverage Gaps
![image](https://user-images.githubusercontent.com/34253496/124035440-63b24b80-d9b1-11eb-927b-c12639bea958.png)
