### PR TITLE
fix(DataTable): Stop explicitly removing scrollbar from DataTable overflow behavior

### DIFF
--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -226,8 +226,4 @@ const InterimState = styled.div`
 
 export const TableScroll = styled.div`
   overflow-x: auto;
-  scrollbar-width: none; /* Firefox */
-  ::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
 `


### PR DESCRIPTION
Additional context available in: https://b.corp.google.com/issues/194313414

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
