### PR TITLE
fix(InputColor): Incorrect coloring and positioning when hueless or saturationless color is provided

### DIFF
--- a/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.test.ts
+++ b/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.test.ts
@@ -1,0 +1,75 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { stringToSimpleHsv } from './stringToSimpleHsv'
+
+describe('stringToSimpleHsv', () => {
+  describe('red', () => {
+    test('converts hex to hsv', () => {
+      const { h, s, v } = stringToSimpleHsv('#FF0000')
+      expect(h).toBe(0)
+      expect(s).toBe(1)
+      expect(v).toBe(1)
+    })
+
+    test('converts color name to hsv', () => {
+      const { h, s, v } = stringToSimpleHsv('red')
+      expect(h).toBe(0)
+      expect(s).toBe(1)
+      expect(v).toBe(1)
+    })
+  })
+
+  /**
+   * We have a specific test suite for black, white and grey
+   * because d3-hsv, which we use for string to hsv conversions,
+   * will return NaN for h and s values when a given color is
+   * hueless and saturationless. We need these values to not be NaN
+   * when calculating handle position for the hue slider and saturation preview.
+   */
+  describe('hueless and saturationless colors', () => {
+    test('returns object with h = 0 and s = 0 when using "black"', () => {
+      const { h, s, v } = stringToSimpleHsv('black')
+      expect(h).toBe(0)
+      expect(s).toBe(0)
+      expect(v).toBe(0)
+    })
+
+    test('returns object with h = 0 when using "white"', () => {
+      const { h, s, v } = stringToSimpleHsv('white')
+      expect(h).toBe(0)
+      expect(s).toBe(0)
+      expect(v).toBe(1)
+    })
+
+    test('returns object with h = 0 when using "grey"', () => {
+      const { h, s, v } = stringToSimpleHsv('grey')
+      expect(h).toBe(0)
+      expect(s).toBe(0)
+      expect(v).toBe(0.5019607843137255)
+    })
+  })
+})

--- a/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
+++ b/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
@@ -29,17 +29,17 @@ import { SimpleHSV } from '../types'
 
 export const stringToSimpleHsv = (color: string): SimpleHSV => {
   const hsvColor = hsv(color)
-
+  let { h, s, v } = hsv(color)
   /**
-   * The hsv helper function returns NaN for hueless and saturationless values
+   * The hsv helper function returns NaN for hueless and saturation-less values
    * like black, white, grey. We will instead send 0 if either value is NaN for use
    * when calculating handle positioning and coloring on the hue slider and saturation preview.
    *
-   * 0 is used as a fallback value to mirror MDN's handling of hueless and saturationless values:
+   * 0 is used as a fallback value to mirror MDN's handling of hueless and saturation-less values:
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color
    */
-  const hue = isNaN(hsvColor.h) ? 0 : hsvColor.h
-  const saturation = isNaN(hsvColor.s) ? 0 : hsvColor.s
+  if(isNaN(h)) h = 0
+  if(isNaN(s)) s = 0
 
-  return { h: hue, s: saturation, v: hsvColor.v }
+  return { h, s, v }
 }

--- a/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
+++ b/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
@@ -29,5 +29,13 @@ import { SimpleHSV } from '../types'
 
 export const stringToSimpleHsv = (color: string): SimpleHSV => {
   const hsvColor = hsv(color)
-  return { h: hsvColor.h, s: hsvColor.s, v: hsvColor.v }
+  /**
+   * The hsv helper function returns NaN for hueless and saturationless values
+   * like black, white, grey. We will instead send 0 if either value is NaN for use
+   * when calculating handle positioning and coloring on the hue slider and saturation preview.
+   */
+  const hue = isNaN(hsvColor.h) ? 0 : hsvColor.h
+  const saturation = isNaN(hsvColor.s) ? 0 : hsvColor.s
+
+  return { h: hue, s: saturation, v: hsvColor.v }
 }

--- a/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
+++ b/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
@@ -28,7 +28,6 @@ import { hsv } from 'd3-hsv'
 import { SimpleHSV } from '../types'
 
 export const stringToSimpleHsv = (color: string): SimpleHSV => {
-  const hsvColor = hsv(color)
   let { h, s, v } = hsv(color)
   /**
    * The hsv helper function returns NaN for hueless and saturation-less values
@@ -38,8 +37,8 @@ export const stringToSimpleHsv = (color: string): SimpleHSV => {
    * 0 is used as a fallback value to mirror MDN's handling of hueless and saturation-less values:
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color
    */
-  if(isNaN(h)) h = 0
-  if(isNaN(s)) s = 0
+  if (isNaN(h)) h = 0
+  if (isNaN(s)) s = 0
 
   return { h, s, v }
 }

--- a/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
+++ b/packages/components/src/Form/Inputs/InputColor/utils/stringToSimpleHsv.ts
@@ -29,10 +29,14 @@ import { SimpleHSV } from '../types'
 
 export const stringToSimpleHsv = (color: string): SimpleHSV => {
   const hsvColor = hsv(color)
+
   /**
    * The hsv helper function returns NaN for hueless and saturationless values
    * like black, white, grey. We will instead send 0 if either value is NaN for use
    * when calculating handle positioning and coloring on the hue slider and saturation preview.
+   *
+   * 0 is used as a fallback value to mirror MDN's handling of hueless and saturationless values:
+   * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color
    */
   const hue = isNaN(hsvColor.h) ? 0 : hsvColor.h
   const saturation = isNaN(hsvColor.s) ? 0 : hsvColor.s


### PR DESCRIPTION
- Added fallback values to `simpleStringToHsv` function to prevent NaN values from appearing in color state's h and s values
- Added tests to assure that we replace NaN values with default values (i.e. 0)

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
