### PR TITLE
docs(DataTable): Clarify numeric-width (percentage) column behavior

### DIFF
--- a/packages/components/src/DataTable/Column/column.ts
+++ b/packages/components/src/DataTable/Column/column.ts
@@ -59,10 +59,10 @@ export interface DataTableColumn {
    * `auto` columns will use browser-native table column behavior.
    * `small`, `medium`, & `large` are the predefined sizes and will truncate
    * `nowrap` - column will not truncate and content will not wrap. Use with caution.
-   * 0-100 (number) - width is a percentage of the table's width.
+   * `0-100` (number) - width is a percentage of the table's width.
    *    Columns sized as a percentage do not support truncation.
    *    Mixing percentage columns with other sizing formats is not supported and yields
-   *    unpredictable behavior. If percentages of all columns to not total 100 column widths
+   *    unpredictable behavior. If percentages of all columns do not total 100% column widths
    *    may be somewhat unpredictable as well (browser table column calculations vary widely
    *    in these scenarios)
    *

--- a/www/package.json
+++ b/www/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@looker/components": "*",
     "@looker/components-theme-editor": "*",
-    "@looker/components-date": "^2.0.0-alpha",
+    "@looker/components-date": "*",
     "@looker/filter-components": "*",
     "@looker/design-tokens": "*",
     "@looker/icons": "*",

--- a/www/src/MDX/Headings.tsx
+++ b/www/src/MDX/Headings.tsx
@@ -30,7 +30,7 @@ import styled from 'styled-components'
 import { maxTextWidth } from './styles'
 
 const generateHeadingAnchor = (children?: ReactNode) => {
-  return (children as string).toLowerCase().replace(/\s/g, '-')
+  return String(children).toLowerCase().replace(/\s/g, '-')
 }
 
 const StyledHeading = styled(Heading).attrs<HeadingProps>(

--- a/www/src/documentation/components/content/data-table.mdx
+++ b/www/src/documentation/components/content/data-table.mdx
@@ -17,7 +17,7 @@ For accessibility `caption` must be specified to describe the table's contents.
 
 ## Columns
 
-`DataTableColumn`s are defined as an array of objects that confirm the the `DataTableColumn` interface:
+`DataTableColumn`s are defined as an array of objects that conform to the `DataTableColumn` interface:
 
 ### **title** (required)
 

--- a/www/src/documentation/components/content/data-table.mdx
+++ b/www/src/documentation/components/content/data-table.mdx
@@ -15,6 +15,42 @@ The `<DataTable>` component acts as the main wrapper to other `<DataTable>`-rela
 
 For accessibility `caption` must be specified to describe the table's contents.
 
+## Columns
+
+`DataTableColumn`s are defined as an array of objects that confirm the the `DataTableColumn` interface:
+
+### **title** (required)
+
+- `title` for the column
+- `titleIcon` is an `Icon` specified instead of the title text in the header row.
+  - NOTE: `title` will still be used in column selector and will be added as a tooltip to the icon displayed in the header row.
+
+### **id** (required)
+
+A unique identifier for a given column. NOTE: A column object's id should match a key in your data object template, see example below.
+
+### **type**
+
+Defaults to `string`. In some locales, we may change horizontal alignment of 'number'
+
+- `string`
+- `number`
+- `date`
+
+### **size**
+
+Specify a size to have the column consume a fixed width. Defaults to `auto`
+
+For content that is not expected to wrap `auto` is often the best choice as the column will only consume the horizontal room needed to contain its content.
+
+- `auto` columns will use browser-native table column behavior.
+- `small`, `medium`, & `large` are the predefined sizes and will truncate
+- `nowrap` - column will not truncate and content will not wrap. Use with caution.
+- `0-100` (number) - width is a percentage of the table's width.
+  - Columns sized as a percentage do not support truncation.
+  - Mixing percentage columns with other sizing formats is not supported and yields unpredictable behavior.
+  - If percentages of all columns do not total 100% column widths may be somewhat unpredictable as well (browser table column calculations vary widely in these scenarios)
+
 ```jsx
 ;() => {
   const data = [


### PR DESCRIPTION
Clarifies behavior of `DataTable` columns when a percentage (numeric) width is used.

- [x] 📚 Documentation updated
