### PR TITLE
fix(RangeSlider): Value reset due to intermediate rerender

### DIFF
--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
@@ -24,9 +24,11 @@
 
  */
 
-import React, { useState } from 'react'
+import React from 'react'
+import { Space } from '../../../Layout'
 import { Button } from '../../../Button'
 import { Paragraph } from '../../../Text'
+import { useToggle } from '../../../utils'
 import { RangeSlider } from './RangeSlider'
 
 export default {
@@ -40,25 +42,28 @@ const getRange = (value?: number[]) => [
 ]
 
 const NumberFilter = ({
-  AST: { value },
+  AST,
   onChange,
 }: {
   AST: { value?: number[] }
   onChange: (value: number[]) => void
 }) => {
-  const [minMax, setMinMax] = useState([0, 100])
-  const rangeValue = getRange(value)
+  const { value, toggle } = useToggle()
+  const rangeValue = getRange(AST.value)
   return (
-    <>
+    <Space>
       <RangeSlider
-        min={minMax[0]}
-        max={minMax[1]}
+        min={0}
+        max={value ? 5 : 100}
         value={rangeValue}
         onChange={onChange}
-        width={200}
+        width={400}
       />
-      <Button onClick={() => setMinMax([0, 5])}>Min/max to 0 - 5</Button>
-    </>
+      <Button onClick={toggle}>
+        Change min/max to 0 - {value ? '100' : '5'}
+      </Button>
+      <Paragraph>Current Value: {rangeValue.join(',')}</Paragraph>
+    </Space>
   )
 }
 

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
@@ -25,8 +25,9 @@
  */
 
 import React from 'react'
-import { Space } from '../../../Layout'
 import { Button } from '../../../Button'
+import { Space, SpaceVertical } from '../../../Layout'
+import { OrderedList } from '../../../OrderedList'
 import { Paragraph } from '../../../Text'
 import { useToggle } from '../../../utils'
 import { RangeSlider } from './RangeSlider'
@@ -51,19 +52,20 @@ const NumberFilter = ({
   const { value, toggle } = useToggle()
   const rangeValue = getRange(AST.value)
   return (
-    <Space>
+    <>
       <RangeSlider
         min={0}
         max={value ? 5 : 100}
         value={rangeValue}
         onChange={onChange}
-        width={400}
       />
-      <Button onClick={toggle}>
-        Change min/max to 0 - {value ? '100' : '5'}
-      </Button>
-      <Paragraph>Current Value: {rangeValue.join(',')}</Paragraph>
-    </Space>
+      <Space>
+        <Button onClick={toggle}>
+          Change min/max to 0 - {value ? '100' : '5'}
+        </Button>
+        <Paragraph>Current Value: {rangeValue.join(',')}</Paragraph>
+      </Space>
+    </>
   )
 }
 
@@ -88,7 +90,7 @@ const Filter = ({
     }
   }, [expression])
   const handleChange = (newValue: number[]) => {
-    onChange(newValue.join(','))
+    onChange(newValue.join(', '))
   }
   return <NumberFilter AST={AST} onChange={handleChange} />
 }
@@ -99,15 +101,16 @@ export const RerenderRepro = () => {
     setExpression(newValue)
   }
   return (
-    <>
-      <Paragraph>
-        When updating the min/max, the value should move to stay within bounds.
-      </Paragraph>
-      <Paragraph>
-        When changing the value, it should not immediately reset.
-      </Paragraph>
+    <SpaceVertical p="medium" align="stretch">
+      <OrderedList type="number">
+        <li>
+          When updating the min/max, the value should move to stay within
+          bounds.
+        </li>
+        <li>When changing the value, it should not immediately reset.</li>
+      </OrderedList>
       <Filter expression={expression} onChange={handleChange} />
-    </>
+    </SpaceVertical>
   )
 }
 

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
@@ -95,9 +95,10 @@ test('warns the developer if value prop falls outside of possible min/max range'
 
   rerender(
     withThemeProvider(
-      <RangeSlider min={10} max={20} value={[-1, 1]} onChange={handleChange} />
+      <RangeSlider onChange={handleChange} min={10} max={20} value={[-1, 1]} />
     )
   )
+
   expect(handleChange).toHaveBeenCalledWith([10, 10])
 })
 
