### PR TITLE
fix(Field): Correct tab-stop order of `Field` & `FieldInline`

### DIFF
--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -130,8 +130,8 @@ const FieldLayout: FunctionComponent<FieldPropsInternal> = ({
       ) : (
         labelComponent
       )}
-      {detail && <FieldDetail>{detail}</FieldDetail>}
       <InputArea>{children}</InputArea>
+      {detail && <FieldDetail>{detail}</FieldDetail>}
       <MessageArea id={`describedby-${id}`}>
         {fieldDescription}
         {fieldValidation}

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -54,12 +54,12 @@ const FieldInlineLayout: FC<FieldInlinePropsInternal> = ({
 }) => {
   return (
     <label className={className} htmlFor={id}>
-      {detail && <FieldDetail>{detail}</FieldDetail>}
       <InputArea>{children}</InputArea>
       <Label as="span">
         <Truncate>{label}</Truncate>
         {required && <RequiredStar />}
       </Label>
+      {detail && <FieldDetail>{detail}</FieldDetail>}
       <MessageArea id={`${id}-describedby`}>
         {description && <FieldDescription>{description}</FieldDescription>}
         {validationMessage ? (

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.story.tsx
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.story.tsx
@@ -26,6 +26,8 @@
 
 import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
+import { Delete } from '@styled-icons/material/Delete'
+import { IconButton } from '../../../Button'
 import { FieldToggleSwitch, FieldToggleSwitchProps } from './FieldToggleSwitch'
 
 const Template: Story<FieldToggleSwitchProps> = (args) => (
@@ -45,6 +47,21 @@ DetailDescription.args = {
   description: 'describe something here.',
   detail: '4/20',
 }
+
+export const Tabstops = Template.bind({})
+Tabstops.args = {
+  ...Basic.args,
+  description: (
+    <>
+      describe something here. <a href="somewhere">Link</a>
+    </>
+  ),
+  detail: <IconButton icon={<Delete />} label="Hello world" />,
+}
+Tabstops.parameters = {
+  storyshots: { disable: true },
+}
+
 export const Checked = Template.bind({})
 Checked.args = {
   ...Basic.args,

--- a/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.test.tsx
+++ b/packages/components/src/Form/Fields/FieldToggleSwitch/FieldToggleSwitch.test.tsx
@@ -26,48 +26,67 @@
 
 import 'jest-styled-components'
 import React from 'react'
+import userEvent from '@testing-library/user-event'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
 import { FieldToggleSwitch } from './FieldToggleSwitch'
+import { Tabstops } from './FieldToggleSwitch.story'
 
-test('A FieldToggleSwitch with error has proper aria setup', () => {
-  const errorMessage = 'This is an error'
+describe('FieldToggleSwitch', () => {
+  test('error has proper aria setup', () => {
+    const errorMessage = 'This is an error'
 
-  const { container } = renderWithTheme(
-    <FieldToggleSwitch
-      id="test"
-      defaultValue="example"
-      validationMessage={{ message: errorMessage, type: 'error' }}
-    />
-  )
+    const { container } = renderWithTheme(
+      <FieldToggleSwitch
+        id="test"
+        defaultValue="example"
+        validationMessage={{ message: errorMessage, type: 'error' }}
+      />
+    )
 
-  const input = screen.getByDisplayValue('example')
-  const id = input.getAttribute('aria-describedby')
-  expect(id).toBeDefined()
-  expect(id).toEqual('describedby-test')
-  expect(container).toHaveTextContent(errorMessage)
-})
+    const input = screen.getByDisplayValue('example')
+    const id = input.getAttribute('aria-describedby')
+    expect(id).toBeDefined()
+    expect(id).toEqual('describedby-test')
+    expect(container).toHaveTextContent(errorMessage)
+  })
 
-test('A FieldToggleSwitch disabled', () => {
-  renderWithTheme(
-    <FieldToggleSwitch
-      disabled
-      id="FieldToggleSwitchID"
-      label="Toggle Switch"
-    />
-  )
+  test('disabled', () => {
+    renderWithTheme(
+      <FieldToggleSwitch
+        disabled
+        id="FieldToggleSwitchID"
+        label="Toggle Switch"
+      />
+    )
 
-  expect(screen.getByLabelText('Toggle Switch')).toBeDisabled()
-})
+    expect(screen.getByLabelText('Toggle Switch')).toBeDisabled()
+  })
 
-test('A FieldToggleSwitch required', () => {
-  renderWithTheme(
-    <FieldToggleSwitch
-      id="FieldToggleSwitchID"
-      label="Toggle Switch"
-      required
-    />
-  )
+  test('required', () => {
+    renderWithTheme(
+      <FieldToggleSwitch
+        id="FieldToggleSwitchID"
+        label="Toggle Switch"
+        required
+      />
+    )
 
-  expect(screen.getByTestId('requiredStar')).toBeVisible()
+    expect(screen.getByTestId('requiredStar')).toBeVisible()
+  })
+
+  test('tabStops', () => {
+    renderWithTheme(<Tabstops {...Tabstops.args} />)
+
+    const input = screen.getByRole('switch')
+    const detail = screen.getByRole('button')
+    const link = screen.getByText('Link')
+
+    userEvent.tab()
+    expect(input).toHaveFocus()
+    userEvent.tab()
+    expect(detail).toHaveFocus()
+    userEvent.tab()
+    expect(link).toHaveFocus()
+  })
 })


### PR DESCRIPTION
Grid layout allows for an easy refactor here to improve tab stop order of `Field` & `FieldInline`

Related ticket: https://buganizer.corp.google.com/issues/194388659

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [x] 🖼 Image Snapshot coverage
- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari