### PR TITLE
fix(VisuallyHidden): Position causing whitespace issue with Page in Chrome

### DIFF
--- a/packages/components/src/Layout/Semantics/Layout/Layout.story.tsx
+++ b/packages/components/src/Layout/Semantics/Layout/Layout.story.tsx
@@ -24,15 +24,17 @@
 
  */
 
+import { Info } from '@styled-icons/material/Info'
 import React from 'react'
 import styled from 'styled-components'
-import { Heading } from '@looker/components'
 import { defaultArgTypes as argTypes } from '../../../../../../storybook/src/defaultArgTypes'
 import {
   Constitution,
   ConstitutionShort,
 } from '../../../__mocks__/Constitution'
 import { ItemsFiller } from '../../../__mocks__/ListHelper'
+import { IconButton } from '../../../Button'
+import { Heading } from '../../../Text'
 import { Page, Header, Layout, Aside, Section, Footer } from '../'
 
 export default {
@@ -172,5 +174,28 @@ export const ScrollAllAreasTogetherDefault = () => (
   </Highlighter>
 )
 ScrollAllAreasTogetherDefault.parameters = {
+  storyshots: { disable: true },
+}
+
+export const WhitespaceRepro = () => (
+  <Highlighter>
+    <Page fixed>
+      <Header height="4rem" px="large">
+        I'm the header
+      </Header>
+      <Layout hasAside>
+        <Aside p="large" width="200px">
+          <ItemsFiller count={20} />
+        </Aside>
+        <Section main p="xxlarge">
+          <Heading>Page title</Heading>
+          <Constitution />
+          <IconButton icon={<Info />} label="Info" />
+        </Section>
+      </Layout>
+    </Page>
+  </Highlighter>
+)
+WhitespaceRepro.parameters = {
   storyshots: { disable: true },
 }

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.test.tsx
@@ -33,6 +33,6 @@ test('VisuallyHiddenText default', () => {
   renderWithTheme(<VisuallyHidden>I am hidden</VisuallyHidden>)
   expect(screen.getByText('I am hidden')).toBeInTheDocument()
   expect(screen.getByText('I am hidden')).toHaveStyle(
-    'clip: rect(1px, 1px, 1px, 1px)'
+    'clip: rect(1px, 1px, 1px, 1px); left: 0; top: 0;'
   )
 })

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.tsx
@@ -29,8 +29,10 @@ import styled, { css } from 'styled-components'
 export const visuallyHiddenStyle = css`
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
+  left: 0;
   overflow: hidden;
   position: absolute;
+  top: 0;
   width: 1px;
 `
 


### PR DESCRIPTION
Somehow Chrome and only Chrome decided to interpret the lack of `left` and `top` in `VisuallyHidden` as `bottom: [a negative number proportional to the height of the page]` when `<Page fixed>`, (i.e. an element with `height: 100vh`) is an ancestor. Explicitly adding `left: 0` and `top: 0` fixes it.

This issue is currently happening on our docs site: https://looker-open-source.github.io/components/latest/components/actions/button

I added a repro story in `Layout.story.tsx` and also made a sandbox repro here: https://codesandbox.io/s/gallant-franklin-wyn7i

- [x] 👾 Browsers tested (**verified that only Chrome had the bug**)
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11

### Bug:
![65fb588d-e815-4384-afb3-ba1c98c82130](https://user-images.githubusercontent.com/53451193/128804380-deddf43a-2c2e-445b-b251-d62f0911372f.gif)

### Fixed:
![a1cf1a23-16b7-4e8b-bb6c-3316150b3577](https://user-images.githubusercontent.com/53451193/128804375-9aed02f5-6ad6-47df-8f52-96b2affd8b05.gif)