### PR TITLE
fix(InputFilters): Should support placeholder attribute

### DIFF
--- a/packages/components/src/Form/Inputs/InputFilters/InputFilters.test.tsx
+++ b/packages/components/src/Form/Inputs/InputFilters/InputFilters.test.tsx
@@ -41,6 +41,17 @@ describe('InputFilters', () => {
     expect(screen.getByPlaceholderText('Filter List')).toBeInTheDocument()
   })
 
+  test('placeholder', () => {
+    renderWithTheme(
+      <InputFilters
+        onChange={() => null}
+        filters={[]}
+        placeholder="Hello world"
+      />
+    )
+    expect(screen.getByPlaceholderText('Hello world')).toBeInTheDocument()
+  })
+
   test('Displays list of filters', () => {
     renderWithTheme(<ControlledComponent />)
 

--- a/packages/components/src/Form/Inputs/InputFilters/InputFilters.tsx
+++ b/packages/components/src/Form/Inputs/InputFilters/InputFilters.tsx
@@ -45,9 +45,11 @@ const InputFiltersLayout: FC<InputFiltersProps> = ({
   className,
   filters,
   hideFilterIcon = false,
+  placeholder,
   onChange,
 }) => {
   const { t } = useTranslation('InputFilters')
+  placeholder ||= t('Filter List')
   const [fieldEditing, setFieldEditing] = useState<undefined | string>(
     undefined
   )
@@ -191,7 +193,7 @@ const InputFiltersLayout: FC<InputFiltersProps> = ({
             isFilterable
             onChange={handleFilterLookupChange}
             options={options}
-            placeholder={t('Filter List')}
+            placeholder={placeholder}
             ref={inputRef}
           />
         )}

--- a/packages/components/src/Form/Inputs/InputFilters/types.ts
+++ b/packages/components/src/Form/Inputs/InputFilters/types.ts
@@ -62,5 +62,13 @@ export interface InputFiltersProps {
   className?: string
   filters: FieldFilter[]
   hideFilterIcon?: boolean
+  /**
+   * Placeholder text for input when empty
+   *
+   * I18n recommended: content that is user visible should be treated for i18n
+   *
+   * Defaults to internationalized "Filter List"
+   */
+  placeholder?: string
   onChange: (filters: FieldFilter[]) => void
 }


### PR DESCRIPTION
`InputFilters` should support user-specification of `placeholder`

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [x] 🌏 Localization & Internationalization addressed
