### PR TITLE
fix: move lodash to peer dependencies

### DIFF
--- a/packages/components-providers/package.json
+++ b/packages/components-providers/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@looker/design-tokens": "^2.0.0",
     "i18next": "20.3.1",
-    "lodash": "^4.17.20",
     "react-helmet-async": "^1.0.9",
     "react-i18next": "11.8.15",
     "tabbable": "^5.2.0"
@@ -30,11 +29,13 @@
     "@types/lodash": "^4.14.168",
     "@types/react": "^16.9.56",
     "@types/styled-components": "*",
+    "lodash": "^4.17.20",
     "react": "^16.14.0",
     "react-is": "^16.13.1",
     "styled-components": "^5.3.0"
   },
   "peerDependencies": {
+    "lodash": "^4.17.20",
     "react": "^16.11",
     "react-is": "^16.11",
     "styled-components": "^5"

--- a/packages/components-theme-editor/package.json
+++ b/packages/components-theme-editor/package.json
@@ -19,15 +19,16 @@
     "@looker/components": "*",
     "@looker/design-tokens": "*",
     "@styled-icons/material": "^10.34.0",
-    "@styled-icons/material-outlined": "^10.28.0",
-    "lodash": "*"
+    "@styled-icons/material-outlined": "^10.28.0"
   },
   "devDependencies": {
+    "lodash": "*",
     "react": "^16.14.0",
     "react-is": "^16.13.1",
     "styled-components": ">=5.3"
   },
   "peerDependencies": {
+    "lodash": "*",
     "react": "^16.11",
     "react-is": "^16.11",
     "styled-components": "^5"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,6 @@
     "d3-hsv": "^0.1.0",
     "hotkeys-js": "^3.8.3",
     "i18next": "20.3.1",
-    "lodash": "^4.17.20",
     "react-hotkeys-hook": "2.3.1",
     "react-i18next": "11.8.15",
     "resize-observer-polyfill": "^1.5.1",
@@ -52,12 +51,14 @@
     "csstype": "^3.0.8",
     "jest-styled-components": "^7.0.4",
     "puppeteer": "^9.1.0",
+    "lodash": "^4.17.20",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-is": "^16.13.1",
     "styled-components": "^5.3.0"
   },
   "peerDependencies": {
+    "lodash": "^4.17.20",
     "react": "^16.11",
     "react-dom": "^16.11",
     "react-is": "^16.11",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@styled-system/props": "^5.1.5",
     "@styled-system/should-forward-prop": "5.1.5",
-    "lodash": "^4.17.20",
     "polished": "^4.1.2",
     "styled-system": "^5.1.5"
   },
@@ -37,6 +36,7 @@
     "styled-components": "^5.3.0"
   },
   "peerDependencies": {
+    "lodash": "^4.17.20",
     "react": "^16.11",
     "react-dom": "^16.11",
     "react-is": "^16.11",

--- a/www/src/documentation/develop/index.mdx
+++ b/www/src/documentation/develop/index.mdx
@@ -8,10 +8,10 @@ To add Looker UI Components to your project, add the [NPM package](https://www.n
 
 ```bash static
 # Looker projects generally utilize Yarn (https://yarnpkg.com/)
-yarn add @looker/components styled-components react react-dom
+yarn add @looker/components styled-components react react-dom lodash
 
 # If you prefer you can of course also use NPM directly:
-npm install @looker/components styled-components
+npm install @looker/components styled-components lodash
 ```
 
 ### Using Typescript?


### PR DESCRIPTION
I observed that components brings in its own version of lodash whenever it's imported to helltool. Although `packages/components/README.md` [states that lodash should be supplied as a peer dependency](https://github.com/looker-open-source/components/blame/12658bddd81bf4dc1625865de424cc674ea07e1c/packages/components/README.md#L15), this does not actually appear to be the case. This PR moves lodash to `peerDependencies` and `devDependencies` wherever it is found in the `components` tree.