### PR TITLE
feat: Ripple effect

### DIFF
--- a/packages/components/src/Ripple/Ripple.story.tsx
+++ b/packages/components/src/Ripple/Ripple.story.tsx
@@ -1,0 +1,114 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import React from 'react'
+import { Story } from '@storybook/react/types-6-0'
+import { shouldForwardProp } from '@looker/design-tokens'
+import styled from 'styled-components'
+import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout'
+import {
+  useRipple,
+  useRippleHandlers,
+  UseRippleProps,
+  rippleStyle,
+  RippleStyleProps,
+} from './'
+
+type RippleProps = SimpleLayoutProps & UseRippleProps
+
+const Ripple = ({ bounded, ...props }: RippleProps) => {
+  const {
+    callbacks,
+    className: rippleClassName,
+    ...rippleProps
+  } = useRipple({
+    bounded,
+  })
+
+  const rippleHandlers = useRippleHandlers(callbacks, {})
+
+  return (
+    <RippleStyle
+      className={rippleClassName}
+      tabIndex={0}
+      {...rippleProps}
+      {...rippleHandlers}
+      {...props}
+    >
+      click me
+    </RippleStyle>
+  )
+}
+
+const RippleStyle = styled.div
+  .withConfig({
+    shouldForwardProp,
+  })
+  .attrs(({ color = 'neutral' }) => ({ color }))<
+  RippleStyleProps & SimpleLayoutProps
+>`
+   ${simpleLayoutCSS}
+   ${rippleStyle}
+
+   align-items: center;
+   display: flex;
+   justify-content: center;
+ `
+
+const Template: Story<RippleProps> = (args) => <Ripple {...args} />
+
+export const Basic = Template.bind({})
+Basic.args = { height: 80, width: 80 }
+Basic.parameters = { storyshots: { disable: true } }
+
+export const Bounded = Template.bind({})
+Bounded.args = { ...Basic.args, bounded: true, width: 200 }
+Bounded.parameters = { storyshots: { disable: true } }
+
+export const Key = Template.bind({})
+Key.args = { ...Basic.args, color: 'key' }
+Key.parameters = { storyshots: { disable: true } }
+
+export const Critical = Template.bind({})
+Critical.args = { ...Basic.args, color: 'critical' }
+Critical.parameters = { storyshots: { disable: true } }
+
+export const Calculation = Template.bind({})
+Calculation.args = { ...Basic.args, color: 'calculation' }
+Calculation.parameters = { storyshots: { disable: true } }
+
+export const Dimension = Template.bind({})
+Dimension.args = { ...Basic.args, color: 'dimension' }
+Dimension.parameters = { storyshots: { disable: true } }
+
+export const Measure = Template.bind({})
+Measure.args = { ...Basic.args, color: 'measure' }
+Measure.parameters = { storyshots: { disable: true } }
+
+export default {
+  component: Ripple,
+  title: 'Ripple',
+}

--- a/packages/components/src/Ripple/Ripple.story.tsx
+++ b/packages/components/src/Ripple/Ripple.story.tsx
@@ -26,58 +26,45 @@
 
 import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
-import { shouldForwardProp } from '@looker/design-tokens'
 import styled from 'styled-components'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout'
-import {
-  useRipple,
-  useRippleHandlers,
-  UseRippleProps,
-  RippleColorProps,
-  rippleStyle,
-  RippleStyleProps,
-} from './'
+import { useRipple, useRippleHandlers, UseRippleProps, rippleStyle } from './'
 
-type RippleProps = SimpleLayoutProps & UseRippleProps & RippleColorProps
+type RippleProps = SimpleLayoutProps & UseRippleProps & { className: string }
 
-const Ripple = ({ bounded, ...props }: RippleProps) => {
-  const {
-    callbacks,
-    className: rippleClassName,
-    ...rippleProps
-  } = useRipple({
-    bounded,
-  })
+const Ripple = styled(
+  ({ className, bounded, color, ...props }: RippleProps) => {
+    const {
+      callbacks,
+      className: rippleClassName,
+      ...rippleProps
+    } = useRipple({
+      bounded,
+      color,
+    })
 
-  const rippleHandlers = useRippleHandlers(callbacks, {})
+    const rippleHandlers = useRippleHandlers(callbacks, {})
 
-  return (
-    <RippleStyle
-      className={rippleClassName}
-      tabIndex={0}
-      {...rippleProps}
-      {...rippleHandlers}
-      {...props}
-    >
-      click me
-    </RippleStyle>
-  )
-}
+    return (
+      <div
+        className={`${className} ${rippleClassName}`}
+        tabIndex={0}
+        {...rippleProps}
+        {...rippleHandlers}
+        {...props}
+      >
+        click me
+      </div>
+    )
+  }
+)<SimpleLayoutProps>`
+  ${simpleLayoutCSS}
+  ${rippleStyle}
 
-const RippleStyle = styled.div
-  .withConfig({
-    shouldForwardProp,
-  })
-  .attrs(({ color = 'neutral' }) => ({ color }))<
-  RippleStyleProps & SimpleLayoutProps
->`
-   ${simpleLayoutCSS}
-   ${rippleStyle}
-
-   align-items: center;
-   display: flex;
-   justify-content: center;
- `
+  align-items: center;
+  display: flex;
+  justify-content: center;
+`
 
 const Template: Story<RippleProps> = (args) => <Ripple {...args} />
 

--- a/packages/components/src/Ripple/Ripple.story.tsx
+++ b/packages/components/src/Ripple/Ripple.story.tsx
@@ -33,11 +33,12 @@ import {
   useRipple,
   useRippleHandlers,
   UseRippleProps,
+  RippleColorProps,
   rippleStyle,
   RippleStyleProps,
 } from './'
 
