### PR TITLE
fix(Tree): Fixed Tree indent bug

### DIFF
--- a/packages/components/src/Tree/TreeItemContent.tsx
+++ b/packages/components/src/Tree/TreeItemContent.tsx
@@ -41,7 +41,7 @@ export const TreeItemContent = styled(
 ).attrs<TreeItemContentProps>(({ role = 'treeitem' }) => ({
   role,
 }))<TreeItemContentProps>`
-  ${generateIndent}
+  ${({ density, depth }) => generateIndent({ density, depth })}
   ${({ labelBackgroundOnly }) => labelBackgroundOnly && 'background: none;'}
   display: flex;
   flex: 1;


### PR DESCRIPTION
When built, `TreeItemContent` did not properly call the `generateIndent` function which led to `Tree / TreeItem`s from indenting properly. Calling the function explicitly in a wrapper arrow function resolves this behavior.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
