### PR TITLE
test(Modal): updated for better test coverage

### DIFF
--- a/packages/components/src/Modal/modal.test.tsx
+++ b/packages/components/src/Modal/modal.test.tsx
@@ -24,35 +24,15 @@
 
  */
 
-import { useTranslation } from 'react-i18next'
-import React, { FC, useContext } from 'react'
-import { Close } from '@styled-icons/material/Close'
-import styled from 'styled-components'
-import { IconButton, IconButtonProps } from '../Button'
-import { DialogContext } from '../Dialog'
+import React from 'react'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { screen } from '@testing-library/react'
+import { ModalHeaderCloseButton } from './ModalHeaderCloseButton'
 
-export interface ModalHeaderCloseButtonProps {
-  /**
-   * this will define the size of the button
-   * @default medium
-   */
-  size?: IconButtonProps['size']
-}
-
-const ModalHeaderCloseButtonLayout: FC<ModalHeaderCloseButtonProps> = ({
-  size = 'medium',
-}) => {
-  const { t } = useTranslation('ModalHeaderCloseButton')
-  const { closeModal, id } = useContext(DialogContext)
-  return (
-    <IconButton
-      id={id ? `${id}-iconButton` : undefined}
-      size={size}
-      onClick={closeModal}
-      label={t('Close')}
-      icon={<Close />}
-    />
-  )
-}
-
-export const ModalHeaderCloseButton = styled(ModalHeaderCloseButtonLayout)``
+describe('ModalHeaderCloseButton', () => {
+  test('render ', () => {
+    renderWithTheme(<ModalHeaderCloseButton />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(screen.getByText('Close')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
-[ ] 🤥  tests update

This will complement the other PR that has some update on test coverage related to the other `Modal` files.

removing `CloseHeaderButton.tsx` seems to stop the trigger for extra test for Modal. This file has been modified a little bit and renamed as `ModalHeaderCloseButton.tsx`. Everything is working as expected with this change

![Screen Shot 2021-08-04 at 2 22 34 PM](https://user-images.githubusercontent.com/23616264/128256718-f8f10708-62d0-4d2c-ba65-4ce308724183.png)
