### PR TITLE
fix(Menu): Close the parent menu after clicking a nested menu item

### DIFF
--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -617,8 +617,11 @@ ArrowKeyNavigation.parameters = {
 }
 
 export const NestedMenu = () => {
-  const getOnClick = (text: string) => () => {
+  const getOnClick = (text: string) => (e: MouseEvent<HTMLLIElement>) => {
     alert(`You clicked ${text}`)
+    if (text === 'preventDefault') {
+      e.preventDefault()
+    }
   }
 
   const nestedMenu = (
@@ -630,6 +633,7 @@ export const NestedMenu = () => {
       <MenuItem onClick={getOnClick('Third Sub Item')}>Third Sub Item</MenuItem>
       <MenuItem onClick={getOnClick('4th Sub Item')}>4th Sub Item</MenuItem>
       <MenuItem onClick={getOnClick('Fifth Sub Item')}>Fifth Sub Item</MenuItem>
+      <MenuItem onClick={getOnClick('preventDefault')}>preventDefault</MenuItem>
     </>
   )
   const content = (

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -352,5 +352,32 @@ describe('<Menu />', () => {
       expect(onClick).toHaveBeenCalledTimes(1)
       expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     })
+
+    test('clicking an item in the nested menu closes the parent menu', () => {
+      const onClick = jest.fn()
+      renderWithTheme(
+        <Menu
+          content={
+            <MenuItem
+              nestedMenu={<MenuItem onClick={onClick}>Camembert</MenuItem>}
+            >
+              French
+            </MenuItem>
+          }
+        >
+          <Button>Cheese</Button>
+        </Menu>
+      )
+
+      // Open menu and nested menu
+      userEvent.click(screen.getByText('Cheese'))
+      fireEvent.keyDown(screen.getByText('French'), { key: 'ArrowRight' })
+
+      // Click an item in the nested menu
+      userEvent.click(screen.getByText('Camembert'))
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -33,7 +33,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import React, { useRef } from 'react'
+import React, { MouseEvent as ReactMouseEvent, useRef } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Favorite } from '@styled-icons/material-outlined/Favorite'
 import { Button } from '../Button'
@@ -94,7 +94,7 @@ describe('<Menu />', () => {
 
   test('closes on MenuItem click', () => {
     const Closable = () => {
-      function handleClick(e: React.MouseEvent<HTMLLIElement>) {
+      function handleClick(e: ReactMouseEvent<HTMLLIElement>) {
         e.preventDefault()
       }
       return (
@@ -378,6 +378,40 @@ describe('<Menu />', () => {
 
       expect(onClick).toHaveBeenCalledTimes(1)
       expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+
+    test('item with preventDefault', () => {
+      const onClickMock = jest.fn()
+      const handleClick = (e: ReactMouseEvent<HTMLLIElement>) => {
+        onClickMock()
+        e.preventDefault()
+      }
+      renderWithTheme(
+        <Menu
+          content={
+            <MenuItem
+              nestedMenu={<MenuItem onClick={handleClick}>Camembert</MenuItem>}
+            >
+              French
+            </MenuItem>
+          }
+        >
+          <Button>Cheese</Button>
+        </Menu>
+      )
+
+      // Open menu and nested menu
+      userEvent.click(screen.getByText('Cheese'))
+      const parent = screen.getByText('French')
+      fireEvent.keyDown(parent, { key: 'ArrowRight' })
+
+      // Click an item in the nested menu
+      const child = screen.getByText('Camembert')
+      userEvent.click(screen.getByText('Camembert'))
+
+      expect(onClickMock).toHaveBeenCalledTimes(1)
+      expect(child).toBeVisible()
+      expect(parent).toBeVisible()
     })
   })
 })

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -25,7 +25,7 @@
  */
 
 import styled from 'styled-components'
-import React, { forwardRef, Ref, useContext } from 'react'
+import React, { forwardRef, MouseEvent, Ref, useContext } from 'react'
 import { shouldForwardProp, size } from '@looker/design-tokens'
 import { ArrowRight } from '@styled-icons/material/ArrowRight'
 import { DialogContext } from '../Dialog'
@@ -36,6 +36,7 @@ import {
   listItemDimensions,
 } from '../ListItem'
 import { useForkedRef, useID } from '../utils'
+import { NestedMenuContext } from './NestedMenuProvider'
 import { useNestedMenu, UseNestedMenuProps } from './useNestedMenu'
 
 export interface MenuItemProps
@@ -86,13 +87,15 @@ const MenuItemInternal = forwardRef(
     detail = nestedMenu ? <NestedMenuIndicator size={iconSize} /> : detail
 
     const { closeModal } = useContext(DialogContext)
+    const { closeParentMenu } = useContext(NestedMenuContext)
 
-    const handleOnClick = (event: React.MouseEvent<HTMLLIElement>) => {
+    const handleOnClick = (event: MouseEvent<HTMLLIElement>) => {
       // nestedMenuOnClick wraps onClick from props
       nestedMenuOnClick(event)
       // Close the Menu unless event has preventDefault
-      if (closeModal && !event.defaultPrevented) {
-        closeModal()
+      if (!event.defaultPrevented) {
+        closeModal?.()
+        closeParentMenu?.()
       }
     }
 

--- a/packages/components/src/Menu/MenuList.tsx
+++ b/packages/components/src/Menu/MenuList.tsx
@@ -28,15 +28,17 @@ import React, { forwardRef, Ref } from 'react'
 import styled from 'styled-components'
 import { List, ListProps } from '../List'
 import { listPadding } from '../List/utils'
-import { NestedMenuProvider } from './NestedMenuProvider'
+import { CloseParentMenuProps, NestedMenuProvider } from './NestedMenuProvider'
+
+export type MenuListProps = Omit<ListProps, 'color'> & CloseParentMenuProps
 
 export const MenuListInternal = forwardRef(
   (
-    { children, ...props }: Omit<ListProps, 'color'>,
+    { children, closeParentMenu, ...props }: MenuListProps,
     forwardedRef: Ref<HTMLUListElement>
   ) => {
     return (
-      <NestedMenuProvider>
+      <NestedMenuProvider closeParentMenu={closeParentMenu}>
         <List role="menu" ref={forwardedRef} {...props}>
           {children}
         </List>

--- a/packages/components/src/Menu/NestedMenuProvider.tsx
+++ b/packages/components/src/Menu/NestedMenuProvider.tsx
@@ -27,7 +27,14 @@
 import React, { FC, createContext } from 'react'
 import { useDelayedState, UseDelayedStateReturn } from '../utils'
 
-const nestedMenuContext: UseDelayedStateReturn<string> = {
+export type CloseParentMenuProps = {
+  closeParentMenu?: () => void
+}
+
+export type NestedMenuContextProps = UseDelayedStateReturn<string> &
+  CloseParentMenuProps
+
+const nestedMenuContext: NestedMenuContextProps = {
   change: () => undefined,
   delayChange: () => undefined,
   value: '',
@@ -38,10 +45,15 @@ export const NestedMenuContext = createContext(nestedMenuContext)
 
 // Stores the id for the current nestedMenu to prevent them
 // from competing with each other (e.g. from hover vs arrow key)
-export const NestedMenuProvider: FC = ({ children }) => {
-  const nestedMenuProps = useDelayedState<string>('')
+export const NestedMenuProvider: FC<CloseParentMenuProps> = ({
+  children,
+  closeParentMenu,
+}) => {
+  const delayedStateProps = useDelayedState<string>('')
   return (
-    <NestedMenuContext.Provider value={nestedMenuProps}>
+    <NestedMenuContext.Provider
+      value={{ ...delayedStateProps, closeParentMenu }}
+    >
       {children}
     </NestedMenuContext.Provider>
   )

--- a/packages/components/src/Menu/useNestedMenu.tsx
+++ b/packages/components/src/Menu/useNestedMenu.tsx
@@ -192,7 +192,12 @@ export const useNestedMenu = ({
 
   const { popover, popperInstanceRef, domProps } = usePopover({
     content: (
-      <MenuList data-autofocus="true" density={density} {...listHandlers}>
+      <MenuList
+        data-autofocus="true"
+        density={density}
+        {...listHandlers}
+        closeParentMenu={closeModal}
+      >
         {nestedMenu}
       </MenuList>
     ),


### PR DESCRIPTION
Clicking a nested menu item now closes the parent menu (unless `preventDefault()` has been called on the event).

I added a `closeParentMenu` callback to `NestedMenuContext` and call that, if present, from the `MenuItem` click handler.