### PR TITLE
test(Badge): testing prop defaults

### DIFF
--- a/packages/components/src/Badge/Badge.test.tsx
+++ b/packages/components/src/Badge/Badge.test.tsx
@@ -28,8 +28,8 @@ import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
 import { Badge } from './Badge'
 
-describe('Defaults', () => {
-  test('Badge', () => {
+describe('Badge', () => {
+  test('Defaults', () => {
     renderWithTheme(<Badge>Good!</Badge>)
     const badge = screen.getByText('Good!')
     expect(badge).toHaveStyle('background: rgb(237, 232, 251)')

--- a/packages/components/src/Badge/Badge.test.tsx
+++ b/packages/components/src/Badge/Badge.test.tsx
@@ -28,13 +28,22 @@ import { renderWithTheme } from '@looker/components-test-utils'
 import { screen } from '@testing-library/react'
 import { Badge } from './Badge'
 
-test('Badge', () => {
-  renderWithTheme(
-    <Badge size="small" intent="positive">
-      Good!
-    </Badge>
-  )
-  const badge = screen.getByText('Good!')
-  expect(badge).toHaveStyle('background: rgb(228, 245, 235)')
-  expect(badge).toHaveStyle('line-height: 16px')
+describe('Defaults', () => {
+  test('Badge', () => {
+    renderWithTheme(<Badge>Good!</Badge>)
+    const badge = screen.getByText('Good!')
+    expect(badge).toHaveStyle('background: rgb(237, 232, 251)')
+    expect(badge).toHaveStyle('line-height: 24px')
+  })
+
+  test('Small, Positive', () => {
+    renderWithTheme(
+      <Badge size="small" intent="positive">
+        Good!
+      </Badge>
+    )
+    const badge = screen.getByText('Good!')
+    expect(badge).toHaveStyle('background: rgb(228, 245, 235)')
+    expect(badge).toHaveStyle('line-height: 16px')
+  })
 })


### PR DESCRIPTION
This PR adds a test for the Badge component using default props and creates a new describe() suite for both tests



