### PR TITLE
test(Accordion): Add coverage

### DIFF
--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -133,13 +133,6 @@ describe('Accordion', () => {
   })
 
   describe('warnings', () => {
-    beforeEach(() => {
-      global.console = {
-        ...globalConsole,
-        warn: jest.fn(),
-      }
-    })
-
     test('warns if isOpen is provided without toggleOpen prop', () => {
       global.console = {
         ...globalConsole,
@@ -154,6 +147,7 @@ describe('Accordion', () => {
 
       // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalled()
+      global.console = globalConsole
     })
   })
 

--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -140,6 +140,10 @@ describe('Accordion', () => {
       }
     })
 
+    afterEach(() => {
+      global.console = globalConsole
+    })
+
     test('warns if isOpen is provided without toggleOpen prop', () => {
       renderWithTheme(
         <Accordion isOpen={true} content="My Accordion Content">
@@ -149,7 +153,6 @@ describe('Accordion', () => {
 
       // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalled()
-      global.console = globalConsole
     })
 
     test('warns if children is a falsy value', () => {
@@ -159,7 +162,6 @@ describe('Accordion', () => {
 
       // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalled()
-      global.console = globalConsole
     })
   })
 

--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -133,16 +133,28 @@ describe('Accordion', () => {
   })
 
   describe('warnings', () => {
-    test('warns if isOpen is provided without toggleOpen prop', () => {
+    beforeEach(() => {
       global.console = {
         ...globalConsole,
         warn: jest.fn(),
       }
+    })
 
+    test('warns if isOpen is provided without toggleOpen prop', () => {
       renderWithTheme(
         <Accordion isOpen={true} content="My Accordion Content">
           My Accordion Label
         </Accordion>
+      )
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalled()
+      global.console = globalConsole
+    })
+
+    test('warns if children is a falsy value', () => {
+      renderWithTheme(
+        <Accordion content="My Accordion Content">{false}</Accordion>
       )
 
       // eslint-disable-next-line no-console

--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -27,7 +27,9 @@
 import React, { useState } from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { fireEvent, screen } from '@testing-library/react'
-import { Accordion } from '.'
+import { Accordion, AccordionContent, AccordionDisclosure } from '.'
+
+const globalConsole = global.console
 
 describe('Accordion', () => {
   test('Renders AccordionDisclosure and AccordionContent (on label click)', () => {
@@ -128,5 +130,44 @@ describe('Accordion', () => {
       key: 'Enter',
     })
     expect(handleKeyUp).toHaveBeenCalled()
+  })
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      global.console = {
+        ...globalConsole,
+        warn: jest.fn(),
+      }
+    })
+
+    test('warns if isOpen is provided without toggleOpen prop', () => {
+      global.console = {
+        ...globalConsole,
+        warn: jest.fn(),
+      }
+
+      renderWithTheme(
+        <Accordion isOpen={true} content="My Accordion Content">
+          My Accordion Label
+        </Accordion>
+      )
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalled()
+    })
+  })
+
+  describe('legacy composition', () => {
+    test('renders Accordion when using AccordionDisclosure and AccordionContent children', () => {
+      renderWithTheme(
+        <Accordion defaultOpen>
+          <AccordionDisclosure>Disclosure</AccordionDisclosure>
+          <AccordionContent>Content</AccordionContent>
+        </Accordion>
+      )
+
+      screen.getByText('Disclosure')
+      screen.getByText('Content')
+    })
   })
 })

--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -87,6 +87,13 @@ const AccordionInternal: FC<AccordionProps> = ({
     )
   }
 
+  if (!label) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "<Accordion>'s child is falsy (i.e. undefined, null, false, etc). Please give <Accordion> a valid ReactNode child."
+    )
+  }
+
   const controlledProps =
     propsIsOpen && propsToggleOpen
       ? {

--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -87,13 +87,6 @@ const AccordionInternal: FC<AccordionProps> = ({
     )
   }
 
-  if (!label) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "<Accordion>'s child is falsy (i.e. undefined, null, false, etc). Please give <Accordion> a valid ReactNode child."
-    )
-  }
-
   const controlledProps =
     propsIsOpen && propsToggleOpen
       ? {


### PR DESCRIPTION
- Added a test to check `console.warn` when `Accordion` is only partially controlled (i.e. only receives one of two controlled open state props)
- Added a test to check legacy composition

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [ ] ♿️ Accessibility addressed
- [ ] 🌏 Localization & Internationalization addressed
- [ ] 🖼 Image Snapshot coverage
- [ ] 📚 Documentation updated
- [ ] 🧳 Bundle size impact addressed
- [ ] 🏁 Performance impacts addressed
- [ ] 👾 Browsers tested
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] IE11