-type RippleProps = SimpleLayoutProps & UseRippleProps
+type RippleProps = SimpleLayoutProps & UseRippleProps & RippleColorProps
 
 const Ripple = ({ bounded, ...props }: RippleProps) => {
   const {

--- a/packages/components/src/Ripple/index.ts
+++ b/packages/components/src/Ripple/index.ts
@@ -24,34 +24,6 @@
 
  */
 
-import { BlendColors } from './blends'
-import { StatefulColors } from './stateful'
-import { SpecifiableColors, TextColor } from './specifiable'
-import { DerivativeColors } from './derivative'
-
-export type Colors = SpecifiableColors &
-  DerivativeColors &
-  BlendColors &
-  StatefulColors
-
-export type TextColors = TextColor
-
-export { coreColors, intentColors, specifiableColors } from './specifiable'
-
-export type { DerivativeColors } from './derivative'
-export type { CoreColors, IntentColors, SpecifiableColors } from './specifiable'
-export type { BlendColors } from './blends'
-export type {
-  ExtendedStatefulColor,
-  StatefulColor,
-  StatefulColors,
-  StatefulColorChoices,
-} from './stateful'
-export type { ColorProps } from 'styled-system'
-
-export type { TextColorProps } from './textColor'
-export { backgroundColor } from './backgroundColor'
-export { uiColors, textColors } from './blends'
-export { derivativeColors } from './derivative'
-export { textColor } from './textColor'
-export { specifiableTextColors } from './specifiable'
+export * from './rippleStyle'
+export * from './useRipple'
+export * from './useRippleHandlers'

--- a/packages/components/src/Ripple/index.ts
+++ b/packages/components/src/Ripple/index.ts
@@ -25,5 +25,6 @@
  */
 
 export * from './rippleStyle'
+export * from './types'
 export * from './useRipple'
 export * from './useRippleHandlers'

--- a/packages/components/src/Ripple/rippleStyle.ts
+++ b/packages/components/src/Ripple/rippleStyle.ts
@@ -25,7 +25,6 @@
  */
 
 import { css, keyframes, Keyframes } from 'styled-components'
-import { RippleAnimationValues, RippleColorProps } from './types'
 
 const rippleRadiusIn: Keyframes = keyframes`
 from {
@@ -58,21 +57,10 @@ to {
 }
 `
 
-export type RippleStyleProps = RippleAnimationValues & RippleColorProps
-
 /**
  * Uses :before as fade-in overlay "background" and :after as rippling overlay
  */
-export const rippleStyle = ({
-  color = 'neutral',
-  rippleOffset,
-  rippleScaleRange,
-  rippleSize,
-}: RippleStyleProps) => css`
-  --ripple-scale-start: ${rippleScaleRange[0] || 1};
-  --ripple-scale-end: ${rippleScaleRange[1] || 1};
-  --ripple-translate: ${rippleOffset};
-
+export const rippleStyle = css`
   outline: none;
   overflow: hidden;
   position: relative;
@@ -80,17 +68,17 @@ export const rippleStyle = ({
 
   &::before,
   &::after {
-    background-color: ${({ theme }) => theme.colors[color]};
+    background-color: var(--ripple-color, #000000);
     border-radius: 50%;
     content: '';
-    height: ${rippleSize};
+    height: var(--ripple-size, 100%);
     left: 0;
     opacity: 0;
     pointer-events: none;
     position: absolute;
     top: 0;
     transform-origin: center center;
-    width: ${rippleSize};
+    width: var(--ripple-size, 100%);
   }
 
   &::before {

--- a/packages/components/src/Ripple/rippleStyle.ts
+++ b/packages/components/src/Ripple/rippleStyle.ts
@@ -1,0 +1,117 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { css, keyframes, Keyframes } from 'styled-components'
+import { RippleAnimationValues, RippleColorProps } from './types'
+
+const rippleRadiusIn: Keyframes = keyframes`
+from {
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transform: translate(var(--ripple-translate, 0)) scale(var(--ripple-scale-start, 1));
+}
+to {
+  transform: translate(var(--ripple-translate, 0))
+    scale(var(--ripple-scale-end, 1));
+}
+`
+
+const rippleOpacityIn: Keyframes = keyframes`
+from {
+  animation-timing-function: linear;
+  opacity: 0;
+}
+to {
+  opacity: .12;
+}
+`
+
+const rippleOpacityOut: Keyframes = keyframes`
+from {
+  animation-timing-function: linear;
+  opacity: .12;
+}
+to {
+  opacity: 0;
+}
+`
+
+export type RippleStyleProps = RippleAnimationValues & RippleColorProps
+
+export const rippleStyle = ({
+  color = 'neutral',
+  rippleOffset,
+  rippleScaleRange,
+  rippleSize,
+}: RippleStyleProps) => css`
+  --ripple-scale-start: ${rippleScaleRange[0] || 1};
+  --ripple-scale-end: ${rippleScaleRange[1] || 1};
+  --ripple-translate: ${rippleOffset};
+
+  outline: none;
+  overflow: hidden;
+  position: relative;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+  &::before,
+  &::after {
+    background-color: ${({ theme }) => theme.colors[color]};
+    border-radius: 50%;
+    content: '';
+    height: ${rippleSize};
+    left: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    transform-origin: center center;
+    width: ${rippleSize};
+  }
+
+  &::before {
+    /* Background shouldn't ripple, only fade */
+    transform: translate(var(--ripple-translate, 0))
+      scale(var(--ripple-scale-end, 1));
+    transition: opacity 75ms linear;
+  }
+
+  &::after {
+    transform: scale(0);
+  }
+
+  &.bg-on::before {
+    opacity: 0.12;
+    transition: opacity 150ms linear;
+  }
+  &.fg-in::after {
+    animation: ${rippleRadiusIn} 225ms forwards,
+      ${rippleOpacityIn} 75ms forwards;
+  }
+  &.fg-out::after {
+    animation: ${rippleOpacityOut} 150ms;
+    transform: translate(var(--ripple-translate, 0))
+      scale(var(--ripple-scale-end, 1));
+  }
+`

--- a/packages/components/src/Ripple/rippleStyle.ts
+++ b/packages/components/src/Ripple/rippleStyle.ts
@@ -60,6 +60,9 @@ to {
 
 export type RippleStyleProps = RippleAnimationValues & RippleColorProps
 
+/**
+ * Uses :before as fade-in overlay "background" and :after as rippling overlay
+ */
 export const rippleStyle = ({
   color = 'neutral',
   rippleOffset,
@@ -91,10 +94,9 @@ export const rippleStyle = ({
   }
 
   &::before {
-    /* Background shouldn't ripple, only fade */
     transform: translate(var(--ripple-translate, 0))
       scale(var(--ripple-scale-end, 1));
-    transition: opacity 75ms linear;
+    transition: opacity 15ms linear;
   }
 
   &::after {
@@ -103,14 +105,20 @@ export const rippleStyle = ({
 
   &.bg-on::before {
     opacity: 0.12;
-    transition: opacity 150ms linear;
   }
+
   &.fg-in::after {
-    animation: ${rippleRadiusIn} 225ms forwards,
-      ${rippleOpacityIn} 75ms forwards;
+    animation-duration: ${({
+      theme: {
+        transitions: { rapid, simple },
+      },
+    }) => `${simple}ms, ${rapid}ms`};
+    animation-fill-mode: forwards, forwards;
+    animation-name: ${rippleRadiusIn}, ${rippleOpacityIn};
   }
   &.fg-out::after {
-    animation: ${rippleOpacityOut} 150ms;
+    animation: ${rippleOpacityOut};
+    animation-duration: ${({ theme: { transitions } }) => transitions.quick}ms;
     transform: translate(var(--ripple-translate, 0))
       scale(var(--ripple-scale-end, 1));
   }

--- a/packages/components/src/Ripple/types.ts
+++ b/packages/components/src/Ripple/types.ts
@@ -24,25 +24,9 @@
 
  */
 
-import { ExtendedStatefulColor } from '@looker/design-tokens'
-
 export type RippleCallbacks = {
   endBG: () => void
   endFG: () => void
   startBG: () => void
   startFG: () => void
-}
-
-export type RippleAnimationValues = {
-  rippleSize: string
-  rippleScaleRange: [number, number]
-  rippleOffset: string
-}
-
-export type RippleColorProps = {
-  /**
-   * Change the color of the ripple background and foreground
-   * @default neutral
-   */
-  color?: ExtendedStatefulColor
 }

--- a/packages/components/src/Ripple/types.ts
+++ b/packages/components/src/Ripple/types.ts
@@ -24,34 +24,25 @@
 
  */
 
-import { BlendColors } from './blends'
-import { StatefulColors } from './stateful'
-import { SpecifiableColors, TextColor } from './specifiable'
-import { DerivativeColors } from './derivative'
+import { ExtendedStatefulColor } from '@looker/design-tokens'
 
-export type Colors = SpecifiableColors &
-  DerivativeColors &
-  BlendColors &
-  StatefulColors
+export type RippleCallbacks = {
+  endBG: () => void
+  endFG: () => void
+  startBG: () => void
+  startFG: () => void
+}
 
-export type TextColors = TextColor
+export type RippleAnimationValues = {
+  rippleSize: string
+  rippleScaleRange: [number, number]
+  rippleOffset: string
+}
 
-export { coreColors, intentColors, specifiableColors } from './specifiable'
-
-export type { DerivativeColors } from './derivative'
-export type { CoreColors, IntentColors, SpecifiableColors } from './specifiable'
-export type { BlendColors } from './blends'
-export type {
-  ExtendedStatefulColor,
-  StatefulColor,
-  StatefulColors,
-  StatefulColorChoices,
-} from './stateful'
-export type { ColorProps } from 'styled-system'
-
-export type { TextColorProps } from './textColor'
-export { backgroundColor } from './backgroundColor'
-export { uiColors, textColors } from './blends'
-export { derivativeColors } from './derivative'
-export { textColor } from './textColor'
-export { specifiableTextColors } from './specifiable'
+export type RippleColorProps = {
+  /**
+   * Change the color of the ripple background and foreground
+   * @default neutral
+   */
+  color?: ExtendedStatefulColor
+}

--- a/packages/components/src/Ripple/useRipple.test.tsx
+++ b/packages/components/src/Ripple/useRipple.test.tsx
@@ -34,9 +34,7 @@ const RippleComponent = (props: UseRippleProps) => {
     callbacks: { startBG, endBG, startFG, endFG },
     className,
     ref,
-    rippleOffset,
-    rippleScaleRange,
-    rippleSize,
+    style,
   } = useRipple(props)
   return (
     <div ref={ref}>
@@ -45,9 +43,7 @@ const RippleComponent = (props: UseRippleProps) => {
       <div data-testid="startFG" onClick={startFG} />
       <div data-testid="endFG" onClick={endFG} />
       <div data-testid="className">{className}</div>
-      <div data-testid="rippleOffset">{rippleOffset}</div>
-      <div data-testid="rippleScaleRange">{rippleScaleRange.join('-')}</div>
-      <div data-testid="rippleSize">{rippleSize}</div>
+      <div style={style}>style</div>
     </div>
   )
 }
@@ -89,18 +85,35 @@ const runTimers = () =>
 describe('useRipple', () => {
   test('animation values', () => {
     renderWithTheme(<RippleComponent />)
-    expect(screen.getByTestId('rippleOffset')).toHaveTextContent('0, 0')
-    expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent('0.1-1')
-    expect(screen.getByTestId('rippleSize')).toHaveTextContent('100%')
+    expect(screen.getByText('style')).toHaveStyle({
+      '--ripple-color': '#71767a',
+      '--ripple-scale-end': '1',
+      '--ripple-scale-start': '0.1',
+      '--ripple-size': '100%',
+      '--ripple-translate': '0, 0',
+    })
   })
 
   test('bounded animation values', () => {
     renderWithTheme(<RippleComponent bounded />)
-    expect(screen.getByTestId('rippleOffset')).toHaveTextContent('165px, 0')
-    expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent(
-      '1-12.041594578792294'
-    )
-    expect(screen.getByTestId('rippleSize')).toHaveTextContent('30px')
+    expect(screen.getByText('style')).toHaveStyle({
+      '--ripple-color': '#71767a',
+      '--ripple-scale-end': '12.041594578792294',
+      '--ripple-scale-start': '1',
+      '--ripple-size': '30px',
+      '--ripple-translate': '165px, 0',
+    })
+  })
+
+  test('color animation values', () => {
+    renderWithTheme(<RippleComponent color="key" />)
+    expect(screen.getByText('style')).toHaveStyle({
+      '--ripple-color': '#6C43E0',
+      '--ripple-scale-end': '1',
+      '--ripple-scale-start': '0.1',
+      '--ripple-size': '100%',
+      '--ripple-translate': '0, 0',
+    })
   })
 
   test('callbacks control className', () => {

--- a/packages/components/src/Ripple/useRipple.test.tsx
+++ b/packages/components/src/Ripple/useRipple.test.tsx
@@ -1,0 +1,166 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { useRipple, UseRippleProps } from './useRipple'
+
+const RippleComponent = (props: UseRippleProps) => {
+  const {
+    callbacks: { startBG, endBG, startFG, endFG },
+    className,
+    ref,
+    rippleOffset,
+    rippleScaleRange,
+    rippleSize,
+  } = useRipple(props)
+  return (
+    <div ref={ref}>
+      <div data-testid="startBG" onClick={startBG} />
+      <div data-testid="endBG" onClick={endBG} />
+      <div data-testid="startFG" onClick={startFG} />
+      <div data-testid="endFG" onClick={endFG} />
+      <div data-testid="className">{className}</div>
+      <div data-testid="rippleOffset">{rippleOffset}</div>
+      <div data-testid="rippleScaleRange">{rippleScaleRange.join('-')}</div>
+      <div data-testid="rippleSize">{rippleSize}</div>
+    </div>
+  )
+}
+
+/* eslint-disable-next-line @typescript-eslint/unbound-method */
+const globalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  /* eslint-disable-next-line @typescript-eslint/unbound-method */
+  Element.prototype.getBoundingClientRect = jest.fn(() => {
+    return {
+      bottom: 0,
+      height: 30,
+      left: 0,
+      right: 0,
+      toJSON: jest.fn(),
+      top: 0,
+      width: 360,
+      x: 0,
+      y: 0,
+    }
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    jest.runOnlyPendingTimers()
+  })
+  jest.useRealTimers()
+  /* eslint-disable-next-line @typescript-eslint/unbound-method */
+  Element.prototype.getBoundingClientRect = globalGetBoundingClientRect
+})
+const runTimers = () =>
+  act(() => {
+    jest.runOnlyPendingTimers()
+  })
+
+describe('useRipple', () => {
+  test('animation values', () => {
+    render(<RippleComponent />)
+    expect(screen.getByTestId('rippleOffset')).toHaveTextContent('0, 0')
+    expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent('0.1-1')
+    expect(screen.getByTestId('rippleSize')).toHaveTextContent('100%')
+  })
+
+  test('bounded animation values', () => {
+    render(<RippleComponent bounded />)
+    expect(screen.getByTestId('rippleOffset')).toHaveTextContent('165px, 0')
+    expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent(
+      '1-12.041594578792294'
+    )
+    expect(screen.getByTestId('rippleSize')).toHaveTextContent('30px')
+  })
+
+  test('callbacks control className', () => {
+    render(<RippleComponent />)
+    expect(screen.getByTestId('className')).toHaveTextContent('')
+
+    fireEvent.click(screen.getByTestId('startBG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
+
+    fireEvent.click(screen.getByTestId('startFG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on fg-in')
+
+    // foreground is locked for a minimum time to animate the ripple
+    fireEvent.click(screen.getByTestId('endFG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on fg-in')
+    runTimers()
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on fg-out')
+    runTimers()
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
+
+    fireEvent.click(screen.getByTestId('endBG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('')
+  })
+
+  test('long press', () => {
+    render(<RippleComponent />)
+    expect(screen.getByTestId('className')).toHaveTextContent('')
+
+    fireEvent.click(screen.getByTestId('startBG'))
+    fireEvent.click(screen.getByTestId('startFG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on fg-in')
+
+    // foreground is locked for a minimum time to animate the ripple
+    runTimers()
+    fireEvent.click(screen.getByTestId('endFG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on fg-out')
+  })
+
+  test('tab keyup', () => {
+    // Key up triggers endFG but shouldn't ripple out unless ripple is already in
+    // e.g. when tabbing onto a ripple element
+    render(<RippleComponent />)
+    fireEvent.click(screen.getByTestId('startBG'))
+    fireEvent.click(screen.getByTestId('endFG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
+  })
+
+  test('"double on" background behavior', () => {
+    // The "double on" behavior tracks when the background has been activated by
+    // both hover and focus and needs both hover out and blur to de-activate
+    render(<RippleComponent />)
+    expect(screen.getByTestId('className')).toHaveTextContent('')
+
+    fireEvent.click(screen.getByTestId('startBG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
+    fireEvent.click(screen.getByTestId('startBG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
+
+    fireEvent.click(screen.getByTestId('endBG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
+    fireEvent.click(screen.getByTestId('endBG'))
+    expect(screen.getByTestId('className')).toHaveTextContent('')
+  })
+})

--- a/packages/components/src/Ripple/useRipple.test.tsx
+++ b/packages/components/src/Ripple/useRipple.test.tsx
@@ -24,7 +24,8 @@
 
  */
 
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { renderWithTheme } from '@looker/components-test-utils'
+import { act, fireEvent, screen } from '@testing-library/react'
 import React from 'react'
 import { useRipple, UseRippleProps } from './useRipple'
 
@@ -87,14 +88,14 @@ const runTimers = () =>
 
 describe('useRipple', () => {
   test('animation values', () => {
-    render(<RippleComponent />)
+    renderWithTheme(<RippleComponent />)
     expect(screen.getByTestId('rippleOffset')).toHaveTextContent('0, 0')
     expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent('0.1-1')
     expect(screen.getByTestId('rippleSize')).toHaveTextContent('100%')
   })
 
   test('bounded animation values', () => {
-    render(<RippleComponent bounded />)
+    renderWithTheme(<RippleComponent bounded />)
     expect(screen.getByTestId('rippleOffset')).toHaveTextContent('165px, 0')
     expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent(
       '1-12.041594578792294'
@@ -103,7 +104,7 @@ describe('useRipple', () => {
   })
 
   test('callbacks control className', () => {
-    render(<RippleComponent />)
+    renderWithTheme(<RippleComponent />)
     expect(screen.getByTestId('className')).toHaveTextContent('')
 
     fireEvent.click(screen.getByTestId('startBG'))
@@ -125,7 +126,7 @@ describe('useRipple', () => {
   })
 
   test('long press', () => {
-    render(<RippleComponent />)
+    renderWithTheme(<RippleComponent />)
     expect(screen.getByTestId('className')).toHaveTextContent('')
 
     fireEvent.click(screen.getByTestId('startBG'))
@@ -141,7 +142,7 @@ describe('useRipple', () => {
   test('tab keyup', () => {
     // Key up triggers endFG but shouldn't ripple out unless ripple is already in
     // e.g. when tabbing onto a ripple element
-    render(<RippleComponent />)
+    renderWithTheme(<RippleComponent />)
     fireEvent.click(screen.getByTestId('startBG'))
     fireEvent.click(screen.getByTestId('endFG'))
     expect(screen.getByTestId('className')).toHaveTextContent('bg-on')
@@ -150,7 +151,7 @@ describe('useRipple', () => {
   test('"double on" background behavior', () => {
     // The "double on" behavior tracks when the background has been activated by
     // both hover and focus and needs both hover out and blur to de-activate
-    render(<RippleComponent />)
+    renderWithTheme(<RippleComponent />)
     expect(screen.getByTestId('className')).toHaveTextContent('')
 
     fireEvent.click(screen.getByTestId('startBG'))

--- a/packages/components/src/Ripple/useRipple.tsx
+++ b/packages/components/src/Ripple/useRipple.tsx
@@ -25,15 +25,11 @@
  */
 
 import { useMeasuredElement, useCallbackRef } from '../utils'
-import {
-  RippleAnimationValues,
-  RippleCallbacks,
-  RippleColorProps,
-} from './types'
+import { RippleAnimationValues, RippleCallbacks } from './types'
 import { useRippleState } from './useRippleState'
 import { useRippleStateBG } from './useRippleStateBG'
 
-export type UseRippleProps = RippleColorProps & {
+export type UseRippleProps = {
   /**
    * Use for elements where the ripple disappears at the edges of
    * a visible rectangle, e.g. a default Button
@@ -42,8 +38,17 @@ export type UseRippleProps = RippleColorProps & {
 }
 
 export type UseRippleResponse = RippleAnimationValues & {
+  /**
+   * The start and end functions for the background and foreground
+   */
   callbacks: RippleCallbacks
+  /**
+   * The class names used in rippleStyle to trigger the animations
+   */
   className: string
+  /**
+   * ref is only used for bounded ripple, to detect element dimensions
+   */
   ref?: (node: HTMLElement | null) => void
 }
 
@@ -83,6 +88,10 @@ const getRippleOffset = (min: number, max: number, bounded?: boolean) => {
   return `${offset}px, 0`
 }
 
+/**
+ * @returns callbacks should be mapped to DOM event handlers (see useRippleHandlers)
+ * and remaining props should be passed to an internal element that includes rippleStyle
+ */
 export const useRipple = ({ bounded }: UseRippleProps): UseRippleResponse => {
   // ref is actually only used for bounded, when dimensions are needed
   // otherwise ref is wasteful since it triggers a state update & re-render

--- a/packages/components/src/Ripple/useRipple.tsx
+++ b/packages/components/src/Ripple/useRipple.tsx
@@ -1,0 +1,119 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { useMeasuredElement, useCallbackRef } from '../utils'
+import {
+  RippleAnimationValues,
+  RippleCallbacks,
+  RippleColorProps,
+} from './types'
+import { useRippleState } from './useRippleState'
+import { useRippleStateBG } from './useRippleStateBG'
+
+export type UseRippleProps = RippleColorProps & {
+  /**
+   * Use for elements where the ripple disappears at the edges of
+   * a visible rectangle, e.g. a default Button
+   */
+  bounded?: boolean
+}
+
+export type UseRippleResponse = RippleAnimationValues & {
+  callbacks: RippleCallbacks
+  className: string
+  ref?: (node: HTMLElement | null) => void
+}
+
+const getMinMaxDimensions = (width: number, height: number) => {
+  const min = Math.min(width, height)
+  const max = Math.max(width, height)
+  return [min, max]
+}
+
+const getRippleScaleRange = (
+  min: number,
+  max: number,
+  bounded?: boolean
+): [number, number] => {
+  // For squares it looks best to start the ripple very small
+  const start = 0.1
+  if (bounded) {
+    // For rectangles it looks better to start at the size of the smaller dimension
+    // which is 1 because of how size is calculated
+    const startBounded = min === max ? start : 1
+    // The ripple needs to spread past all corners, use hypotenuse as the
+    // final diameter, and start at 1 to make the animation less jarring
+    return [startBounded, Math.hypot(min, max) / min]
+  }
+  // Start small and expand to the full size
+  return [start, 1]
+}
+
+const getRippleOffset = (min: number, max: number, bounded?: boolean) => {
+  if (!bounded || min === max) {
+    return '0, 0'
+  }
+  // If the element is rectangular, adjust the center of the ripple
+  // further along the larger dimension
+  // NOTE: Currently only works for a horizontal rectangle like a Button
+  const offset = max / 2 - min / 2
+  return `${offset}px, 0`
+}
+
+export const useRipple = ({ bounded }: UseRippleProps): UseRippleResponse => {
+  // ref is actually only used for bounded, when dimensions are needed
+  // otherwise ref is wasteful since it triggers a state update & re-render
+  const [element, ref] = useCallbackRef()
+  const [{ width, height }] = useMeasuredElement(element)
+
+  // Get values for animation – bounded uses dimensions, otherwise they're static
+  const [min, max] = getMinMaxDimensions(width, height)
+  const rippleScaleRange = getRippleScaleRange(min, max, bounded)
+  const rippleOffset = getRippleOffset(min, max, bounded)
+
+  // Background (hover, focus) and foreground (press) ripple states
+  const { start: startBG, end: endBG, className: bgClass } = useRippleStateBG()
+  const { start: startFG, end: endFG, className: fgClass } = useRippleState()
+
+  return {
+    // Functions to be called from event handlers
+    // Use useRippleHandlers for most common mapping
+    callbacks: {
+      endBG,
+      endFG,
+      startBG,
+      startFG,
+    },
+    // Props to be applied to the same element that gets rippleStyle
+    className: `${bgClass} ${fgClass}`,
+    // bounded needs to get the element size
+    ref: bounded ? ref : undefined,
+    rippleOffset,
+    rippleScaleRange,
+    // bounded needs an explicit size, otherwise just fill the whole area
+    rippleSize: bounded ? `${min}px` : '100%',
+  }
+}

--- a/packages/components/src/Ripple/useRippleHandlers.test.tsx
+++ b/packages/components/src/Ripple/useRippleHandlers.test.tsx
@@ -97,10 +97,45 @@ describe('useRippleHandlers', () => {
 
     fireEvent.keyDown(button, { key: ' ' })
     expect(callbackMocks.startFG).toHaveBeenCalledTimes(3)
-    expect(handlerMocks.onMouseDown).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onKeyDown).toHaveBeenCalledTimes(1)
 
     fireEvent.keyUp(button)
     expect(callbackMocks.endFG).toHaveBeenCalledTimes(3)
-    expect(handlerMocks.onMouseUp).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onKeyUp).toHaveBeenCalledTimes(1)
+  })
+
+  test('disabled', () => {
+    render(
+      <RippleHandlersComponent
+        callbacks={callbackMocks}
+        currentHandlers={handlerMocks}
+        disabled
+      />
+    )
+    const button = screen.getByRole('button')
+
+    fireEvent.mouseEnter(button)
+    fireEvent.mouseLeave(button)
+    fireEvent.focus(button)
+    fireEvent.blur(button)
+    fireEvent.mouseDown(button)
+    fireEvent.mouseUp(button)
+    fireEvent.keyDown(button, { key: 'Enter' })
+    fireEvent.keyDown(button, { key: ' ' })
+    fireEvent.keyUp(button)
+
+    expect(callbackMocks.startBG).not.toHaveBeenCalled()
+    expect(callbackMocks.endBG).not.toHaveBeenCalled()
+    expect(callbackMocks.startFG).not.toHaveBeenCalled()
+    expect(callbackMocks.endFG).not.toHaveBeenCalled()
+
+    expect(handlerMocks.onMouseEnter).not.toHaveBeenCalled()
+    expect(handlerMocks.onMouseLeave).not.toHaveBeenCalled()
+    expect(handlerMocks.onFocus).not.toHaveBeenCalled()
+    expect(handlerMocks.onBlur).not.toHaveBeenCalled()
+    expect(handlerMocks.onMouseDown).not.toHaveBeenCalled()
+    expect(handlerMocks.onMouseUp).not.toHaveBeenCalled()
+    expect(handlerMocks.onKeyDown).not.toHaveBeenCalled()
+    expect(handlerMocks.onKeyUp).not.toHaveBeenCalled()
   })
 })

--- a/packages/components/src/Ripple/useRippleHandlers.test.tsx
+++ b/packages/components/src/Ripple/useRippleHandlers.test.tsx
@@ -1,0 +1,105 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { RippleCallbacks } from './types'
+import { RippleHandlers, useRippleHandlers } from './useRippleHandlers'
+
+const RippleHandlersComponent = ({
+  callbacks,
+  currentHandlers,
+  disabled,
+}: {
+  callbacks: RippleCallbacks
+  currentHandlers: RippleHandlers<HTMLButtonElement>
+  disabled?: boolean
+}) => {
+  const handlers = useRippleHandlers(callbacks, currentHandlers, disabled)
+  return <button {...handlers} />
+}
+
+const callbackMocks = {
+  endBG: jest.fn(),
+  endFG: jest.fn(),
+  startBG: jest.fn(),
+  startFG: jest.fn(),
+}
+const handlerMocks = {
+  onBlur: jest.fn(),
+  onFocus: jest.fn(),
+  onKeyDown: jest.fn(),
+  onKeyUp: jest.fn(),
+  onMouseDown: jest.fn(),
+  onMouseEnter: jest.fn(),
+  onMouseLeave: jest.fn(),
+  onMouseUp: jest.fn(),
+}
+
+describe('useRippleHandlers', () => {
+  test('maps handlers', () => {
+    render(
+      <RippleHandlersComponent
+        callbacks={callbackMocks}
+        currentHandlers={handlerMocks}
+      />
+    )
+
+    const button = screen.getByRole('button')
+
+    fireEvent.mouseEnter(button)
+    expect(callbackMocks.startBG).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onMouseEnter).toHaveBeenCalledTimes(1)
+    fireEvent.mouseLeave(button)
+    expect(callbackMocks.endBG).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onMouseLeave).toHaveBeenCalledTimes(1)
+
+    fireEvent.focus(button)
+    expect(callbackMocks.startBG).toHaveBeenCalledTimes(2)
+    expect(handlerMocks.onFocus).toHaveBeenCalledTimes(1)
+    fireEvent.blur(button)
+    expect(callbackMocks.endBG).toHaveBeenCalledTimes(2)
+    expect(handlerMocks.onBlur).toHaveBeenCalledTimes(1)
+
+    fireEvent.mouseDown(button)
+    expect(callbackMocks.startFG).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onMouseDown).toHaveBeenCalledTimes(1)
+    fireEvent.mouseUp(button)
+    expect(callbackMocks.endFG).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onMouseUp).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(callbackMocks.startFG).toHaveBeenCalledTimes(2)
+
+    fireEvent.keyDown(button, { key: ' ' })
+    expect(callbackMocks.startFG).toHaveBeenCalledTimes(3)
+    expect(handlerMocks.onMouseDown).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyUp(button)
+    expect(callbackMocks.endFG).toHaveBeenCalledTimes(2)
+    expect(handlerMocks.onMouseUp).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/components/src/Ripple/useRippleHandlers.test.tsx
+++ b/packages/components/src/Ripple/useRippleHandlers.test.tsx
@@ -75,6 +75,7 @@ describe('useRippleHandlers', () => {
     expect(handlerMocks.onMouseEnter).toHaveBeenCalledTimes(1)
     fireEvent.mouseLeave(button)
     expect(callbackMocks.endBG).toHaveBeenCalledTimes(1)
+    expect(callbackMocks.endFG).toHaveBeenCalledTimes(1)
     expect(handlerMocks.onMouseLeave).toHaveBeenCalledTimes(1)
 
     fireEvent.focus(button)
@@ -88,7 +89,7 @@ describe('useRippleHandlers', () => {
     expect(callbackMocks.startFG).toHaveBeenCalledTimes(1)
     expect(handlerMocks.onMouseDown).toHaveBeenCalledTimes(1)
     fireEvent.mouseUp(button)
-    expect(callbackMocks.endFG).toHaveBeenCalledTimes(1)
+    expect(callbackMocks.endFG).toHaveBeenCalledTimes(2)
     expect(handlerMocks.onMouseUp).toHaveBeenCalledTimes(1)
 
     fireEvent.keyDown(button, { key: 'Enter' })
@@ -99,7 +100,7 @@ describe('useRippleHandlers', () => {
     expect(handlerMocks.onMouseDown).toHaveBeenCalledTimes(1)
 
     fireEvent.keyUp(button)
-    expect(callbackMocks.endFG).toHaveBeenCalledTimes(2)
+    expect(callbackMocks.endFG).toHaveBeenCalledTimes(3)
     expect(handlerMocks.onMouseUp).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/components/src/Ripple/useRippleHandlers.test.tsx
+++ b/packages/components/src/Ripple/useRippleHandlers.test.tsx
@@ -59,6 +59,10 @@ const handlerMocks = {
   onMouseUp: jest.fn(),
 }
 
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
 describe('useRippleHandlers', () => {
   test('maps handlers', () => {
     render(
@@ -97,7 +101,7 @@ describe('useRippleHandlers', () => {
 
     fireEvent.keyDown(button, { key: ' ' })
     expect(callbackMocks.startFG).toHaveBeenCalledTimes(3)
-    expect(handlerMocks.onKeyDown).toHaveBeenCalledTimes(1)
+    expect(handlerMocks.onKeyDown).toHaveBeenCalledTimes(2)
 
     fireEvent.keyUp(button)
     expect(callbackMocks.endFG).toHaveBeenCalledTimes(3)

--- a/packages/components/src/Ripple/useRippleHandlers.ts
+++ b/packages/components/src/Ripple/useRippleHandlers.ts
@@ -1,0 +1,77 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { KeyboardEvent, useCallback } from 'react'
+import { CompatibleHTMLProps } from '@looker/design-tokens'
+import { useWrapEvent } from '../utils'
+import { RippleCallbacks } from './types'
+
+export const rippleHandlerKeys = [
+  'onBlur',
+  'onFocus',
+  'onKeyDown',
+  'onKeyUp',
+  'onMouseDown',
+  'onMouseEnter',
+  'onMouseLeave',
+  'onMouseUp',
+] as const
+
+export type RippleHandlers<E extends HTMLElement> = Pick<
+  CompatibleHTMLProps<E>,
+  typeof rippleHandlerKeys[number]
+>
+
+export const useRippleHandlers = <E extends HTMLElement>(
+  { startBG, endBG, startFG, endFG }: RippleCallbacks,
+  currentHandlers: RippleHandlers<E>,
+  disabled?: boolean
+): RippleHandlers<E> => {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Enter':
+        case ' ':
+          startFG()
+          break
+      }
+    },
+    [startFG]
+  )
+
+  const wrappedCallbacks = {
+    onBlur: useWrapEvent(endBG, currentHandlers.onBlur),
+    onFocus: useWrapEvent(startBG, currentHandlers.onFocus),
+    onKeyDown: useWrapEvent(handleKeyDown, currentHandlers.onKeyDown),
+    onKeyUp: useWrapEvent(endFG, currentHandlers.onKeyUp),
+    onMouseDown: useWrapEvent(startFG, currentHandlers.onMouseDown),
+    onMouseEnter: useWrapEvent(startBG, currentHandlers.onMouseEnter),
+    onMouseLeave: useWrapEvent(endBG, currentHandlers.onMouseLeave),
+    onMouseUp: useWrapEvent(endFG, currentHandlers.onMouseUp),
+  }
+
+  return disabled ? {} : wrappedCallbacks
+}

--- a/packages/components/src/Ripple/useRippleHandlers.ts
+++ b/packages/components/src/Ripple/useRippleHandlers.ts
@@ -45,6 +45,13 @@ export type RippleHandlers<E extends HTMLElement> = Pick<
   typeof rippleHandlerKeys[number]
 >
 
+/**
+ *
+ * @param callbacks from useRipple, start and end functions for foreground and background
+ * @param currentHandlers existing event handlers for the element will be wrapped
+ * @param disabled
+ * @returns wrapped event handlers
+ */
 export const useRippleHandlers = <E extends HTMLElement>(
   { startBG, endBG, startFG, endFG }: RippleCallbacks,
   currentHandlers: RippleHandlers<E>,
@@ -53,6 +60,7 @@ export const useRippleHandlers = <E extends HTMLElement>(
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       switch (e.key) {
+        // Only start the ripple for enter or space key
         case 'Enter':
         case ' ':
           startFG()
@@ -62,6 +70,12 @@ export const useRippleHandlers = <E extends HTMLElement>(
     [startFG]
   )
 
+  const handleMouseLeave = useCallback(() => {
+    endBG()
+    // If the user hovers off of the element while pressing, end the ripple
+    endFG()
+  }, [endFG, endBG])
+
   const wrappedCallbacks = {
     onBlur: useWrapEvent(endBG, currentHandlers.onBlur),
     onFocus: useWrapEvent(startBG, currentHandlers.onFocus),
@@ -69,7 +83,7 @@ export const useRippleHandlers = <E extends HTMLElement>(
     onKeyUp: useWrapEvent(endFG, currentHandlers.onKeyUp),
     onMouseDown: useWrapEvent(startFG, currentHandlers.onMouseDown),
     onMouseEnter: useWrapEvent(startBG, currentHandlers.onMouseEnter),
-    onMouseLeave: useWrapEvent(endBG, currentHandlers.onMouseLeave),
+    onMouseLeave: useWrapEvent(handleMouseLeave, currentHandlers.onMouseLeave),
     onMouseUp: useWrapEvent(endFG, currentHandlers.onMouseUp),
   }
 

--- a/packages/components/src/Ripple/useRippleState.ts
+++ b/packages/components/src/Ripple/useRippleState.ts
@@ -1,0 +1,94 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { Reducer, useCallback, useEffect, useReducer, useRef } from 'react'
+
+export interface RippleAction {
+  type: 'START' | 'END' | 'DONE'
+}
+
+export type RippleState = 'IN' | 'OUT' | 'OFF'
+
+const reducer: Reducer<RippleState, RippleAction> = (state, action) => {
+  switch (action.type) {
+    case 'START':
+      return 'IN'
+    case 'END':
+      return state === 'IN' ? 'OUT' : state
+    case 'DONE':
+      return 'OFF'
+  }
+}
+
+const getRippleClassName = (rippling: RippleState) => {
+  if (rippling === 'IN') {
+    return `fg-in`
+  } else if (rippling === 'OUT') {
+    return `fg-out`
+  }
+  return ''
+}
+
+export const useRippleState = () => {
+  const [rippling, dispatch] = useReducer(reducer, 'OFF')
+  const isInRef = useRef(false)
+  const isLockedRef = useRef(false)
+
+  const start = useCallback(() => {
+    dispatch({ type: 'START' })
+    isInRef.current = true
+  }, [])
+
+  const end = useCallback(() => {
+    isInRef.current = false
+    if (!isLockedRef.current) {
+      dispatch({ type: 'END' })
+    }
+  }, [])
+
+  useEffect(() => {
+    let t: ReturnType<typeof setTimeout>
+    if (rippling === 'IN') {
+      isLockedRef.current = true
+      t = setTimeout(() => {
+        isLockedRef.current = false
+        if (!isInRef.current) {
+          dispatch({ type: 'END' })
+        }
+      }, 200)
+    }
+    if (rippling === 'OUT') {
+      t = setTimeout(() => {
+        dispatch({ type: 'DONE' })
+      }, 200)
+    }
+    return () => {
+      clearTimeout(t)
+    }
+  }, [rippling])
+
+  return { className: getRippleClassName(rippling), end, start }
+}

--- a/packages/components/src/Ripple/useRippleState.ts
+++ b/packages/components/src/Ripple/useRippleState.ts
@@ -55,9 +55,9 @@ const reducer: Reducer<RippleState, RippleAction> = (state, action) => {
 
 const getRippleClassName = (rippling: RippleState) => {
   if (rippling === 'IN') {
-    return `fg-in`
+    return 'fg-in'
   } else if (rippling === 'OUT') {
-    return `fg-out`
+    return 'fg-out'
   }
   return ''
 }

--- a/packages/components/src/Ripple/useRippleStateBG.ts
+++ b/packages/components/src/Ripple/useRippleStateBG.ts
@@ -24,34 +24,32 @@
 
  */
 
-import { BlendColors } from './blends'
-import { StatefulColors } from './stateful'
-import { SpecifiableColors, TextColor } from './specifiable'
-import { DerivativeColors } from './derivative'
+import { Reducer, useCallback, useReducer } from 'react'
 
-export type Colors = SpecifiableColors &
-  DerivativeColors &
-  BlendColors &
-  StatefulColors
+export interface RippleActionBG {
+  type: 'START' | 'END'
+}
 
-export type TextColors = TextColor
+export type RippleStateBG = 'ON' | 'DOUBLE_ON' | 'OFF'
 
-export { coreColors, intentColors, specifiableColors } from './specifiable'
+const reducer: Reducer<RippleStateBG, RippleActionBG> = (state, action) => {
+  switch (action.type) {
+    case 'START':
+      return state === 'ON' ? 'DOUBLE_ON' : 'ON'
+    case 'END':
+      return state === 'DOUBLE_ON' ? 'ON' : 'OFF'
+  }
+}
 
-export type { DerivativeColors } from './derivative'
-export type { CoreColors, IntentColors, SpecifiableColors } from './specifiable'
-export type { BlendColors } from './blends'
-export type {
-  ExtendedStatefulColor,
-  StatefulColor,
-  StatefulColors,
-  StatefulColorChoices,
-} from './stateful'
-export type { ColorProps } from 'styled-system'
-
-export type { TextColorProps } from './textColor'
-export { backgroundColor } from './backgroundColor'
-export { uiColors, textColors } from './blends'
-export { derivativeColors } from './derivative'
-export { textColor } from './textColor'
-export { specifiableTextColors } from './specifiable'
+export const useRippleStateBG = () => {
+  const [state, dispatch] = useReducer(reducer, 'OFF')
+  return {
+    className: state === 'OFF' ? '' : 'bg-on',
+    end: useCallback(() => {
+      dispatch({ type: 'END' })
+    }, []),
+    start: useCallback(() => {
+      dispatch({ type: 'START' })
+    }, []),
+  }
+}

--- a/packages/components/src/Ripple/useRippleStateBG.ts
+++ b/packages/components/src/Ripple/useRippleStateBG.ts
@@ -34,6 +34,8 @@ export type RippleStateBG = 'ON' | 'DOUBLE_ON' | 'OFF'
 
 const reducer: Reducer<RippleStateBG, RippleActionBG> = (state, action) => {
   switch (action.type) {
+    // 'DOUBLE_ON' allows detection of "hover & focus" state
+    // background should only turn off when hovered out AND blurred
     case 'START':
       return state === 'ON' ? 'DOUBLE_ON' : 'ON'
     case 'END':


### PR DESCRIPTION
Adds hooks and style helpers to support the ripple effect, and a story file to demo it.

This PR adds it to `IconButton`: https://github.com/looker-open-source/components/pull/2721

**Question: should the ripple functions be exported or for internal use only? If the latter, I guess this would be a "chore" PR instead of a "feat".**

- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] IE11 – only the background renders, not the foreground ripple. Same with material web components.
