### PR TITLE
test(DataTable): Utilities Test Coverage

### DIFF
--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -357,6 +357,15 @@ describe('DataTable', () => {
       expect(onSelect).toHaveBeenCalled()
     })
 
+    test('Checkbox keyboard entry calls onSelect', () => {
+      renderWithTheme(dataTableWithSelect)
+      fireEvent.keyDown(screen.getAllByRole('checkbox')[1], {
+        key: 'Enter',
+        code: 'Enter',
+      })
+      expect(onSelect).toHaveBeenCalled()
+    })
+
     test('selectedItems determines if a checkbox is checked', () => {
       renderWithTheme(dataTableWithSelectedItems)
       const checkbox = screen.getAllByRole('checkbox')[1]

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -548,6 +548,23 @@ describe('DataTable', () => {
       expect(screen.queryByText('Bulk Actions')).not.toBeInTheDocument()
     })
 
+    test('Control bar message reflects when all items are selected', () => {
+      renderWithTheme(
+        <DataTable
+          caption="this is a table's caption"
+          columns={columns}
+          bulk={bulk}
+          select={{ ...defaultSelectConfig, selectedItems: ['0', '1'] }}
+        >
+          {items}
+        </DataTable>
+      )
+
+      expect(
+        screen.getByText('AllPageCountDisplayedSelected 2')
+      ).toBeInTheDocument()
+    })
+
     test('Clicking the "Bulk Actions" button reveals elements passed via bulk prop', () => {
       renderWithTheme(
         <DataTable

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -360,8 +360,8 @@ describe('DataTable', () => {
     test('Checkbox keyboard entry calls onSelect', () => {
       renderWithTheme(dataTableWithSelect)
       fireEvent.keyDown(screen.getAllByRole('checkbox')[1], {
-        key: 'Enter',
         code: 'Enter',
+        key: 'Enter',
       })
       expect(onSelect).toHaveBeenCalled()
     })

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -87,6 +87,7 @@ const columns: DataTableColumns = [
   },
   {
     id: 'role',
+    size: 100,
     title: 'Role',
     type: 'string',
   },

--- a/packages/components/src/DataTable/Item/DataTableItem.tsx
+++ b/packages/components/src/DataTable/Item/DataTableItem.tsx
@@ -84,13 +84,6 @@ const DataTableItemLayout: FC<DataTableItemProps> = (props) => {
 
   const handleClick = disabled ? undefined : onClick || undefined
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const isEventFromChild = event.currentTarget !== event.target
-    if (event.keyCode === 13 && !isEventFromChild) {
-      event.currentTarget.click()
-    }
-  }
-
   const ItemActions = (actionPrimary || actions) && (
     <ItemTargetGroup>
       {actionPrimary && <ItemTarget>{actionPrimary}</ItemTarget>}
@@ -121,7 +114,6 @@ const DataTableItemLayout: FC<DataTableItemProps> = (props) => {
       id={id}
       onChange={onChange}
       onClick={handleClick}
-      onKeyDown={handleKeyDown}
       ref={ref}
       secondary={ItemActions}
       tabIndex={0}

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -79,16 +79,14 @@ const DataTableRowLayout = forwardRef(
     const sizedChildren = Children.map(children, (child, index) => {
       if (columnsDisplayState && !columnsDisplayState[index]) {
         return null
-      } else if (isValidElement(child)) {
-        const size = getColumnSize(index)
-        const cellProps =
-          index === 0
-            ? { id: `rowheader-${id}`, role: 'rowheader', size }
-            : { size }
-        return cloneElement(child, cellProps)
-      } else {
-        return child
       }
+
+      const size = getColumnSize(index)
+      const cellProps =
+        index === 0
+          ? { id: `rowheader-${id}`, role: 'rowheader', size }
+          : { size }
+      return isValidElement(child) && cloneElement(child, cellProps)
     })
 
     const handleOnClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -128,9 +128,9 @@ const getRowHoverColor = (
   isHeader: boolean,
   isSelected: boolean
 ) => {
-  if (isHeader || !hasOnClick) return undefined
-  if (isSelected && hasOnClick) return theme.colors.keyAccent
-  if (hasOnClick) return theme.colors.ui1
+  if (!isHeader && hasOnClick) {
+    return isSelected ? theme.colors.keyAccent : theme.colors.ui1
+  }
   return undefined
 }
 

--- a/packages/components/src/DataTable/utils/__snapshots__/sort_utils.test.ts.snap
+++ b/packages/components/src/DataTable/utils/__snapshots__/sort_utils.test.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataTable Sort Utils Sort Date Ascending 1`] = `
+Array [
+  Object {
+    "birthday": 1972-03-06T08:00:00.000Z,
+    "id": 1,
+    "name": "Shaq",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 2,
+    "name": "Kobe",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 3,
+    "name": "Andrew Rannells",
+  },
+]
+`;
+
+exports[`DataTable Sort Utils Sort Date Descending 1`] = `
+Array [
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 2,
+    "name": "Kobe",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 3,
+    "name": "Andrew Rannells",
+  },
+  Object {
+    "birthday": 1972-03-06T08:00:00.000Z,
+    "id": 1,
+    "name": "Shaq",
+  },
+]
+`;
+
+exports[`DataTable Sort Utils Sort ID Ascending 1`] = `
+Array [
+  Object {
+    "birthday": 1972-03-06T08:00:00.000Z,
+    "id": 1,
+    "name": "Shaq",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 2,
+    "name": "Kobe",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 3,
+    "name": "Andrew Rannells",
+  },
+]
+`;
+
+exports[`DataTable Sort Utils Sort ID Descending 1`] = `
+Array [
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 3,
+    "name": "Andrew Rannells",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 2,
+    "name": "Kobe",
+  },
+  Object {
+    "birthday": 1972-03-06T08:00:00.000Z,
+    "id": 1,
+    "name": "Shaq",
+  },
+]
+`;
+
+exports[`DataTable Sort Utils Sort Name Ascending 1`] = `
+Array [
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 3,
+    "name": "Andrew Rannells",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 2,
+    "name": "Kobe",
+  },
+  Object {
+    "birthday": 1972-03-06T08:00:00.000Z,
+    "id": 1,
+    "name": "Shaq",
+  },
+]
+`;
+
+exports[`DataTable Sort Utils Sort Name Ascending 2`] = `
+Array [
+  Object {
+    "birthday": 1972-03-06T08:00:00.000Z,
+    "id": 1,
+    "name": "Shaq",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 2,
+    "name": "Kobe",
+  },
+  Object {
+    "birthday": 1978-08-23T07:00:00.000Z,
+    "id": 3,
+    "name": "Andrew Rannells",
+  },
+]
+`;

--- a/packages/components/src/DataTable/utils/allItemsSelected.ts
+++ b/packages/components/src/DataTable/utils/allItemsSelected.ts
@@ -27,13 +27,17 @@
 import { MixedBoolean } from '../../Form/Inputs/Checkbox'
 import { SelectConfig } from '../types'
 
-export const allItemsSelected = (select?: SelectConfig): MixedBoolean => {
-  if (!select) return false
+type HelperArgs = Pick<SelectConfig, 'selectedItems' | 'pageItems'>
 
+export const allItemsSelected = (
+  select: HelperArgs = { pageItems: [], selectedItems: [] }
+): MixedBoolean => {
   const { selectedItems, pageItems } = select
 
-  if (selectedItems.length === 0) return false
-  else if (pageItems.every((id) => selectedItems.includes(id))) return true
-  else if (pageItems.some((id) => selectedItems.includes(id))) return 'mixed'
-  else return false
+  if (selectedItems.length > 0) {
+    if (pageItems.every((id) => selectedItems.includes(id))) return true
+    else if (pageItems.some((id) => selectedItems.includes(id))) return 'mixed'
+  }
+
+  return false
 }

--- a/packages/components/src/DataTable/utils/sort_utils.test.ts
+++ b/packages/components/src/DataTable/utils/sort_utils.test.ts
@@ -55,19 +55,19 @@ describe('DataTable Sort Utils', () => {
 
   const data = [
     {
+      birthday: new Date('March 6, 1972'),
       id: 1,
       name: 'Shaq',
-      birthday: new Date('March 6, 1972'),
     },
     {
+      birthday: new Date('August 23, 1978'),
       id: 2,
       name: 'Kobe',
-      birthday: new Date('August 23, 1978'),
     },
     {
+      birthday: new Date('August 23, 1978'), // testing two identical dates
       id: 3,
       name: 'Andrew Rannells',
-      birthday: new Date('August 23, 1978'), // testing two identical dates
     },
   ]
   const columns: DataTableColumns = [

--- a/packages/components/src/DataTable/utils/sort_utils.test.ts
+++ b/packages/components/src/DataTable/utils/sort_utils.test.ts
@@ -48,172 +48,99 @@ describe('DataTable Sort Utils', () => {
     `)
   })
 
-  test('Default sort', () => {
-    const data = [
-      {
-        id: 1,
-        name: 'Shaq',
-      },
-      {
-        id: 2,
-        name: 'Kobe',
-      },
-    ]
-    const columns: DataTableColumns = [
-      {
-        canSort: true,
-        id: 'id',
-        title: 'ID',
-        type: 'number',
-      },
-      {
-        canSort: true,
-        id: 'name',
-        title: 'Name',
-        type: 'string',
-      },
-    ]
+  interface ExampleArgumentSet {
+    id: string
+    sortDirection: 'asc' | 'desc'
+  }
 
-    interface ExampleArgumentSet {
-      id: string
-      sortDirection: 'asc' | 'desc'
-    }
-    const sets: ExampleArgumentSet[] = [
+  const data = [
+    {
+      id: 1,
+      name: 'Shaq',
+      birthday: new Date('March 6, 1972'),
+    },
+    {
+      id: 2,
+      name: 'Kobe',
+      birthday: new Date('August 23, 1978'),
+    },
+    {
+      id: 3,
+      name: 'Andrew Rannells',
+      birthday: new Date('August 23, 1978'), // testing two identical dates
+    },
+  ]
+  const columns: DataTableColumns = [
+    {
+      canSort: true,
+      id: 'id',
+      title: 'ID',
+      type: 'number',
+    },
+    {
+      canSort: true,
+      id: 'name',
+      title: 'Name',
+      type: 'string',
+    },
+    {
+      canSort: true,
+      id: 'birthday',
+      title: 'Birthday',
+      type: 'date',
+    },
+  ]
+
+  type TestTuple = [string, ExampleArgumentSet]
+
+  const testConditions: TestTuple[] = [
+    [
+      'Sort ID Ascending',
       {
         id: 'id',
         sortDirection: 'asc',
       },
+    ],
+    [
+      'Sort ID Descending',
       {
         id: 'id',
         sortDirection: 'desc',
       },
+    ],
+    [
+      'Sort Name Ascending',
       {
         id: 'name',
         sortDirection: 'asc',
       },
+    ],
+    [
+      'Sort Name Ascending',
       {
         id: 'name',
         sortDirection: 'desc',
       },
-    ]
+    ],
+    [
+      'Sort Date Ascending',
+      {
+        id: 'birthday',
+        sortDirection: 'asc',
+      },
+    ],
+    [
+      'Sort Date Descending',
+      {
+        id: 'birthday',
+        sortDirection: 'desc',
+      },
+    ],
+  ]
 
-    const defaultSort = sets.map(({ id, sortDirection }) =>
-      doDataTableSort(data, columns, id, sortDirection)
-    )
-
-    expect(defaultSort).toMatchInlineSnapshot(
-      `
-      Array [
-        Object {
-          "columns": Array [
-            Object {
-              "canSort": true,
-              "id": "id",
-              "title": "ID",
-              "type": "number",
-            },
-            Object {
-              "canSort": true,
-              "id": "name",
-              "sortDirection": "desc",
-              "title": "Name",
-              "type": "string",
-            },
-          ],
-          "data": Array [
-            Object {
-              "id": 1,
-              "name": "Shaq",
-            },
-            Object {
-              "id": 2,
-              "name": "Kobe",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "canSort": true,
-              "id": "id",
-              "title": "ID",
-              "type": "number",
-            },
-            Object {
-              "canSort": true,
-              "id": "name",
-              "sortDirection": "desc",
-              "title": "Name",
-              "type": "string",
-            },
-          ],
-          "data": Array [
-            Object {
-              "id": 2,
-              "name": "Kobe",
-            },
-            Object {
-              "id": 1,
-              "name": "Shaq",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "canSort": true,
-              "id": "id",
-              "title": "ID",
-              "type": "number",
-            },
-            Object {
-              "canSort": true,
-              "id": "name",
-              "sortDirection": "desc",
-              "title": "Name",
-              "type": "string",
-            },
-          ],
-          "data": Array [
-            Object {
-              "id": 2,
-              "name": "Kobe",
-            },
-            Object {
-              "id": 1,
-              "name": "Shaq",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "canSort": true,
-              "id": "id",
-              "title": "ID",
-              "type": "number",
-            },
-            Object {
-              "canSort": true,
-              "id": "name",
-              "sortDirection": "desc",
-              "title": "Name",
-              "type": "string",
-            },
-          ],
-          "data": Array [
-            Object {
-              "id": 1,
-              "name": "Shaq",
-            },
-            Object {
-              "id": 2,
-              "name": "Kobe",
-            },
-          ],
-        },
-      ]
-    `
-    )
+  test.each(testConditions)('%s', (_, { id, sortDirection }) => {
+    expect(
+      doDataTableSort(data, columns, id, sortDirection).data
+    ).toMatchSnapshot()
   })
 })

--- a/packages/components/src/DataTable/utils/useSelectManager.test.tsx
+++ b/packages/components/src/DataTable/utils/useSelectManager.test.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React from 'react'
+import React, { FC } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { screen, fireEvent } from '@testing-library/react'
 import { DataTableAction, DataTableItem } from '../Item'
@@ -61,11 +61,15 @@ describe('useSelectManager', () => {
     },
   ]
 
-  const Test = () => {
+  type TestProps = { defaultSelected?: string[] }
+
+  const Test: FC<TestProps> = ({ defaultSelected }) => {
     const allSelectableItems = data.map(({ id }) => String(id))
 
-    const { onSelect, onSelectAll, selections } =
-      useSelectManager(allSelectableItems)
+    const { onSelect, onSelectAll, selections } = useSelectManager(
+      allSelectableItems,
+      defaultSelected
+    )
 
     const items = data.map(({ id, name }) => (
       <DataTableItem
@@ -121,6 +125,34 @@ describe('useSelectManager', () => {
     expect(checkbox[1]).toHaveAttribute('aria-checked', 'true')
   })
 
+  test('clicking the header deselects all when a mixed selection exists', () => {
+    renderWithTheme(<Test defaultSelected={['2', '3']} />)
+    const checkbox = screen.getAllByRole('checkbox')
+    expect(checkbox[0]).toHaveAttribute('aria-checked', 'mixed') // header
+    expect(checkbox[1]).toHaveAttribute('aria-checked', 'false')
+    expect(checkbox[2]).toHaveAttribute('aria-checked', 'true')
+    expect(checkbox[3]).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(checkbox[0]) // unselect all
+    expect(checkbox[0]).toHaveAttribute('aria-checked', 'false')
+    expect(checkbox[1]).toHaveAttribute('aria-checked', 'false')
+    expect(checkbox[2]).toHaveAttribute('aria-checked', 'false')
+    expect(checkbox[3]).toHaveAttribute('aria-checked', 'false')
+  })
+
+  test('toggles mixed checkbox state in header', () => {
+    renderWithTheme(<Test defaultSelected={['2']} />)
+    const checkbox = screen.getAllByRole('checkbox')
+    expect(checkbox[0]).toHaveAttribute('aria-checked', 'mixed') // header
+    expect(checkbox[1]).toHaveAttribute('aria-checked', 'false')
+    expect(checkbox[2]).toHaveAttribute('aria-checked', 'true') // default selected
+    expect(checkbox[3]).toHaveAttribute('aria-checked', 'false')
+
+    fireEvent.click(checkbox[2]) // unselect default option
+    expect(checkbox[0]).toHaveAttribute('aria-checked', 'false') // header
+    expect(checkbox[2]).toHaveAttribute('aria-checked', 'false')
+  })
+
   test('selects individual checkbox', () => {
     renderWithTheme(<Test />)
     const checkbox = screen.getAllByRole('checkbox')
@@ -129,5 +161,6 @@ describe('useSelectManager', () => {
     fireEvent.click(checkbox[1])
     expect(checkbox[1]).toHaveAttribute('aria-checked', 'true')
     expect(checkbox[2]).toHaveAttribute('aria-checked', 'false')
+    expect(checkbox[3]).toHaveAttribute('aria-checked', 'false')
   })
 })

--- a/packages/components/src/DataTable/utils/useSelectManager.tsx
+++ b/packages/components/src/DataTable/utils/useSelectManager.tsx
@@ -41,7 +41,7 @@ export const useSelectManager = (
     setSelections(
       selections.includes(selectionId)
         ? selections.filter(
-            (itemId) => itemId !== selectionId && possibilities.includes(itemId)
+            (itemId) => possibilities.includes(itemId) && itemId !== selectionId
           )
         : [...selections, selectionId]
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,35 +2389,7 @@
     debug "^2.2.0"
     es6-promise "^4.2.8"
 
-"@looker/components-date@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@looker/components-date/-/components-date-2.0.0.tgz#436ee40122ccb5ac91cec7130ffe7e9310d1e1d3"
-  integrity sha512-JJUpLUKAdZWJCqtKEj4C1SkSBsOTcV0TKvEoCtdtCewPLVg1y5cya9t6Lw7/c3kEZ2Dhrr0zzzEbnQZWzW4vdA==
-  dependencies:
-    "@looker/components" "^2.0.0"
-    "@looker/design-tokens" "^2.0.0"
-    "@styled-icons/material-rounded" "^10.28.0"
-    date-fns "^2.21.1"
-    date-fns-tz "^1.0.12"
-    i18next "20.3.1"
-    lodash "^4.17.20"
-    react-day-picker "^7.4.8"
-    react-i18next "11.8.15"
-    styled-system "^5.1.5"
-
-"@looker/components-providers@*", "@looker/components-providers@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-1.4.0.tgz#d9754a1eb2d5141e1b875957d1532ae5014d839e"
-  integrity sha512-9zOiw8KjM9u/CsT9HrThb2Hixuj1xNVY+OF3nzVRkmEi8IZhMh6w9fVfLyimhk4ebg86OE2ZNSVfyI1r84/6pA==
-  dependencies:
-    "@looker/design-tokens" "^2.0.0"
-    i18next "20.3.1"
-    lodash "^4.17.20"
-    react-helmet-async "^1.0.9"
-    react-i18next "11.8.15"
-    tabbable "^5.2.0"
-
-"@looker/components@*", "@looker/components@2.0.0", "@looker/components@^2.0.0":
+"@looker/components@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@looker/components/-/components-2.0.0.tgz#579e5c0823a8799e2806abc0a73369d19c4442ba"
   integrity sha512-+o8Cgw2MPy7FRS1lVqNoGrWNsSyBtCN70KRWkLyl1QXwX/k6K9IqvDq5RbMa5seeumD9dm/L0xKTmwpE0YlXyA==
@@ -2439,17 +2411,6 @@
     resize-observer-polyfill "^1.5.1"
     styled-system "^5.1.5"
     uuid "^8.3.2"
-
-"@looker/design-tokens@*", "@looker/design-tokens@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-2.0.0.tgz#f697ee86640ee5fde743878bdcabe562c6dfb58e"
-  integrity sha512-p8rTB8auSR94Qld2eVdWnEVJ5ZzBZHfpE0+3p5QsWBqsL204KTC+ygdWfrns3jG0PDaEUGkGwPyfshyQEf2FLg==
-  dependencies:
-    "@styled-system/props" "^5.1.5"
-    "@styled-system/should-forward-prop" "5.1.5"
-    lodash "^4.17.20"
-    polished "^4.1.2"
-    styled-system "^5.1.5"
 
 "@looker/embed-sdk@^1.4.0":
   version "1.6.0"
@@ -2516,12 +2477,23 @@
     request-promise-native "^1.0.8"
     semver "^7.3.4"
 
-"@looker/icons@*":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@looker/icons/-/icons-1.4.0.tgz#155591c3e6b4ade0bff078a6827da6453d2f7d74"
-  integrity sha512-0nXfxcXBkQJ3+/WzUE0F9nK9IGCMP83qHJdv/zTsmGqzY1dH0trQm8wkrJI1fB8mR4xicGf9CPLgXrWYnGB3mQ==
+"@looker/filter-components@0.6.0-alpha.1":
+  version "0.6.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@looker/filter-components/-/filter-components-0.6.0-alpha.1.tgz#7ddf228df1de11554948fe9d6acb56d6bd14a63d"
+  integrity sha512-yoi2fS+D0lQmtHFM0yMLGki70BGmiQWdAQ1DC8eqE4GLcrPU442oIVj85lDq3aa97r/wO1TmkpfSmGWpWQSLcA==
   dependencies:
-    "@styled-icons/styled-icon" "^10.6.3"
+    "@looker/components" "^2.1.0-alpha.1"
+    "@looker/components-date" "^2.0.1-alpha.1"
+    "@looker/filter-expressions" "^0.6.0-alpha.1"
+    "@looker/icons" "^1.4.1-alpha.1"
+    "@looker/sdk" "^21.8.0"
+    "@looker/sdk-rtl" "^21.0.12"
+    "@styled-icons/material" "10.28.0"
+    "@styled-icons/material-outlined" "10.28.0"
+    "@styled-icons/material-rounded" "10.28.0"
+    lodash "^4.17.20"
+    polished "3.4.1"
+    use-debounce "5.2.1"
 
 "@looker/prettier-config@1.4.0":
   version "1.4.0"
@@ -7869,10 +7841,10 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@~4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -7896,13 +7868,6 @@ debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@~4.3.1:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,7 +2389,35 @@
     debug "^2.2.0"
     es6-promise "^4.2.8"
 
-"@looker/components@2.0.0":
+"@looker/components-date@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@looker/components-date/-/components-date-2.0.0.tgz#436ee40122ccb5ac91cec7130ffe7e9310d1e1d3"
+  integrity sha512-JJUpLUKAdZWJCqtKEj4C1SkSBsOTcV0TKvEoCtdtCewPLVg1y5cya9t6Lw7/c3kEZ2Dhrr0zzzEbnQZWzW4vdA==
+  dependencies:
+    "@looker/components" "^2.0.0"
+    "@looker/design-tokens" "^2.0.0"
+    "@styled-icons/material-rounded" "^10.28.0"
+    date-fns "^2.21.1"
+    date-fns-tz "^1.0.12"
+    i18next "20.3.1"
+    lodash "^4.17.20"
+    react-day-picker "^7.4.8"
+    react-i18next "11.8.15"
+    styled-system "^5.1.5"
+
+"@looker/components-providers@*", "@looker/components-providers@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-1.4.0.tgz#d9754a1eb2d5141e1b875957d1532ae5014d839e"
+  integrity sha512-9zOiw8KjM9u/CsT9HrThb2Hixuj1xNVY+OF3nzVRkmEi8IZhMh6w9fVfLyimhk4ebg86OE2ZNSVfyI1r84/6pA==
+  dependencies:
+    "@looker/design-tokens" "^2.0.0"
+    i18next "20.3.1"
+    lodash "^4.17.20"
+    react-helmet-async "^1.0.9"
+    react-i18next "11.8.15"
+    tabbable "^5.2.0"
+
+"@looker/components@*", "@looker/components@2.0.0", "@looker/components@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@looker/components/-/components-2.0.0.tgz#579e5c0823a8799e2806abc0a73369d19c4442ba"
   integrity sha512-+o8Cgw2MPy7FRS1lVqNoGrWNsSyBtCN70KRWkLyl1QXwX/k6K9IqvDq5RbMa5seeumD9dm/L0xKTmwpE0YlXyA==
@@ -2411,6 +2439,17 @@
     resize-observer-polyfill "^1.5.1"
     styled-system "^5.1.5"
     uuid "^8.3.2"
+
+"@looker/design-tokens@*", "@looker/design-tokens@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-2.0.0.tgz#f697ee86640ee5fde743878bdcabe562c6dfb58e"
+  integrity sha512-p8rTB8auSR94Qld2eVdWnEVJ5ZzBZHfpE0+3p5QsWBqsL204KTC+ygdWfrns3jG0PDaEUGkGwPyfshyQEf2FLg==
+  dependencies:
+    "@styled-system/props" "^5.1.5"
+    "@styled-system/should-forward-prop" "5.1.5"
+    lodash "^4.17.20"
+    polished "^4.1.2"
+    styled-system "^5.1.5"
 
 "@looker/embed-sdk@^1.4.0":
   version "1.6.0"
@@ -2477,23 +2516,12 @@
     request-promise-native "^1.0.8"
     semver "^7.3.4"
 
-"@looker/filter-components@0.6.0-alpha.1":
-  version "0.6.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@looker/filter-components/-/filter-components-0.6.0-alpha.1.tgz#7ddf228df1de11554948fe9d6acb56d6bd14a63d"
-  integrity sha512-yoi2fS+D0lQmtHFM0yMLGki70BGmiQWdAQ1DC8eqE4GLcrPU442oIVj85lDq3aa97r/wO1TmkpfSmGWpWQSLcA==
+"@looker/icons@*":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@looker/icons/-/icons-1.4.0.tgz#155591c3e6b4ade0bff078a6827da6453d2f7d74"
+  integrity sha512-0nXfxcXBkQJ3+/WzUE0F9nK9IGCMP83qHJdv/zTsmGqzY1dH0trQm8wkrJI1fB8mR4xicGf9CPLgXrWYnGB3mQ==
   dependencies:
-    "@looker/components" "^2.1.0-alpha.1"
-    "@looker/components-date" "^2.0.1-alpha.1"
-    "@looker/filter-expressions" "^0.6.0-alpha.1"
-    "@looker/icons" "^1.4.1-alpha.1"
-    "@looker/sdk" "^21.8.0"
-    "@looker/sdk-rtl" "^21.0.12"
-    "@styled-icons/material" "10.28.0"
-    "@styled-icons/material-outlined" "10.28.0"
-    "@styled-icons/material-rounded" "10.28.0"
-    lodash "^4.17.20"
-    polished "3.4.1"
-    use-debounce "5.2.1"
+    "@styled-icons/styled-icon" "^10.6.3"
 
 "@looker/prettier-config@1.4.0":
   version "1.4.0"
@@ -7841,10 +7869,10 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@~4.3.1:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 
@@ -7868,6 +7896,13 @@ debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@~4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Increases test coverage for DataTable utilities and child components. This is accomplished by both adding tests but also refactoring instances where branches of code were functionally unreachable.

https://buganizer.corp.google.com/issues/194403850

## Screenshot

![Group](https://user-images.githubusercontent.com/238293/128064055-20cbeb8d-516c-45db-8364-24154187e618.png)

## Followup

I'll create a new branch for DataTable/getNextFocus tests, which is a separate buganizer ticket and will be a decent chunk of work on its own. 

