### PR TITLE
fix(IconButton): IconButton label should support same typing as Tooltip content

### DIFF
--- a/packages/components/src/Button/iconButtonTypes.ts
+++ b/packages/components/src/Button/iconButtonTypes.ts
@@ -36,6 +36,7 @@ import {
 import { Placement } from '@popperjs/core'
 import { Property } from 'csstype'
 import { IconProps } from '../Icon'
+import { TooltipProps } from '../Tooltip'
 import { ButtonBaseProps } from './types'
 interface IconButtonVariantProps {
   /**
@@ -78,7 +79,7 @@ export interface IconButtonProps
   /**
    *  A hidden text label for the IconButton that is accessible to assistive technology
    */
-  label: string
+  label: TooltipProps['content']
   /**
    *  Sets the size of the button
    * @default xsmall


### PR DESCRIPTION
IconButton's label element is used to propagate a tooltip applied to the `IconButton`. With that in mind they should share the same typing

Bug: https://buganizer.corp.google.com/issues/194341079


## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [ ] 👾 Browsers tested
  - [x] Chrome
  - [ ] Firefox