### PR TITLE
fix(ButtonToggle): Remove background color for focus via click

### DIFF
--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -98,6 +98,7 @@ const ButtonOuter = styled.button.attrs(({ type = 'button' }) => ({
 }))<ButtonItemProps & FocusVisibleProps>`
   ${focusVisibleCSSWrapper(
     ({ theme }) => css`
+      background: ${({ theme }) => theme.colors.neutralSubtle};
       box-shadow: 0 0 0.5px 1px ${theme.colors.keyFocus};
     `
   )}
@@ -122,7 +123,6 @@ export const ButtonItem = styled(ButtonLayout)`
   ${space}
 
   &:active,
-  &:focus,
   &:hover {
     background: ${({ theme }) => theme.colors.neutralSubtle};
     color: ${({ theme }) => theme.colors.text5};

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -31,6 +31,7 @@ import React, {
   ReactNode,
   Ref,
   useCallback,
+  useRef,
   useState,
 } from 'react'
 import styled from 'styled-components'
@@ -101,19 +102,31 @@ export const ButtonSetLayout = forwardRef(
     }
 
     const [isWrapping, setIsWrapping] = useState(false)
+
+    const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
     const measureRef = useCallback(
       (node: HTMLElement | null) => {
         if (node) {
           const { height } = node.getBoundingClientRect()
-          const firstItem = node.childNodes[0] as HTMLElement
-          const rowHeight = firstItem
-            ? firstItem.getBoundingClientRect().height
-            : inputHeightNumber
-          if (height >= rowHeight * 2) {
-            setIsWrapping(true)
-          } else {
-            setIsWrapping(false)
+          const getIsWrapping = () => {
+            const firstItem = node.childNodes[0] as HTMLElement
+            const rowHeight = firstItem
+              ? firstItem.getBoundingClientRect().height
+              : inputHeightNumber
+            if (height >= rowHeight * 2) {
+              setIsWrapping(true)
+            } else {
+              setIsWrapping(false)
+            }
           }
+
+          if (height > 0) {
+            getIsWrapping()
+          } else {
+            timeoutRef.current = setTimeout(getIsWrapping, 10)
+          }
+        } else if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/components/src/Button/ButtonToggle.story.tsx
+++ b/packages/components/src/Button/ButtonToggle.story.tsx
@@ -28,7 +28,9 @@ import { Story } from '@storybook/react/types-6-0'
 import { Page } from 'puppeteer'
 import React, { useState } from 'react'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
+import { Popover } from '../Popover'
 import { ButtonItem } from './ButtonItem'
+import { Button } from './Button'
 import { ButtonToggle, ButtonToggleProps } from './ButtonToggle'
 
 export default {
@@ -103,4 +105,29 @@ Options.args = {
     { value: 'Cheddar' },
     { disabled: true, value: 'Swiss' },
   ],
+}
+
+export const PopoverFocus = () => {
+  const [toggle, setToggle] = useState('Swiss')
+  return (
+    <Popover
+      content={
+        <ButtonToggle
+          margin="large"
+          value={toggle}
+          onChange={setToggle}
+          options={[
+            { label: 'Smoked Gouda', value: 'Gouda' },
+            { value: 'Cheddar' },
+            { value: 'Swiss' },
+          ]}
+        />
+      }
+    >
+      <Button>Open Popover</Button>
+    </Popover>
+  )
+}
+PopoverFocus.parameters = {
+  storyshots: { disable: true },
 }


### PR DESCRIPTION
When a user opens a button toggle filter via click inside a popover, the first item is focused (via the "initial focus" logic of the popover's focus trap) and the `neutralSubtle` override used in the core product is a dark enough grey as to make it look disabled (see screen recording below).

If the user opens the popover via keyboard, the focus ring is shown, which is a more obvious indicator. Activating the "click only" focus style is actually rare and pretty much only happens with the initial focus of the popover. Short of our preferred solution of adding a Done button to the popover that would instead receive initial focus, removing the background color for click-only focus will reduce confusion.

### Issue in the core product:
https://user-images.githubusercontent.com/53451193/128808419-9ff7d0ed-b0a0-48a9-bf1f-f620711a1b1b.mov

### After fix, open popover via click:
![image](https://user-images.githubusercontent.com/53451193/128808896-0a69ce8a-d565-4b89-bbde-7b271326cc24.png)

### Open via keyboard:
![image](https://user-images.githubusercontent.com/53451193/128808949-a0c8d483-80fc-4a54-ad0b-14db2badb7fa.png)
