### PR TITLE
feat(ComponentsProvider): ThemeCustomizations should support overloading fontSources

### DIFF
--- a/packages/design-tokens/src/theme/ThemeCustomizations.ts
+++ b/packages/design-tokens/src/theme/ThemeCustomizations.ts
@@ -25,7 +25,7 @@
  */
 
 import { SpecifiableColors } from '../color'
-import { FontFamilyChoices } from '../system'
+import { FontFamilyChoices, FontSources } from '../system'
 
 export interface ThemeCustomizations {
   /**
@@ -38,4 +38,8 @@ export interface ThemeCustomizations {
    * support and fallbacks for browsers that can't load web fonts.
    */
   fontFamilies?: Partial<FontFamilyChoices>
+  /**
+   * Specify font sources
+   */
+  fontSources?: FontSources
 }

--- a/packages/design-tokens/src/theme/utils/generateTheme.test.ts
+++ b/packages/design-tokens/src/theme/utils/generateTheme.test.ts
@@ -317,4 +317,30 @@ describe('generateTheme', () => {
       }
     `)
   })
+
+  describe('fontSources', () => {
+    const generated = generateTheme(theme, {
+      fontSources: [
+        {
+          url: 'http://not-really-a.font.com',
+        },
+        {
+          face: 'Faux Font',
+          url: 'http://faux-font.com',
+        },
+      ],
+    })
+
+    expect(generated.fontSources).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "url": "http://not-really-a.font.com",
+        },
+        Object {
+          "face": "Faux Font",
+          "url": "http://faux-font.com",
+        },
+      ]
+    `)
+  })
 })

--- a/packages/design-tokens/src/theme/utils/generateTheme.ts
+++ b/packages/design-tokens/src/theme/utils/generateTheme.ts
@@ -38,6 +38,8 @@ export const generateTheme = (
     return theme
   }
 
+  const { fontSources } = customizations
+
   const fonts = customizations.fontFamilies
     ? generateFontFamilies(
         theme.fonts,
@@ -53,6 +55,7 @@ export const generateTheme = (
   return {
     ...theme,
     colors,
+    fontSources,
     fonts,
   }
 }


### PR DESCRIPTION
Currently `ThemeCustomizations` supports overloading `fontFamilies` but not `fontSources`. Both would be needed to successfully use a font-face that's not available on locally.