### PR TITLE
chore(Filter Packages): Build .js files and ignore .spec files

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,6 +30,8 @@ const ignore = [
   '**/*.test.jsx',
   '**/*.test.ts',
   '**/*.test.tsx',
+  '**/*.spec.ts',
+  '**/*.spec.tsx',
   '**/*.stories.tsx',
   '**/*.story.tsx',
   '**/stories/*',

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "scripts": {
     "prebuild": "yarn clean && yarn lerna run prebuild  --stream",
     "build": "run-p -c build:*",
-    "build:cjs": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name cjs --root-mode upward --out-dir lib/cjs --source-maps --extensions .ts,.tsx --no-comments'",
-    "build:esm": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name esm --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments'",
+    "build:cjs": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name cjs --root-mode upward --out-dir lib/cjs --source-maps --extensions .ts,.tsx,.js --no-comments'",
+    "build:esm": "yarn lerna exec --scope '@looker/*' --stream 'babel src --env-name esm --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments'",
     "build:ts": "yarn lerna exec --stream --scope '@looker/*' --sort 'tsc -b tsconfig.build.json'",
     "bumpversion": "yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes",
     "clean": "run-p -c clean:*",


### PR DESCRIPTION
* Files in the filter packages `./src/locales` folder were not getting built since they were `.js` file format – added `.js` to the build commands.
* `.spec` files were getting built unnecessarily – added them to the ignore section of `babel.config.js`