### PR TITLE
fix(InputSearch): Return focus to input after clearing

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/ComboboxInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxInput.tsx
@@ -72,6 +72,7 @@ export const ComboboxInputInternal = forwardRef(
       data: { navigationOption, option, inputValue: contextInputValue },
       onChange: contextOnChange,
       inputCallbackRef,
+      inputElement,
       state,
       transition,
       id,
@@ -87,6 +88,7 @@ export const ComboboxInputInternal = forwardRef(
     function handleClear() {
       contextOnChange && contextOnChange(undefined)
       transition && transition(ComboboxActionType.CLEAR)
+      inputElement?.focus()
     }
 
     function handleValueChange(value: string) {

--- a/packages/components/src/Form/Inputs/InputSearch/InputSearch.test.tsx
+++ b/packages/components/src/Form/Inputs/InputSearch/InputSearch.test.tsx
@@ -92,6 +92,8 @@ describe('InputSearch', () => {
       fireEvent.click(button)
       expect(screen.getByPlaceholderText('type here')).toHaveDisplayValue('')
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
+      const input = screen.getByRole('textbox')
+      expect(input).toHaveFocus()
     })
 
     test('calls onChange', () => {


### PR DESCRIPTION
Adds `focus()` to the clear button handler in `ComboboxInput`. (`InputSearch` is the most obvious use case but this also affects `Select` and `SelectMulti` if they have `isClearable`).

- [ ] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11
