### PR TITLE
fix(Tree): Controlled isOpen

### DIFF
--- a/packages/components/src/Tree/Tree.test.tsx
+++ b/packages/components/src/Tree/Tree.test.tsx
@@ -24,11 +24,12 @@
 
  */
 
-import React, { useState } from 'react'
+import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Science } from '@styled-icons/material-outlined/Science'
 import { screen, fireEvent } from '@testing-library/react'
 import { Button } from '../Button'
+import { Controlled } from './stories/Tree.story'
 import { Tree } from '.'
 
 describe('Tree', () => {
@@ -74,22 +75,19 @@ describe('Tree', () => {
   })
 
   test('Handles controlled open state via isOpen and toggleOpen props', () => {
-    const Wrapper = () => {
-      const [isOpen, setIsOpen] = useState(true)
+    renderWithTheme(<Controlled />)
 
-      return (
-        <Tree label="Tree Label" isOpen={isOpen} toggleOpen={setIsOpen}>
-          Hello World
-        </Tree>
-      )
-    }
-
-    renderWithTheme(<Wrapper />)
-
-    const treeLabel = screen.getByText('Tree Label')
-    screen.getByText('Hello World')
+    const treeLabel = screen.getByText('Controlled Tree')
+    screen.getByText('Stuff here')
     fireEvent.click(treeLabel)
-    expect(screen.queryByText('Hello World')).not.toBeInTheDocument()
+    expect(screen.queryByText('Stuff here')).not.toBeInTheDocument()
+
+    fireEvent.click(treeLabel)
+    screen.getByText('Stuff here')
+
+    const toggleSwitch = screen.getByRole('switch')
+    fireEvent.click(toggleSwitch)
+    expect(screen.queryByText('Stuff here')).not.toBeInTheDocument()
   })
 
   test('Triggers onClose and onOpen callbacks when provided via props', () => {

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -161,7 +161,7 @@ const TreeLayout = ({
     onOpen,
     ...accordionInnerProps,
   }
-  if (isOpen && toggleOpen) {
+  if (isOpen !== undefined && toggleOpen) {
     accordionProps = { ...accordionProps, isOpen, toggleOpen }
   }
 

--- a/packages/components/src/Tree/stories/Tree.story.tsx
+++ b/packages/components/src/Tree/stories/Tree.story.tsx
@@ -31,6 +31,8 @@ import { Story } from '@storybook/react/types-6-0'
 import { Tree, TreeProps, TreeCollection, TreeItem } from '..'
 import { Button } from '../../Button'
 import { Space } from '../../Layout'
+import { FieldToggleSwitch } from '../../Form'
+import { useToggle } from '../../utils'
 
 export * from './BorderRadius.story'
 export * from './ColorfulTree.story'
@@ -120,5 +122,21 @@ Accessory.args = {
   },
 }
 Accessory.parameters = {
+  storyshots: { disable: true },
+}
+
+export const Controlled = () => {
+  const { value, change, toggle } = useToggle(true)
+
+  return (
+    <>
+      <FieldToggleSwitch on={value} onChange={toggle} label="Toggle" />
+      <Tree isOpen={value} toggleOpen={change} label="Controlled Tree">
+        Stuff here
+      </Tree>
+    </>
+  )
+}
+Controlled.parameters = {
   storyshots: { disable: true },
 }


### PR DESCRIPTION
Check `isOpen` for being defined rather than truthy to get correct accordion props.

Add story and update controlled test to catch this failure.