### PR TITLE
fix(MenuItem): SVG error when opening a nested menu

### DIFF
--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -26,7 +26,7 @@
 
 import styled from 'styled-components'
 import React, { forwardRef, Ref, useContext } from 'react'
-import { size } from '@looker/design-tokens'
+import { shouldForwardProp, size } from '@looker/design-tokens'
 import { ArrowRight } from '@styled-icons/material/ArrowRight'
 import { DialogContext } from '../Dialog'
 import {
@@ -120,7 +120,9 @@ MenuItemInternal.displayName = 'MenuItemInternal'
 
 export const MenuItem = styled(MenuItemInternal)``
 
-const NestedMenuIndicator = styled(ArrowRight)`
+const NestedMenuIndicator = styled(ArrowRight).withConfig({
+  shouldForwardProp,
+})`
   color: ${({ theme }) => theme.colors.text1};
   ${size}
 `


### PR DESCRIPTION
Fixes an SVG attribute error message in the console when opening a nested menu:
![image](https://user-images.githubusercontent.com/53451193/125506225-6f860047-f231-461a-b124-a15ef2ac8fc0.png)