### PR TITLE
fix(DataTable): Corrects issue where "All Selected" checkbox is checked when `selectedItems=0` and `pageItems=0` (easily triggered by loading state)

### DIFF
--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -386,6 +386,25 @@ describe('DataTable', () => {
       const checkbox = screen.getAllByRole('checkbox')[4]
       expect(checkbox as HTMLInputElement).not.toBeChecked()
     })
+
+    test('Selection - no pageItems & no selectedItems', () => {
+      renderWithTheme(
+        <DataTable
+          caption="this is a table's caption"
+          columns={columns}
+          select={{
+            ...defaultSelectConfig,
+            pageItems: [],
+            selectedItems: [],
+          }}
+        >
+          {items}
+        </DataTable>
+      )
+
+      const checkbox = screen.getAllByRole('checkbox')[0]
+      expect(checkbox as HTMLInputElement).not.toBeChecked()
+    })
   })
 
   describe('Selecting All', () => {

--- a/packages/components/src/DataTable/DataTable.tsx
+++ b/packages/components/src/DataTable/DataTable.tsx
@@ -26,12 +26,12 @@
 
 import styled from 'styled-components'
 import React, { FC, useState } from 'react'
-import { MixedBoolean } from '../Form'
 import { BulkActions } from './BulkActions'
 import { DataTableContext } from './DataTableContext'
 import { DataTableFilters } from './Filters/DataTableFilters'
 import { Table } from './Table'
 import { DataTableProps } from './types'
+import { allItemsSelected } from './utils/allItemsSelected'
 
 export const DataTableLayout: FC<DataTableProps> = (props) => {
   const {
@@ -80,16 +80,8 @@ export const DataTableLayout: FC<DataTableProps> = (props) => {
       ? explicitFirstColumnStuck
       : Boolean(select)
 
-  const allSelected: MixedBoolean =
-    select && select.pageItems.every((id) => select.selectedItems.includes(id))
-      ? true
-      : select &&
-        select.pageItems.some((id) => select.selectedItems.includes(id))
-      ? 'mixed'
-      : false
-
   const context = {
-    allSelected,
+    allSelected: allItemsSelected(select),
     columns,
     columnsDisplayState,
     onSort,

--- a/packages/components/src/DataTable/stories/Interaction.tsx
+++ b/packages/components/src/DataTable/stories/Interaction.tsx
@@ -112,8 +112,8 @@ const Template: Story<DemoProps> = ({
   const selectConfig: SelectConfig = {
     onSelect,
     onSelectAll,
-    pageItems: allPageItems,
-    selectedItems: selections,
+    pageItems: [],
+    selectedItems: [],
   }
 
   const bulkActionsConfig: BulkActionsConfig = {

--- a/packages/components/src/DataTable/utils/allItemsSelected.ts
+++ b/packages/components/src/DataTable/utils/allItemsSelected.ts
@@ -23,30 +23,17 @@
  SOFTWARE.
 
  */
-process.env.TZ = 'PST8PDT'
 
-module.exports = {
-  automock: false,
-  collectCoverage: true,
-  collectCoverageFrom: [
-    'packages/**/*.(ts)?(x)',
-    '!packages/components-theme-editor/**/*',
-    '!packages/**/stories/*',
-    '!packages/**/*.stories.tsx',
-    '!packages/**/*.story.tsx',
-    '!packages/icons/src/**/*',
-    '!packages/**/index.ts',
-    '!packages/**/types.ts',
-  ],
-  coverageReporters: ['json', 'html', 'lcov', 'text-summary'],
-  moduleDirectories: ['./node_modules', './packages'],
-  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
-  moduleNameMapper: {
-    '@looker\\/((?!sdk)[^\\/]+)': '<rootDir>/packages/$1/src',
-    '\\.(css)$': '<rootDir>/config/jest/styleMock.js',
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      '<rootDir>/config/jest/fileMock.js',
-  },
-  setupFilesAfterEnv: ['./jest.setup.js'],
-  testMatch: ['**/?(*.)(spec|test).(ts|js)?(x)'],
+import { MixedBoolean } from '../../Form/Inputs/Checkbox'
+import { SelectConfig } from '../types'
+
+export const allItemsSelected = (select?: SelectConfig): MixedBoolean => {
+  if (!select) return false
+
+  const { selectedItems, pageItems } = select
+
+  if (selectedItems.length === 0) return false
+  else if (pageItems.every((id) => selectedItems.includes(id))) return true
+  else if (pageItems.some((id) => selectedItems.includes(id))) return 'mixed'
+  else return false
 }


### PR DESCRIPTION
- [x] 🖼 Image Snapshot coverage
- [ ] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
