### PR TITLE
fix(RadioGroup): correct usage of `defaultValue` in documentation

### DIFF
--- a/www/src/documentation/components/forms/radio-group.mdx
+++ b/www/src/documentation/components/forms/radio-group.mdx
@@ -32,13 +32,8 @@ Groups of radio can be displayed with `RadioGroup`. `Disabled` can be used on ea
 
   return (
     <Grid m="xxlarge">
-      <RadioGroup defaultValue={['cheddar']} name="group1" options={options} />
-      <RadioGroup
-        defaultValue={['cheddar']}
-        inline
-        name="group1"
-        options={options}
-      />
+      <RadioGroup defaultValue={'cheddar'} name="group1" options={options} />
+      <RadioGroup inline name="group1" options={options} />
       <RadioGroup name="group1" options={optionsDisabled} />
       <RadioGroup inline name="group1" options={optionsDisabled} />
       <RadioGroup disabled name="group1" options={options} />


### PR DESCRIPTION

- [x] 📚 Documentation updated