@@ -154,10 +155,7 @@ test('prevents value from going outside of min/max range', () => {
   renderWithTheme(
     <RangeSlider onChange={handleChange} min={9} max={10} value={[0, 100]} />
   )
-  const minThumb = screen.getByLabelText('Minimum Value')
-  const maxThumb = screen.getByLabelText('Maximum Value')
-  expect(minThumb).toHaveAttribute('aria-valuenow', '9')
-  expect(maxThumb).toHaveAttribute('aria-valuenow', '10')
+  expect(handleChange).toHaveBeenCalledWith([9, 10])
 })
 
 describe('readOnly prop', () => {

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
@@ -85,25 +85,20 @@ test('it selects the entire range by default', () => {
 test('warns the developer if value prop falls outside of possible min/max range', () => {
   // eslint-disable-next-line no-console
   expect(console.warn).not.toHaveBeenCalled()
+  const handleChange = jest.fn()
   const { rerender } = renderWithTheme(
-    <RangeSlider defaultValue={[0, 1000]} min={10} max={20} />
+    <RangeSlider value={[0, 1000]} min={10} max={20} onChange={handleChange} />
   )
   // eslint-disable-next-line no-console
   expect(console.warn).toHaveBeenCalled()
-
-  const minThumb = screen.getByLabelText('Minimum Value')
-  const maxThumb = screen.getByLabelText('Maximum Value')
-  expect(minThumb).toHaveAttribute('aria-valuenow', '10')
-  expect(maxThumb).toHaveAttribute('aria-valuenow', '20')
+  expect(handleChange).toHaveBeenCalledWith([10, 20])
 
   rerender(
     withThemeProvider(
-      <RangeSlider min={10} max={20} value={[-1, 1]} onChange={jest.fn()} />
+      <RangeSlider min={10} max={20} value={[-1, 1]} onChange={handleChange} />
     )
   )
-
-  expect(minThumb).toHaveAttribute('aria-valuenow', '10')
-  expect(maxThumb).toHaveAttribute('aria-valuenow', '10')
+  expect(handleChange).toHaveBeenCalledWith([10, 10])
 })
 
 test('fires onChange callback on mouseMove', () => {

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.test.tsx
@@ -43,7 +43,6 @@ type VoidFN = () => void
 beforeEach(() => {
   global.console = {
     ...globalConsole,
-    error: jest.fn(),
     warn: jest.fn(),
   }
   global.requestAnimationFrame = jest
@@ -76,32 +75,35 @@ afterEach(() => {
 test('it selects the entire range by default', () => {
   const handleChange = jest.fn()
   renderWithTheme(<RangeSlider onChange={handleChange} min={5} max={100} />)
-  expect(handleChange).toHaveBeenCalledWith([5, 100])
+
+  const minThumb = screen.getByLabelText('Minimum Value')
+  const maxThumb = screen.getByLabelText('Maximum Value')
+  expect(minThumb).toHaveAttribute('aria-valuenow', '5')
+  expect(maxThumb).toHaveAttribute('aria-valuenow', '100')
 })
 
 test('warns the developer if value prop falls outside of possible min/max range', () => {
   // eslint-disable-next-line no-console
   expect(console.warn).not.toHaveBeenCalled()
-  const handleChange = jest.fn()
   const { rerender } = renderWithTheme(
-    <RangeSlider
-      defaultValue={[0, 1000]}
-      min={10}
-      max={20}
-      onChange={handleChange}
-    />
+    <RangeSlider defaultValue={[0, 1000]} min={10} max={20} />
   )
   // eslint-disable-next-line no-console
   expect(console.warn).toHaveBeenCalled()
-  expect(handleChange).toHaveBeenCalledWith([10, 20])
+
+  const minThumb = screen.getByLabelText('Minimum Value')
+  const maxThumb = screen.getByLabelText('Maximum Value')
+  expect(minThumb).toHaveAttribute('aria-valuenow', '10')
+  expect(maxThumb).toHaveAttribute('aria-valuenow', '20')
 
   rerender(
     withThemeProvider(
-      <RangeSlider onChange={handleChange} min={10} max={20} value={[-1, 1]} />
+      <RangeSlider min={10} max={20} value={[-1, 1]} onChange={jest.fn()} />
     )
   )
 
-  expect(handleChange).toHaveBeenCalledWith([10, 10])
+  expect(minThumb).toHaveAttribute('aria-valuenow', '10')
+  expect(maxThumb).toHaveAttribute('aria-valuenow', '10')
 })
 
 test('fires onChange callback on mouseMove', () => {
@@ -136,7 +138,8 @@ test('increments point by STEP value during keyboard navigation', () => {
 
   const minThumb = screen.getByLabelText('Minimum Value')
   const maxThumb = screen.getByLabelText('Maximum Value')
-  expect(handleChange).toHaveBeenCalledWith([0, 100])
+  expect(minThumb).toHaveAttribute('aria-valuenow', '0')
+  expect(maxThumb).toHaveAttribute('aria-valuenow', '100')
 
   minThumb.focus()
   fireEvent.keyDown(document.activeElement as Element, { key: 'ArrowUp' })
@@ -156,7 +159,10 @@ test('prevents value from going outside of min/max range', () => {
   renderWithTheme(
     <RangeSlider onChange={handleChange} min={9} max={10} value={[0, 100]} />
   )
-  expect(handleChange).toHaveBeenCalledWith([9, 10])
+  const minThumb = screen.getByLabelText('Minimum Value')
+  const maxThumb = screen.getByLabelText('Maximum Value')
+  expect(minThumb).toHaveAttribute('aria-valuenow', '9')
+  expect(maxThumb).toHaveAttribute('aria-valuenow', '10')
 })
 
 describe('readOnly prop', () => {
@@ -164,14 +170,10 @@ describe('readOnly prop', () => {
     const handleChange = jest.fn()
     renderWithTheme(<RangeSlider onChange={handleChange} readOnly />)
 
-    expect(handleChange).toHaveBeenCalledWith([0, 10]) // initial render
-
     const wrapper = screen.getByTestId('range-slider-wrapper')
     fireEvent.mouseDown(wrapper)
     fireEvent.mouseMove(wrapper, { clientX: 100, clientY: 10 })
-
-    expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
-    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).not.toHaveBeenCalled()
   })
 
   test('readOnly component does not respond to KEYBOARD input', () => {
@@ -181,12 +183,10 @@ describe('readOnly prop', () => {
     )
 
     const minThumb = screen.getByLabelText('Minimum Value')
-    expect(handleChange).toHaveBeenCalledWith([0, 10]) // initial render
 
     minThumb.focus()
     fireEvent.keyDown(document.activeElement as Element, { key: 'ArrowUp' })
-    expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
-    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).not.toHaveBeenCalled()
   })
 })
 
@@ -195,14 +195,10 @@ describe('disabled prop', () => {
     const handleChange = jest.fn()
     renderWithTheme(<RangeSlider onChange={handleChange} disabled />)
 
-    expect(handleChange).toHaveBeenCalledWith([0, 10]) // initial render
-
     const wrapper = screen.getByTestId('range-slider-wrapper')
     fireEvent.mouseDown(wrapper)
     fireEvent.mouseMove(wrapper, { clientX: 100, clientY: 10 })
-
-    expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
-    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).not.toHaveBeenCalled()
   })
 
   test('disabled component does not respond to KEYBOARD input', () => {
@@ -212,30 +208,24 @@ describe('disabled prop', () => {
     )
 
     const minThumb = screen.getByLabelText('Minimum Value')
-    expect(handleChange).toHaveBeenCalledWith([0, 10]) // initial render
 
     minThumb.focus()
     fireEvent.keyDown(document.activeElement as Element, { key: 'ArrowUp' })
-    expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
-    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).not.toHaveBeenCalled()
   })
 
   test('disabled component does not respond to TOUCH input', () => {
     const handleChange = jest.fn()
     renderWithTheme(<RangeSlider onChange={handleChange} disabled />)
 
-    expect(handleChange).toHaveBeenCalledWith([0, 10]) // initial render
-
     const wrapper = screen.getByTestId('range-slider-wrapper')
     fireEvent.touchStart(wrapper)
     fireEvent.touchMove(wrapper, { touches: [{ clientX: 100, clientY: 10 }] })
-
-    expect(handleChange).toHaveBeenLastCalledWith([0, 10]) // unchanged
-    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).not.toHaveBeenCalled()
   })
 
   // TODO un-skip this test after fixing useEffect re-render issue (properly)
-  xtest('intermediate re-render does not cause value to revert', () => {
+  test('intermediate re-render does not cause value to revert', () => {
     renderWithTheme(<RerenderRepro />)
 
     const minThumb = screen.getByLabelText('Minimum Value')

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -30,10 +30,10 @@ import React, {
   Ref,
   useState,
   KeyboardEvent,
-  useRef,
-  useEffect,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
 } from 'react'
 import {
   SpaceProps,
@@ -41,9 +41,8 @@ import {
   space,
   typography,
   TypographyProps,
-  width,
-  WidthProps,
 } from '@looker/design-tokens'
+import { WidthProps } from 'styled-system'
 import styled from 'styled-components'
 import sortBy from 'lodash/sortBy'
 import indexOf from 'lodash/indexOf'
@@ -252,7 +251,11 @@ export const InternalRangeSlider = forwardRef(
     const maxPos = ((maxValue - min) / (max - min)) * containerRect.width
     const fillWidth = maxPos - minPos
 
-    // Behavioral callbacks
+    /*
+     * Behavioral callbacks
+     * ------------------------------------------------------
+     */
+
     const roundSliderValue = partial(roundToStep, min, max, step)
 
     const focusChangedPoint = useCallback(
@@ -356,9 +359,11 @@ export const InternalRangeSlider = forwardRef(
       [handleMouseEvent]
     )
 
-    // Mouse down event (and re-measure the client rectangle values before calculating value).
-    // This ensures accurate calculation when slider has moved to new location on page due
-    // to asynchronous dom changes.
+    /*
+     * Mouse down event (and re-measure the client rectangle values before calculating value).
+     * This ensures accurate calculation when slider has moved to new location on page due
+     * to asynchronous dom changes.
+     */
     useEffect(() => {
       if (isMouseDown) {
         refreshDomRect() // re-measure rectangle when isMouseDown changes from false to true
@@ -371,14 +376,18 @@ export const InternalRangeSlider = forwardRef(
       }
     }, [isMouseDown, handleMouseDown, containerRect])
 
-    // Only fire mouse drag event when mouse moves AFTER initial click
+    /*
+     * Only fire mouse drag event when mouse moves AFTER initial click
+     */
     useEffect(() => {
       if (isMouseDown && previousIsMouseDown) {
         handleMouseDrag()
       }
     }, [isMouseDown, previousIsMouseDown, handleMouseDrag, mousePos])
 
-    // Controlled Component: update value state when external value prop changes
+    /*
+     * Controlled Component: update value state when external value prop changes
+     */
     const previousValueProp = usePreviousValue(valueProp)
     useEffect(() => {
       const boundedValueProp = boundValueProp(min, max, valueProp)
@@ -391,7 +400,9 @@ export const InternalRangeSlider = forwardRef(
       }
     }, [valueProp, previousValueProp, value, min, max])
 
-    // Call onChange if min/max update and valueProp is not within them
+    /*
+     * Call onChange if min/max update and valueProp is not within them
+     */
     useEffect(() => {
       const boundedValueProp = boundValueProp(min, max, valueProp)
       if (valueProp && !isEqual(valueProp, boundedValueProp)) {
@@ -399,7 +410,11 @@ export const InternalRangeSlider = forwardRef(
       }
     }, [valueProp, onChange, min, max])
 
-    // Render markup!
+    /*
+     * Render markup!
+     * -------------------------------------------
+     */
+
     return (
       <div
         data-testid="range-slider-wrapper"
@@ -479,7 +494,6 @@ export const RangeSlider = styled(InternalRangeSlider).attrs<RangeSliderProps>(
   ${reset}
   ${space}
   ${typography}
-  ${width}
   padding: 1.5rem 0 0.5rem;
   touch-action: none;
   user-select: none;

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -41,8 +41,9 @@ import {
   space,
   typography,
   TypographyProps,
+  width,
+  WidthProps,
 } from '@looker/design-tokens'
-import { WidthProps } from 'styled-system'
 import styled from 'styled-components'
 import sortBy from 'lodash/sortBy'
 import indexOf from 'lodash/indexOf'
@@ -235,12 +236,25 @@ export const InternalRangeSlider = forwardRef(
     }, [valueMin, valueMax])
 
     // Controlled Component: update value state when external value prop changes
+    const previousValueProp = usePreviousValue(valueProp)
     useEffect(() => {
       const boundedValueProp = boundValueProp(min, max, valueProp)
-      if (valueProp && !isEqual(value, boundedValueProp)) {
+      if (
+        valueProp &&
+        !isEqual(value, boundedValueProp) &&
+        !isEqual(valueProp, previousValueProp)
+      ) {
         setValue(sort(boundedValueProp))
       }
-    }, [valueProp, value, min, max])
+    }, [valueProp, previousValueProp, value, min, max])
+
+    // Call onChange if min/max update and valueProp is not within them
+    useEffect(() => {
+      const boundedValueProp = boundValueProp(min, max, valueProp)
+      if (valueProp && !isEqual(valueProp, boundedValueProp)) {
+        onChange?.(sort(boundedValueProp))
+      }
+    }, [valueProp, onChange, min, max])
 
     const [containerRef, setContainerRef] = useState<HTMLElement | null>(null)
     const [focusedThumb, setFocusedThumb] = useState<ThumbIndices>()
@@ -465,6 +479,7 @@ export const RangeSlider = styled(InternalRangeSlider).attrs<RangeSliderProps>(
   ${reset}
   ${space}
   ${typography}
+  ${width}
   padding: 1.5rem 0 0.5rem;
   touch-action: none;
   user-select: none;

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -235,27 +235,6 @@ export const InternalRangeSlider = forwardRef(
       return [valueMin, valueMax]
     }, [valueMin, valueMax])
 
-    // Controlled Component: update value state when external value prop changes
-    const previousValueProp = usePreviousValue(valueProp)
-    useEffect(() => {
-      const boundedValueProp = boundValueProp(min, max, valueProp)
-      if (
-        valueProp &&
-        !isEqual(value, boundedValueProp) &&
-        !isEqual(valueProp, previousValueProp)
-      ) {
-        setValue(sort(boundedValueProp))
-      }
-    }, [valueProp, previousValueProp, value, min, max])
-
-    // Call onChange if min/max update and valueProp is not within them
-    useEffect(() => {
-      const boundedValueProp = boundValueProp(min, max, valueProp)
-      if (valueProp && !isEqual(valueProp, boundedValueProp)) {
-        onChange?.(sort(boundedValueProp))
-      }
-    }, [valueProp, onChange, min, max])
-
     const [containerRef, setContainerRef] = useState<HTMLElement | null>(null)
     const [focusedThumb, setFocusedThumb] = useState<ThumbIndices>()
 
@@ -398,6 +377,27 @@ export const InternalRangeSlider = forwardRef(
         handleMouseDrag()
       }
     }, [isMouseDown, previousIsMouseDown, handleMouseDrag, mousePos])
+
+    // Controlled Component: update value state when external value prop changes
+    const previousValueProp = usePreviousValue(valueProp)
+    useEffect(() => {
+      const boundedValueProp = boundValueProp(min, max, valueProp)
+      if (
+        valueProp &&
+        !isEqual(value, boundedValueProp) &&
+        !isEqual(valueProp, previousValueProp)
+      ) {
+        setValue(sort(boundedValueProp))
+      }
+    }, [valueProp, previousValueProp, value, min, max])
+
+    // Call onChange if min/max update and valueProp is not within them
+    useEffect(() => {
+      const boundedValueProp = boundValueProp(min, max, valueProp)
+      if (valueProp && !isEqual(valueProp, boundedValueProp)) {
+        onChange?.(sort(boundedValueProp))
+      }
+    }, [valueProp, onChange, min, max])
 
     // Render markup!
     return (


### PR DESCRIPTION
If `RangeSlider` is rendered inside a component with a "double re-render", e.g. one state variable is set due to the `onChange` being called, then another state variable is set in a `useEffect` as a result of the first state change, or certain implementations of redux can cause this, then it exposes a bug where the value is continually reverted: https://looker-open-source.github.io/components/canary/storybook/?path=/story/rangeslider--rerender-repro&globals=measureEnabled:false

My first attempt to fix this https://github.com/looker-open-source/components/pull/2174 introduced a different bug where the value would not respond to min/max changes.

This time around, my approach was to remove all the `// eslint-disable-next-line react-hooks/exhaustive-deps`, since breaking this rule does lead to confusing behavior (and the min/max bug I introduced), and add `useMemo` / `useCallback` as necessary.

To verify that this fix wouldn't introduce regressions in the core product, I created a test-only PR in that repo (see ticket comment).