### PR TITLE
feat: Leverage `uX` theme.space unit notation within library

### DIFF
--- a/apps/filter-demo/src/HeaderButtons.tsx
+++ b/apps/filter-demo/src/HeaderButtons.tsx
@@ -63,7 +63,7 @@ export const HeaderButtons: FC<HeaderButtonProps> = ({
   }, [needsUpdate])
 
   return (
-    <Space gap="xsmall">
+    <Space gap="u2">
       {needsUpdate ? (
         <Button
           iconBefore={<Refresh />}

--- a/packages/components-date/src/InputDate/InputDate.story.tsx
+++ b/packages/components-date/src/InputDate/InputDate.story.tsx
@@ -60,9 +60,9 @@ export const Controlled = () => {
     setSelectedDate(date)
   }
   return (
-    <Space gap="xxlarge">
+    <Space gap="u10">
       <InputDate defaultValue={selectedDate} onChange={handleChange} />
-      <Box p="large" height="100%" borderLeft="1px solid #ccc">
+      <Box p="u5" height="100%" borderLeft="1px solid #ccc">
         <Heading>Selected:</Heading>
         <Text color="text2">
           <DateFormat>{selectedDate}</DateFormat>

--- a/packages/components-date/src/InputDateRange/InputDateRange.tsx
+++ b/packages/components-date/src/InputDateRange/InputDateRange.tsx
@@ -471,8 +471,8 @@ const InputDateRangeWrapper = styled.div`
 
 const MultiCalendarLayout = styled.div`
   display: inline-grid;
-  grid-column-gap: ${({ theme }) => theme.space.large};
-  grid-row-gap: ${({ theme }) => theme.space.medium};
+  grid-column-gap: ${({ theme }) => theme.space.u5};
+  grid-row-gap: ${({ theme }) => theme.space.u4};
   grid-template-columns: 1fr 1fr;
   @media screen and (max-width: ${({ theme }) => theme.breakpoints[1]}) {
     grid-template-columns: 1fr;
@@ -491,9 +491,9 @@ const InputTextGroupWrapper = styled.div<InputTextGroupWrapperProps>`
   align-items: center;
   display: grid;
   font-family: ${({ theme }) => theme.fonts.body};
-  grid-gap: ${({ theme }) => theme.space.xsmall};
+  grid-gap: ${({ theme }) => theme.space.u2};
   grid-template-columns: auto auto auto 1fr;
-  padding: 0 ${({ theme: { space } }) => space.small};
+  padding: 0 ${({ theme: { space } }) => space.u3};
   width: 100%;
   &:hover {
     ${inputTextHover}
@@ -509,12 +509,12 @@ const InputTextGroupWrapper = styled.div<InputTextGroupWrapperProps>`
 
   ${ErrorIcon} {
     justify-self: right;
-    margin-right: ${({ theme }) => theme.space.xxsmall};
+    margin-right: ${({ theme }) => theme.space.u1};
   }
 `
 
 const InputTextWrapper = styled.div<{ inputLength: number }>`
-  padding: ${({ theme: { space } }) => space.xxsmall} 0;
+  padding: ${({ theme: { space } }) => space.u1} 0;
   ${InlineInputTextBase} {
     align-self: center;
     height: ${({ theme }) => theme.lineHeights.large};

--- a/packages/components-date/src/InputTime/InputTime.tsx
+++ b/packages/components-date/src/InputTime/InputTime.tsx
@@ -556,7 +556,7 @@ export const InputTime = styled(InputTimeInternal)`
   display: inline-grid;
   grid-gap: 0.15rem;
   grid-template-columns: auto auto auto auto 1fr;
-  padding: 0 ${({ theme }) => theme.space.xsmall};
+  padding: 0 ${({ theme }) => theme.space.u2};
 
   ${ErrorIcon} {
     justify-self: end;

--- a/packages/components-theme-editor/src/Examples/ColorSwatches.tsx
+++ b/packages/components-theme-editor/src/Examples/ColorSwatches.tsx
@@ -43,5 +43,5 @@ export const ColorSwatches = () => {
     </Card>
   ))
 
-  return <SpaceVertical gap="xxsmall">{swatches}</SpaceVertical>
+  return <SpaceVertical gap="u1">{swatches}</SpaceVertical>
 }

--- a/packages/components-theme-editor/src/Examples/ComponentSuite.tsx
+++ b/packages/components-theme-editor/src/Examples/ComponentSuite.tsx
@@ -55,7 +55,7 @@ export const ComponentSuite = () => {
   const [value, setValue] = useState(['One'])
 
   return (
-    <SpaceVertical gap="xsmall">
+    <SpaceVertical gap="u2">
       <Button>My neat button</Button>
       <Button color="neutral">My neat button</Button>
       <Button color="critical">My neat button</Button>

--- a/packages/components-theme-editor/src/Examples/Dashboard.tsx
+++ b/packages/components-theme-editor/src/Examples/Dashboard.tsx
@@ -48,10 +48,10 @@ import { FauxPieChart, FauxBarChart } from './Charts'
 
 export const FauxDashboard = () => (
   <Box bg="background">
-    <SpaceVertical p="xlarge" gap="xlarge">
+    <SpaceVertical p="u8" gap="u8">
       <Space between>
         <Heading fontSize="xxxlarge">Title</Heading>
-        <Space width="auto" gap="small">
+        <Space width="auto" gap="u3">
           <IconButton size="medium" label="Refresh" icon={<Refresh />} />
           <IconButton size="medium" label="Options" icon={<MoreVert />} />
         </Space>
@@ -75,7 +75,7 @@ export const FauxDashboard = () => (
         </Field>
       </Space>
 
-      <SpaceVertical align="center" gap="xxsmall">
+      <SpaceVertical align="center" gap="u1">
         <Heading as="h2">Some title here</Heading>
         <Heading as="h3" color="text2">
           Some less important information

--- a/packages/components-theme-editor/src/stories/Theme.story.tsx
+++ b/packages/components-theme-editor/src/stories/Theme.story.tsx
@@ -36,7 +36,7 @@ ThemeEditor.parameters = {
 }
 
 export const CompareThemes = () => (
-  <Grid m="xlarge" gap="large" columns={4}>
+  <Grid m="xlarge" gap="u5" columns={4}>
     <Editor name="Default" />
     <Editor
       name="Generated"

--- a/packages/components/src/Accordion2/accordionDimensions.ts
+++ b/packages/components/src/Accordion2/accordionDimensions.ts
@@ -36,7 +36,7 @@ type AccordionDensityDimensions = {
 // Positive density values
 export const densityPositive1: AccordionDensityDimensions = {
   fontSize: 'medium',
-  indicatorGap: 'xxsmall',
+  indicatorGap: 'u1',
   indicatorSize: 'medium',
 }
 

--- a/packages/components/src/Breakpoint/Breakpoint.story.tsx
+++ b/packages/components/src/Breakpoint/Breakpoint.story.tsx
@@ -111,7 +111,7 @@ const Template: Story<BreakpointProps> = () => {
   return (
     <>
       <Breakpoint show="mobile">
-        <NavHeader backgroundColor="ui1" p="small">
+        <NavHeader backgroundColor="ui1" p="u3">
           <MobileHeaderGrid>
             <Box color="key">
               <Home size="1.5rem" title="Home" />
@@ -119,7 +119,7 @@ const Template: Story<BreakpointProps> = () => {
             <IconButton icon={<Menu />} label="navigation" />
           </MobileHeaderGrid>
         </NavHeader>
-        <Grid p="small" columns={1}>
+        <Grid p="u3" columns={1}>
           <NatureCard backgroundColor="criticalFocus" />
           <NatureCard backgroundColor="keyFocus" />
           <NatureCard backgroundColor="text2" />
@@ -128,7 +128,7 @@ const Template: Story<BreakpointProps> = () => {
       </Breakpoint>
 
       <Breakpoint show={['tablet', undefined]}>
-        <NavHeader backgroundColor="inverse" p="medium">
+        <NavHeader backgroundColor="inverse" p="u4">
           <LargeHeaderGrid>
             <Box color="text1">My logo here!</Box>
             <nav>
@@ -150,7 +150,7 @@ const Template: Story<BreakpointProps> = () => {
             <InputSearch placeholder="Search" />
           </LargeHeaderGrid>
         </NavHeader>
-        <Box p="medium">
+        <Box p="u4">
           <Breakpoint show={['tablet', 'laptop']}>
             <Grid columns={2}>
               <NatureCard backgroundColor="criticalFocus" />

--- a/packages/components/src/Button/ButtonGroup.tsx
+++ b/packages/components/src/Button/ButtonGroup.tsx
@@ -59,7 +59,7 @@ export const ButtonGroup = styled(ButtonGroupLayout)`
   ${ButtonItem} {
     border: 1px solid ${({ theme }) => theme.colors.ui2};
     border-radius: ${({ theme }) => theme.radii.medium};
-    margin-right: ${({ theme }) => theme.space.xxsmall};
+    margin-right: ${({ theme }) => theme.space.u1};
     &:last-child {
       margin-right: 0;
     }
@@ -69,9 +69,9 @@ export const ButtonGroup = styled(ButtonGroupLayout)`
     }
   }
   &.wrapping {
-    margin: -${({ theme }) => theme.space.xxxsmall};
+    margin: -${({ theme }) => theme.space.u05};
     ${ButtonItem} {
-      margin: ${({ theme }) => theme.space.xxxsmall};
+      margin: ${({ theme }) => theme.space.u05};
     }
   }
 `

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -116,7 +116,7 @@ export const ButtonItem = styled(ButtonLayout)`
   height: ${inputHeight};
   justify-content: center;
   margin: 0;
-  padding: 0 ${({ theme }) => theme.space.small};
+  padding: 0 ${({ theme }) => theme.space.u3};
   transition: background ${({ theme }) => theme.transitions.quick}ms ease;
   user-select: none;
 

--- a/packages/components/src/Button/ButtonTransparent.tsx
+++ b/packages/components/src/Button/ButtonTransparent.tsx
@@ -32,7 +32,7 @@ export const ButtonTransparent = styled(ButtonBase)`
   background: transparent;
   border: 1px solid transparent;
   color: ${({ theme, color = 'key' }) => theme.colors[color]};
-  padding: 0 ${(props) => props.theme.space.xsmall};
+  padding: 0 ${(props) => props.theme.space.u2};
 
   &:hover,
   &:focus,

--- a/packages/components/src/Card/CardContent.test.tsx
+++ b/packages/components/src/Card/CardContent.test.tsx
@@ -36,7 +36,7 @@ describe('CardContent', () => {
   })
 
   test('custom padding', () => {
-    renderWithTheme(<CardContent p="xlarge">🥑</CardContent>)
+    renderWithTheme(<CardContent p="u8">🥑</CardContent>)
     expect(screen.getByText('🥑')).toHaveStyle('padding: 2rem')
   })
 })

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -73,7 +73,7 @@ const ChipStyle = styled.span<FocusVisibleProps & MaxWidthProps>`
   font-weight: ${({ theme }) => theme.fontWeights.semiBold};
   height: 28px;
   min-width: 44px;
-  padding: ${({ theme: { space } }) => `${space.xxsmall} ${space.xsmall}`};
+  padding: ${({ theme: { space } }) => `${space.u1} ${space.u2}`};
 
   &:hover,
   &:active,

--- a/packages/components/src/ChipButton/ChipButton.tsx
+++ b/packages/components/src/ChipButton/ChipButton.tsx
@@ -46,7 +46,7 @@ export const ChipButton = styled(Chip).attrs(() => ({
   font-size: ${({ theme }) => theme.fontSizes.small};
   font-weight: ${({ theme }) => theme.fontWeights.normal};
   height: ${inputHeight};
-  padding: 0 ${({ theme }) => theme.space.medium};
+  padding: 0 ${({ theme }) => theme.space.u4};
 
   &:active,
   &[aria-pressed='true'] {

--- a/packages/components/src/DataTable/BulkActions/BulkActions.tsx
+++ b/packages/components/src/DataTable/BulkActions/BulkActions.tsx
@@ -98,7 +98,7 @@ const BulkActionsLayout: FC<BulkActionsProps> = ({
           {t('Bulk Actions')}
         </Button>
       </Menu>
-      <Space gap="small" justifyContent="center">
+      <Space gap="u3" justifyContent="center">
         {selectedItemsText}
         {selectTotalResultsButton}
       </Space>
@@ -116,7 +116,7 @@ export const BulkActions = styled(BulkActionsLayout)`
   position: relative;
 
   ${Button} {
-    left: ${({ theme }) => theme.space.small};
+    left: ${({ theme }) => theme.space.u3};
     position: absolute;
   }
 `

--- a/packages/components/src/DataTable/Column/DataTableCell.tsx
+++ b/packages/components/src/DataTable/Column/DataTableCell.tsx
@@ -76,7 +76,7 @@ const DataTableCellLayout = forwardRef(
 
     if (description) {
       content = (
-        <SpaceVertical gap="xxxsmall" align="stretch">
+        <SpaceVertical gap="u05" align="stretch">
           <span>{content}</span>
           {description && (
             <Paragraph fontSize="xsmall" color="text1" truncate>
@@ -88,7 +88,7 @@ const DataTableCellLayout = forwardRef(
 
       if (indicator) {
         content = (
-          <Space gap="medium">
+          <Space gap="u4">
             {indicator}
             {content}
           </Space>
@@ -96,7 +96,7 @@ const DataTableCellLayout = forwardRef(
       }
     } else if (indicator) {
       content = (
-        <Space gap="medium">
+        <Space gap="u4">
           {indicator}
           <span>{content}</span>
         </Space>

--- a/packages/components/src/DataTable/Filters/ColumnSelector.tsx
+++ b/packages/components/src/DataTable/Filters/ColumnSelector.tsx
@@ -73,7 +73,7 @@ export const ColumnSelector: FC<ColumnSelectorProps> = ({
   const content = (
     <PopoverContent width="12rem" overflow="hidden">
       <SpaceVertical>
-        <Space gap="xxsmall">
+        <Space gap="u1">
           <ButtonTransparent size="xsmall" onClick={all}>
             {t('Select All')}
           </ButtonTransparent>

--- a/packages/components/src/DataTable/Header/DataTableHeaderCell.tsx
+++ b/packages/components/src/DataTable/Header/DataTableHeaderCell.tsx
@@ -92,7 +92,7 @@ const DataTableHeaderCellLayout = forwardRef(
         style={{ cursor: canSort ? 'pointer' : undefined }}
         {...clickableProps}
       >
-        <Space gap="xxsmall" reverse={type === 'number'}>
+        <Space gap="u1" reverse={type === 'number'}>
           {label}
           {sortDirection && (
             <Icon

--- a/packages/components/src/DataTable/Table.tsx
+++ b/packages/components/src/DataTable/Table.tsx
@@ -114,7 +114,7 @@ const selectColumn = css<TableProps>`
             width: ${densityTarget};
           }
           &:nth-child(2) {
-            padding-left: ${({ theme }) => theme.space.xsmall};
+            padding-left: ${({ theme }) => theme.space.u2};
           }
         `
       : css`
@@ -188,7 +188,7 @@ export const Table = styled(TableLayout)`
   td,
   th {
     height: ${densityTarget}; /* acts like min-height */
-    padding: ${({ theme: { space } }) => `${space.xsmall}  ${space.medium}`};
+    padding: ${({ theme: { space } }) => `${space.u2}  ${space.u4}`};
 
     :first-child,
     :last-child {
@@ -221,7 +221,7 @@ const InterimState = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
-  padding: ${({ theme }) => theme.space.xlarge};
+  padding: ${({ theme }) => theme.space.u8};
 `
 
 export const TableScroll = styled.div`

--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.story.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.story.tsx
@@ -36,7 +36,7 @@ export const Basic = () => (
 )
 
 export const Overflow = () => (
-  <Box height="10rem" display="flex" bg="white" p="large">
+  <Box height="10rem" display="flex" bg="white" p="u5">
     <DialogContent>
       <Paragraph>Scroll down here...</Paragraph>
       <Box height="12rem" bg="rebeccapurple" />

--- a/packages/components/src/Form/Fields/Field.tsx
+++ b/packages/components/src/Form/Fields/Field.tsx
@@ -158,12 +158,12 @@ const fieldLabelCSS = (inline?: boolean) =>
         height: ${inputHeight};
         justify-self: end;
         line-height: ${inputHeight};
-        padding-right: ${({ theme }) => theme.space.small};
+        padding-right: ${({ theme }) => theme.space.u3};
         text-align: right;
       `
     : css`
         line-height: ${({ theme }) => theme.lineHeights.xsmall};
-        padding-bottom: ${({ theme }) => theme.space.xxsmall};
+        padding-bottom: ${({ theme }) => theme.space.u1};
       `
 
 const inlineTemplateAreas = css`
@@ -209,7 +209,7 @@ export const Field = styled(FieldLayout)<FieldPropsInternal>`
   ${FieldDetail} {
     grid-area: detail;
     justify-self: end;
-    padding-left: ${({ theme: { space } }) => space.small};
+    padding-left: ${({ theme: { space } }) => space.u3};
 
     ${({ inline }) =>
       inline &&
@@ -219,6 +219,6 @@ export const Field = styled(FieldLayout)<FieldPropsInternal>`
   }
 
   ${ValidationMessage} {
-    margin-top: ${({ theme }) => theme.space.xsmall};
+    margin-top: ${({ theme }) => theme.space.u2};
   }
 `

--- a/packages/components/src/Form/Fields/FieldInline.tsx
+++ b/packages/components/src/Form/Fields/FieldInline.tsx
@@ -80,21 +80,21 @@ const FieldDetail = styled(Paragraph)`
   -ms-grid-column-span: 2;
   -ms-grid-row: 1;
   /* stylelint-enable */
-  padding-left: ${({ theme }) => theme.space.xsmall};
+  padding-left: ${({ theme }) => theme.space.u2};
 `
 
 const FieldDescription = styled(Paragraph)`
   color: ${({ theme }) => theme.colors.text2};
   font-size: ${({ theme }) => theme.fontSizes.xsmall};
   line-height: ${({ theme }) => theme.lineHeights.xsmall};
-  padding-bottom: ${({ theme }) => theme.space.xxxsmall};
-  padding-top: ${({ theme }) => theme.space.xxxsmall};
+  padding-bottom: ${({ theme }) => theme.space.u05};
+  padding-top: ${({ theme }) => theme.space.u05};
 `
 
 const InputArea = styled.div`
   grid-column: 1;
   grid-row: 1;
-  padding-right: ${({ theme: { space } }) => space.xsmall};
+  padding-right: ${({ theme: { space } }) => space.u2};
   /* stylelint-disable */
   -ms-grid-column: 1;
   -ms-grid-column-span: 1;

--- a/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelect/FieldSelect.story.tsx
@@ -386,7 +386,7 @@ export const EmptyValue = () => {
   const options = [{ value: 'Option A' }, { value: 'Option B' }]
 
   return (
-    <Space p="large">
+    <Space p="u5">
       <FieldToggleSwitch
         label="Use empty value"
         on={value}

--- a/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.story.tsx
+++ b/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.story.tsx
@@ -280,7 +280,7 @@ export const SelectMultiDemo = () => {
   }
 
   return (
-    <SpaceVertical p="large" width={400}>
+    <SpaceVertical p="u5" width={400}>
       <Dialog isOpen={isOpen} onClose={handleClose}>
         <DialogLayout header="SelectMulti in a Dialog">
           <FieldSelectMulti

--- a/packages/components/src/Form/Fieldset/Fieldset.story.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.story.tsx
@@ -180,7 +180,7 @@ AccordionAlt.parameters = {
 }
 
 export const Nesting = () => (
-  <Fieldset gap="xxlarge">
+  <Fieldset gap="u10">
     <Button fullWidth>Button A</Button>
     <Button fullWidth>Button B</Button>
     <Button fullWidth>Button C</Button>
@@ -190,7 +190,7 @@ export const Nesting = () => (
       <Button fullWidth>Button B</Button>
       <Button fullWidth>Button C</Button>
 
-      <Fieldset gap="medium">
+      <Fieldset gap="u4">
         <Button fullWidth>Button A</Button>
         <Button fullWidth>Button B</Button>
         <Button fullWidth>Button C</Button>

--- a/packages/components/src/Form/Fieldset/Fieldset.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.tsx
@@ -88,7 +88,7 @@ const FieldsetLayout = forwardRef(
       accordion,
       className,
       inline,
-      gap = 'medium',
+      gap = 'u4',
       legend,
       fieldsHideLabel,
       children,
@@ -197,7 +197,7 @@ const FieldsetAccordionContent = styled.div`
     `calc(${theme.sizes[accordionDimensions().indicatorSize]} + ${
       theme.space[accordionDimensions().indicatorGap]
     })`};
-  padding-top: ${({ theme }) => theme.space.medium};
+  padding-top: ${({ theme }) => theme.space.u4};
 `
 
 export const Fieldset = styled(FieldsetLayout).attrs(({ width = '100%' }) => ({

--- a/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
+++ b/packages/components/src/Form/Inputs/AdvancedInputControls.tsx
@@ -119,7 +119,7 @@ const SearchControlGrid = styled.div`
   align-items: center;
   display: grid;
   grid-auto-flow: column dense;
-  grid-gap: ${({ theme }) => theme.space.xxsmall};
+  grid-gap: ${({ theme }) => theme.space.u1};
   justify-items: center;
   max-height: 1.9rem;
 `

--- a/packages/components/src/Form/Inputs/Combobox/stories/Combobox.story.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/stories/Combobox.story.tsx
@@ -69,7 +69,7 @@ export const ComboboxDemo = () => {
   }
 
   return (
-    <Space p="large" align="start">
+    <Space p="u5" align="start">
       <SpaceVertical>
         <Heading>Controlled</Heading>
         <Combobox width={300} value={option} onChange={handleChange}>

--- a/packages/components/src/Form/Inputs/Combobox/stories/ListLayout.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/stories/ListLayout.tsx
@@ -55,7 +55,7 @@ export const ListLayoutDemo = () => {
   }
 
   return (
-    <SpaceVertical p="large">
+    <SpaceVertical p="u5">
       <Heading>ComboboxList width override</Heading>
       <Label>Move slider to adjust container width:</Label>
       <Slider

--- a/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChipsBase.tsx
@@ -424,7 +424,7 @@ export const InputChipsBase = styled(InputChipsBaseInternal)`
 
   ${Chip} {
     margin: 1px 0;
-    margin-right: ${({ theme: { space } }) => space.xxsmall};
+    margin-right: ${({ theme: { space } }) => space.u1};
   }
 
   .inner {

--- a/packages/components/src/Form/Inputs/InputColor/ColorPicker/ColorPicker.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/ColorPicker/ColorPicker.tsx
@@ -31,7 +31,7 @@ import { LightSaturationPreview, HueSlider } from '..'
 import { ColorPickerProps } from '../types'
 
 const ColorPickerInternal: FC<ColorPickerProps> = ({ hsv, setHsv, width }) => (
-  <SpaceVertical gap="medium" data-testid="color-picker">
+  <SpaceVertical gap="u4" data-testid="color-picker">
     <LightSaturationPreview hsv={hsv} setHsv={setHsv} width={width} />
     <HueSlider hsv={hsv} setHsv={setHsv} width={width} />
   </SpaceVertical>

--- a/packages/components/src/Form/Inputs/InputColor/Handle/Handle.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Handle/Handle.tsx
@@ -56,5 +56,5 @@ export const Handle = styled.div.attrs<HandleProps>(({ color, x }) => ({
   ${handleCSS}
 
   /* Vertically centers slider */
-  top: ${({ theme }) => `calc(${theme.space.small} / 2 - ${HANDLE_SIZE} / 2)`};
+  top: ${({ theme }) => `calc(${theme.space.u3} / 2 - ${HANDLE_SIZE} / 2)`};
 `

--- a/packages/components/src/Form/Inputs/InputColor/HueSlider/HueSlider.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/HueSlider/HueSlider.tsx
@@ -115,7 +115,7 @@ const HueSliderTrack = styled.div<HueSliderTrackProps>`
 
   border-radius: ${({ theme }) => theme.radii.large};
   cursor: ${({ isMouseDown }) => (isMouseDown ? 'grabbing' : 'default')};
-  height: ${({ theme }) => theme.space.small};
+  height: ${({ theme }) => theme.space.u3};
   width: ${({ width }) => width}px;
 `
 

--- a/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/InputColor.tsx
@@ -136,7 +136,7 @@ export const InputColorInternal = forwardRef(
     }
 
     const content = (
-      <PopoverContent p="medium">
+      <PopoverContent p="u4">
         <ColorPicker
           hsv={color || { h: 0, s: 1, v: 1 }}
           setHsv={setColorState}

--- a/packages/components/src/Form/Inputs/InputFilters/InputFilters.tsx
+++ b/packages/components/src/Form/Inputs/InputFilters/InputFilters.tsx
@@ -45,11 +45,11 @@ const InputFiltersLayout: FC<InputFiltersProps> = ({
   className,
   filters,
   hideFilterIcon = false,
-  placeholder,
   onChange,
+  ...props
 }) => {
   const { t } = useTranslation('InputFilters')
-  placeholder ||= t('Filter List')
+  const placeholder = props.placeholder || t('Filter List')
   const [fieldEditing, setFieldEditing] = useState<undefined | string>(
     undefined
   )
@@ -219,7 +219,7 @@ const ChipWrapper = styled.div`
   flex-wrap: wrap;
 
   @supports (gap: 4px) {
-    gap: ${({ theme }) => theme.space.xxsmall};
+    gap: ${({ theme }) => theme.space.u1};
     ${Chip} {
       margin: 0;
     }
@@ -232,13 +232,13 @@ export const InputFilters = styled(InputFiltersLayout)`
   border-radius: ${({ theme: { radii } }) => radii.medium};
   display: flex;
   flex-wrap: wrap;
-  padding: ${({ theme: { space } }) => space.xxxsmall} 0;
-  padding-left: ${({ theme: { space } }) => space.xsmall};
+  padding: ${({ theme: { space } }) => space.u05} 0;
+  padding-left: ${({ theme: { space } }) => space.u2};
 
   width: 100%;
 
   ${Select} {
-    margin-left: ${({ theme: { space } }) => space.xxsmall};
+    margin-left: ${({ theme: { space } }) => space.u1};
   }
 
   ${Select} ${Icon} {

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -234,7 +234,7 @@ const StyledInput = styled.input`
   font-size: ${(props) => props.theme.fontSizes.small};
   max-width: 100%;
   min-width: 2rem;
-  padding: 0 ${({ theme: { space } }) => space.xsmall};
+  padding: 0 ${({ theme: { space } }) => space.u2};
 `
 
 export const inputTextHover = css`
@@ -321,7 +321,7 @@ export const InputText = styled(InputTextLayout).attrs<InputTextProps>(
   cursor: text;
   display: inline-flex;
   justify-content: space-evenly;
-  padding: ${({ theme: { space } }) => `${space.xxxsmall} ${space.xxsmall}`};
+  padding: ${({ theme: { space } }) => `${space.u05} ${space.u1}`};
   width: ${({ autoResize }) => (autoResize ? 'auto' : '100%')};
 
   ${layout}
@@ -338,7 +338,7 @@ export const InputText = styled(InputTextLayout).attrs<InputTextProps>(
     width: 100%;
     input,
     span {
-      padding: 0 ${({ theme: { space } }) => space.xsmall};
+      padding: 0 ${({ theme: { space } }) => space.u2};
     }
   }
 

--- a/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/CheckboxGroup.tsx
@@ -108,7 +108,7 @@ const CheckboxGroupLayout = forwardRef(
         data-testid="checkbox-list"
         inline={inline}
         wrap={inline}
-        gap={!inline ? 'xxsmall' : undefined}
+        gap={!inline ? 'u1' : undefined}
         width={inline ? 'auto' : undefined}
         ref={ref}
         {...rest}

--- a/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
+++ b/packages/components/src/Form/Inputs/OptionsGroup/RadioGroup.tsx
@@ -101,7 +101,7 @@ const RadioGroupLayout = forwardRef(
         data-testid="radio-list"
         inline={inline}
         wrap={inline}
-        gap={!inline ? 'xxsmall' : undefined}
+        gap={!inline ? 'u1' : undefined}
         width={inline ? 'auto' : undefined}
         ref={ref}
         {...rest}

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.story.tsx
@@ -103,7 +103,7 @@ export const RerenderRepro = () => {
     setExpression(newValue)
   }
   return (
-    <SpaceVertical p="medium" align="stretch">
+    <SpaceVertical p="u4" align="stretch">
       <OrderedList type="number">
         <li>
           When updating the min/max, the value should move to stay within

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -167,7 +167,7 @@ const SelectOptionGroupTitle = styled(Heading).attrs<HeadingProps>(() => ({
   py: 'xxsmall',
 }))<{ isMulti?: boolean }>`
   display: flex;
-  padding-top: ${({ theme }) => theme.space.xxsmall};
+  padding-top: ${({ theme }) => theme.space.u1};
 `
 
 export interface SelectOptionsBaseProps {
@@ -355,5 +355,5 @@ const SelectCreateOption = ({
 const EmptyListItem = styled.li`
   display: flex;
   justify-content: center;
-  padding: ${({ theme }) => `${theme.space.xlarge} ${theme.space.medium}`};
+  padding: ${({ theme }) => `${theme.space.u8} ${theme.space.u4}`};
 `

--- a/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
+++ b/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
@@ -106,8 +106,8 @@ export const TextArea = styled(TextAreaLayout).attrs<TextAreaProps>(
     margin: 0; /* override browser default(s) */
     ${simpleLayoutCSS}
     ${inputCSS}
-    padding: ${({ theme }) => `${theme.space.xsmall} ${theme.space.small}`};
-    padding-right: ${(props) => props.theme.space.xlarge};
+    padding: ${({ theme }) => `${theme.space.u2} ${theme.space.u3}`};
+    padding-right: ${(props) => props.theme.space.u8};
     ${textAreaResize}
     vertical-align: top; /* textarea is inline-block so this removes 4px generated below */
     width: 100%;

--- a/packages/components/src/Icon/Icon.story.tsx
+++ b/packages/components/src/Icon/Icon.story.tsx
@@ -132,33 +132,33 @@ Artwork.parameters = {
 
 export const IconsInsideComponents = () => (
   <SpaceVertical>
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Button size="large" iconAfter={<Refresh />}>
         Add
       </Button>
       <IconButton size="large" icon={<FilterList />} label="Filter" />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Button iconAfter={<Refresh />}>Add</Button>
       <IconButton size="medium" icon={<FilterList />} label="Filter" />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Button size="small" iconAfter={<Refresh />}>
         Add
       </Button>
       <IconButton size="small" icon={<FilterList />} label="Filter" />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Button size="xsmall" iconAfter={<Refresh />}>
         Add
       </Button>
       <IconButton size="xsmall" icon={<FilterList />} label="Filter" />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Button size="xxsmall" iconAfter={<Refresh />}>
         Add
       </Button>
@@ -173,70 +173,70 @@ IconsInsideComponents.parameters = {
 
 export const IconsPairedWithText = () => (
   <SpaceVertical>
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xxsmall">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="xxxsmall" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xsmall">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="xxxsmall" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="small">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="xxsmall" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="medium">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="xxsmall" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="large">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="xsmall" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xlarge">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="small" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xxlarge">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="small" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xxxlarge">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="medium" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xxxxlarge">
         This is to compare icons size with a Heading
       </Heading>
       <Icon size="medium" icon={<Create />} />
     </Space>
 
-    <Space gap="xsmall">
+    <Space gap="u2">
       <Heading fontSize="xxxxxlarge">
         This is to compare icons size with a Heading
       </Heading>

--- a/packages/components/src/Layout/Grid/Grid.story.tsx
+++ b/packages/components/src/Layout/Grid/Grid.story.tsx
@@ -78,12 +78,12 @@ GapSize.args = {
       <Placeholder>D</Placeholder>
     </>
   ),
-  gap: 'xxlarge',
+  gap: 'u10',
 }
 
 export const VerticalGrid = () => (
   <Grid columns={4}>
-    <Grid columns={1} gap="xxlarge">
+    <Grid columns={1} gap="u10">
       <Placeholder minHeight="5rem">A</Placeholder>
       <Placeholder>B</Placeholder>
       <Placeholder>C</Placeholder>

--- a/packages/components/src/Layout/Grid/Grid.test.tsx
+++ b/packages/components/src/Layout/Grid/Grid.test.tsx
@@ -47,7 +47,7 @@ describe('Grid', () => {
 
   test('specified gap', () => {
     renderWithTheme(
-      <Grid data-testid="grid" gap="xlarge">
+      <Grid data-testid="grid" gap="u8">
         {content}
       </Grid>
     )

--- a/packages/components/src/Layout/Semantics/Aside/Aside.story.tsx
+++ b/packages/components/src/Layout/Semantics/Aside/Aside.story.tsx
@@ -38,7 +38,7 @@ export default {
 }
 
 const Template: Story<AsideProps> = (args) => (
-  <AsideStyle p="large" text-align="center" {...args} />
+  <AsideStyle p="u5" text-align="center" {...args} />
 )
 
 const AsideStyle = styled(Aside)`
@@ -88,7 +88,7 @@ AsideCollapse.parameters = {
 }
 
 const TemplateBorder: Story<AsideProps> = (args) => (
-  <Aside p="large" text-align="center" {...args} />
+  <Aside p="u5" text-align="center" {...args} />
 )
 
 export const AsideDefaultBorderAndColor = TemplateBorder.bind({})

--- a/packages/components/src/Layout/Semantics/Layout/Layout.story.tsx
+++ b/packages/components/src/Layout/Semantics/Layout/Layout.story.tsx
@@ -72,10 +72,10 @@ export const Basic = () => (
         I'm the header
       </Header>
       <Layout hasAside>
-        <Aside p="large" width="200px">
+        <Aside p="u5" width="200px">
           <ItemsFiller count={20} />
         </Aside>
-        <Section main p="xxlarge">
+        <Section main p="u10">
           <Heading>Page title</Heading>
           <Constitution />
         </Section>
@@ -94,10 +94,10 @@ export const FixedWithFooterAndHeaderShadow = () => (
         I'm the header
       </Header>
       <Layout hasAside>
-        <Aside p="large" width="200px">
+        <Aside p="u5" width="200px">
           <ItemsFiller count={20} />
         </Aside>
-        <Section main p="xxlarge">
+        <Section main p="u10">
           <Heading>Page title</Heading>
           <Constitution />
         </Section>
@@ -113,14 +113,14 @@ export const ScrollIndependently = () => (
   <Highlighter>
     <Page fixed>
       <Layout hasAside>
-        <Aside p="large">
+        <Aside p="u5">
           <Constitution />
         </Aside>
-        <Section main p="xxlarge">
+        <Section main p="u10">
           <Heading>Page title</Heading>
           <Constitution />
         </Section>
-        <AsideAlt p="xxlarge" width="navigation">
+        <AsideAlt p="u10" width="navigation">
           <ConstitutionShort />
         </AsideAlt>
       </Layout>
@@ -135,15 +135,15 @@ export const ScrollSelectedAreas = () => (
   <Highlighter>
     <Page fixed>
       <Layout hasAside>
-        <Aside p="large" width="200px">
+        <Aside p="u5" width="200px">
           <ConstitutionShort />
         </Aside>
         <Layout hasAside>
-          <Section main scrollWithin p="xxlarge">
+          <Section main scrollWithin p="u10">
             <Heading>Page title</Heading>
             <Constitution />
           </Section>
-          <AsideAlt scrollWithin p="xxlarge">
+          <AsideAlt scrollWithin p="u10">
             <ConstitutionShort />
           </AsideAlt>
         </Layout>
@@ -159,14 +159,14 @@ export const ScrollAllAreasTogetherDefault = () => (
   <Highlighter>
     <Page>
       <Layout hasAside>
-        <Aside p="large" width="200px">
+        <Aside p="u5" width="200px">
           <ConstitutionShort />
         </Aside>
-        <Section main p="xxlarge">
+        <Section main p="u10">
           <Heading>Page title</Heading>
           <Constitution />
         </Section>
-        <AsideAlt p="xxlarge" width="10rem">
+        <AsideAlt p="u10" width="10rem">
           <ConstitutionShort />
         </AsideAlt>
       </Layout>
@@ -184,10 +184,10 @@ export const WhitespaceRepro = () => (
         I'm the header
       </Header>
       <Layout hasAside>
-        <Aside p="large" width="200px">
+        <Aside p="u5" width="200px">
           <ItemsFiller count={20} />
         </Aside>
-        <Section main p="xxlarge">
+        <Section main p="u10">
           <Heading>Page title</Heading>
           <Constitution />
           <IconButton icon={<Info />} label="Info" />

--- a/packages/components/src/Layout/Space/Space.test.tsx
+++ b/packages/components/src/Layout/Space/Space.test.tsx
@@ -53,7 +53,7 @@ describe('Space', () => {
 
   test('around + gap (all you get is around)', () => {
     renderWithTheme(
-      <Space around gap="xxlarge" data-testid="space">
+      <Space around gap="u10" data-testid="space">
         {content}
       </Space>
     )

--- a/packages/components/src/Layout/Space/Space.tsx
+++ b/packages/components/src/Layout/Space/Space.tsx
@@ -92,7 +92,7 @@ export interface SpaceHelperProps extends CommonLayoutProps, FlexboxProps {
   stretch?: boolean
 }
 
-export const defaultGap = 'medium'
+export const defaultGap = 'u4'
 
 export const spaceCSS = css`
   ${commonLayoutCSS}

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -67,7 +67,7 @@ export interface LinkProps
 
 const ExternalLinkIndicator = styled(Launch)`
   height: ${({ theme }) => theme.sizes.xxsmall};
-  margin-left: ${({ theme }) => theme.space.xxsmall};
+  margin-left: ${({ theme }) => theme.space.u1};
   width: ${({ theme }) => theme.sizes.xxsmall};
 `
 

--- a/packages/components/src/List/ListDivider.tsx
+++ b/packages/components/src/List/ListDivider.tsx
@@ -42,7 +42,7 @@ const ListDividerLayout: FC = (props) => (
 export const ListDivider = styled(ListDividerLayout)<SpaceProps>`
   ${space}
 
-  margin: ${({ theme }) => theme.space.xsmall} 0;
+  margin: ${({ theme }) => theme.space.u2} 0;
 
   /* CSS for hiding second divider when 2 ListDividers are adjacent */
   & + & {

--- a/packages/components/src/List/utils/listPadding.ts
+++ b/packages/components/src/List/utils/listPadding.ts
@@ -35,7 +35,7 @@ import { Divider } from '../../Divider'
  */
 export const listPadding = css`
   > :first-child {
-    margin-top: ${({ theme }) => theme.space.xsmall};
+    margin-top: ${({ theme }) => theme.space.u2};
 
     ${Divider} {
       display: none;
@@ -43,7 +43,7 @@ export const listPadding = css`
   }
 
   > :last-child {
-    margin-bottom: ${({ theme }) => theme.space.xsmall};
+    margin-bottom: ${({ theme }) => theme.space.u2};
 
     ${Divider} {
       display: none;

--- a/packages/components/src/ListItem/utils/listItemDimensions.ts
+++ b/packages/components/src/ListItem/utils/listItemDimensions.ts
@@ -31,12 +31,12 @@ export const density0: ListItemDimensions = {
   descriptionFontSize: 'xsmall',
   descriptionLineHeight: 'xsmall',
   height: 36,
-  iconGap: 'small',
+  iconGap: 'u3',
   iconSize: 'small',
   labelFontSize: 'small',
   labelLineHeight: 'small',
-  px: 'medium',
-  py: 'xsmall',
+  px: 'u4',
+  py: 'u2',
 }
 
 // Positive density values
@@ -45,11 +45,11 @@ export const densityPositive1: ListItemDimensions = {
   descriptionFontSize: 'small',
   descriptionLineHeight: 'small',
   height: 48,
-  iconGap: 'medium',
+  iconGap: 'u4',
   iconSize: 'medium',
   labelFontSize: 'medium',
   labelLineHeight: 'medium',
-  py: 'small',
+  py: 'u3',
 }
 
 // Negative density values
@@ -61,12 +61,12 @@ export const densityNegative1: ListItemDimensions = {
 export const densityNegative2: ListItemDimensions = {
   ...densityNegative1,
   height: 28,
-  py: 'xxsmall',
+  py: 'u1',
 }
 export const densityNegative3: ListItemDimensions = {
   ...densityNegative2,
   height: 24,
-  iconGap: 'xsmall',
+  iconGap: 'u2',
   iconSize: 'xxsmall',
   labelFontSize: 'xsmall',
   labelLineHeight: 'xsmall',

--- a/packages/components/src/Menu/Menu.story.tsx
+++ b/packages/components/src/Menu/Menu.story.tsx
@@ -254,7 +254,7 @@ export const Hover = () => {
   const close = () => setOpen(false)
 
   return (
-    <Card ref={hoverRef} p="large" raised height="auto" tabIndex={0}>
+    <Card ref={hoverRef} p="u5" raised height="auto" tabIndex={0}>
       <Space between>
         <Paragraph>
           Hovering in this card will show the button that triggers the menu.
@@ -280,7 +280,7 @@ Hover.parameters = {
 
 export const RealisticMenus = () => {
   return (
-    <Space gap="xxlarge">
+    <Space gap="u10">
       <Menu
         iconGutter
         content={
@@ -453,7 +453,7 @@ export const LongMenus = () => {
     return getGroups(longLabels ? 120 : 30)
   }, [longLabels])
   return (
-    <SpaceVertical align="start" p="xlarge">
+    <SpaceVertical align="start" p="u8">
       <Space>
         <Menu
           content={array95.map((item, i) => (

--- a/packages/components/src/Menu/MenuList.story.tsx
+++ b/packages/components/src/Menu/MenuList.story.tsx
@@ -157,7 +157,7 @@ export const MenuHeadingOverride = () => (
  * and space below the last item is maintained even with extraneous dividers.
  */
 export const MenuListSpacing = () => (
-  <Space p="medium" style={{ background: '#ff8c69' }}>
+  <Space p="u4" style={{ background: '#ff8c69' }}>
     <Box bg="background">
       <MenuList>
         <MenuDivider />

--- a/packages/components/src/MessageBar/MessageBar.tsx
+++ b/packages/components/src/MessageBar/MessageBar.tsx
@@ -242,7 +242,7 @@ MessageBarLayout.displayName = 'MessageBarLayout'
 
 const MessageBarContent = styled.div`
   flex-grow: 1;
-  padding: 0 ${({ theme: { space } }) => space.large};
+  padding: 0 ${({ theme: { space } }) => space.u5};
 `
 
 const backgroundColor = variant({

--- a/packages/components/src/Modal/ModalContent/ModalContent.tsx
+++ b/packages/components/src/Modal/ModalContent/ModalContent.tsx
@@ -69,7 +69,7 @@ const ModalContentLayout = forwardRef(
       pt,
       py,
       p,
-      overflowVerticalPadding = 'xxxsmall',
+      overflowVerticalPadding = 'u05',
       ...props
     }: ModalContentPropsInternal,
     forwardedRef: Ref<HTMLDivElement>

--- a/packages/components/src/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/components/src/Modal/ModalHeader/ModalHeader.tsx
@@ -71,8 +71,8 @@ const ModalHeaderLayout: FC<ModalHeaderProps> = ({
 }
 
 const Detail = styled.div`
-  margin-bottom: -${({ theme }) => theme.space.xsmall};
-  margin-top: -${({ theme }) => theme.space.xsmall};
+  margin-bottom: -${({ theme }) => theme.space.u2};
+  margin-top: -${({ theme }) => theme.space.u2};
 `
 
 export const ModalHeader = styled(ModalHeaderLayout)<ModalHeaderProps>``

--- a/packages/components/src/OrderedList/OrderedList.tsx
+++ b/packages/components/src/OrderedList/OrderedList.tsx
@@ -99,6 +99,6 @@ export const OrderedList = styled.div
   ${layout}
 
   li {
-    margin-bottom: ${({ theme }) => theme.space.xxsmall};
+    margin-bottom: ${({ theme }) => theme.space.u1};
   }
 `

--- a/packages/components/src/Overlay/OverlaySurface.tsx
+++ b/packages/components/src/Overlay/OverlaySurface.tsx
@@ -101,19 +101,19 @@ export const OverlaySurface = styled(OverlaySurfaceLayout)`
   z-index: ${({ theme: { zIndexFloor } }) => zIndexFloor || undefined};
 
   &[data-placement*='top'] {
-    padding-bottom: ${({ theme: { space } }) => space.xsmall};
+    padding-bottom: ${({ theme: { space } }) => space.u2};
   }
 
   &[data-placement*='right'] {
-    padding-left: ${({ theme: { space } }) => space.xsmall};
+    padding-left: ${({ theme: { space } }) => space.u2};
   }
 
   &[data-placement*='bottom'] {
-    padding-top: ${({ theme: { space } }) => space.xsmall};
+    padding-top: ${({ theme: { space } }) => space.u2};
   }
 
   &[data-placement*='left'] {
-    padding-right: ${({ theme: { space } }) => space.xsmall};
+    padding-right: ${({ theme: { space } }) => space.u2};
   }
 
   &:focus {

--- a/packages/components/src/Panel/PanelHeader.tsx
+++ b/packages/components/src/Panel/PanelHeader.tsx
@@ -47,9 +47,9 @@ export const PanelHeader: FC<PanelBaseProps> = ({
   return (
     <Space
       as="header"
-      height={space.xxlarge}
+      height={space.u10}
       px="large"
-      gap="small"
+      gap="u3"
       mt="small"
       mb="1.5rem"
       flexShrink={0}

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.test.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.test.tsx
@@ -40,7 +40,7 @@ describe('PopoverContent', () => {
 
   test('Custom padding', () => {
     renderWithTheme(
-      <PopoverContent pb="small" pt="xlarge" px="small">
+      <PopoverContent pb="u3" pt="u8" px="u3">
         Hello world
       </PopoverContent>
     )

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
@@ -36,12 +36,7 @@ const PopoverContentLayout: FC<PopoverContentProps> = ({
   ...props
 }) => {
   return (
-    <ModalContent
-      overflowVerticalPadding="xxsmall"
-      py="medium"
-      px="large"
-      {...props}
-    >
+    <ModalContent overflowVerticalPadding="u1" py="u4" px="u5" {...props}>
       {children}
     </ModalContent>
   )

--- a/packages/components/src/Popover/stories/OverflowExamples.tsx
+++ b/packages/components/src/Popover/stories/OverflowExamples.tsx
@@ -32,7 +32,7 @@ import { EdgeOverflow } from './EdgeOverflow'
 
 export const OverflowExamples = () => {
   return (
-    <Box p="xxlarge" width="100%" position="relative" height="100%">
+    <Box p="u10" width="100%" position="relative" height="100%">
       <EdgeOverflow top={0} left={0}>
         Top Left
       </EdgeOverflow>

--- a/packages/components/src/Popover/stories/Popover.story.tsx
+++ b/packages/components/src/Popover/stories/Popover.story.tsx
@@ -154,7 +154,7 @@ export const PopoverFocusTrap = () => {
         <Popover
           cancelClickOutside={value}
           content={
-            <PopoverContent p="large" width="360px">
+            <PopoverContent p="u5" width="360px">
               <Paragraph>
                 Does tabbing focus only loop through these 3 buttons &amp;
                 Select?
@@ -255,7 +255,7 @@ export const OverlayOpenDialog = () => {
       <Heading>Popover Opening a Dialog</Heading>
       <Popover
         content={
-          <SpaceVertical p="large">
+          <SpaceVertical p="u5">
             <Button onClick={setOn}>Open Dialog</Button>
             <Box height={500} />
           </SpaceVertical>
@@ -335,7 +335,7 @@ const DialogInner = () => {
 
 const popoverContent = (
   <PopoverContent>
-    <Paragraph width={300} p="xxlarge">
+    <Paragraph width={300} p="u10">
       👋 Hello, I am a popover!
     </Paragraph>
   </PopoverContent>
@@ -363,7 +363,7 @@ RenderPropsSpread.parameters = {
 export const Placement = () => {
   const popoverContent = (
     <PopoverContent>
-      <Paragraph width={300} p="xxlarge">
+      <Paragraph width={300} p="u10">
         👋 Hello, I am a popover!
       </Paragraph>
     </PopoverContent>
@@ -395,7 +395,7 @@ const MovingTargetInner = () => {
   const { value, toggle } = useToggle()
   const { popover, popperInstanceRef, open, ref, isOpen } = usePopover({
     content: (
-      <PopoverContent p="large" width="360px">
+      <PopoverContent p="u5" width="360px">
         <Paragraph>
           The anchor is moving around so the Popover position must be updated
           via popperInstanceRef.current.update.
@@ -425,7 +425,7 @@ const MovingTargetInner = () => {
         mt={value ? 'xxxlarge' : 'medium'}
         border="2px solid"
         width={150}
-        p="small"
+        p="u3"
         cursor="pointer"
         height={value ? 80 : undefined}
         onClick={open}

--- a/packages/components/src/Table/TableCell/tableCell.ts
+++ b/packages/components/src/Table/TableCell/tableCell.ts
@@ -50,7 +50,7 @@ export interface TableCellProps
 
 export const tableCellCSS = css`
   ${reset}
-  padding: ${(props) => props.theme.space.xsmall} 0;
+  padding: ${(props) => props.theme.space.u2} 0;
   ${border}
   ${color}
   ${layout}

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -87,7 +87,7 @@ const defaultLayoutCSS = css`
   }
 
   ${Tab} + ${Tab} {
-    margin-left: ${(props) => props.theme.space.xlarge};
+    margin-left: ${(props) => props.theme.space.u8};
   }
 `
 
@@ -97,7 +97,7 @@ const distributeCSS = css`
   grid-auto-flow: column;
 
   ${Tab} {
-    padding: ${({ theme: { space } }) => `${space.xsmall} ${space.medium}`};
+    padding: ${({ theme: { space } }) => `${space.u2} ${space.u4}`};
   }
 `
 

--- a/packages/components/src/Tooltip/Tooltip.story.tsx
+++ b/packages/components/src/Tooltip/Tooltip.story.tsx
@@ -126,7 +126,7 @@ RenderProp.parameters = {
 
 export const LargeTrigger = () => (
   <Tooltip content="See what happens when you scroll" placement="right">
-    <Card width={500} height={800} raised p="large">
+    <Card width={500} height={800} raised p="u5">
       Very large trigger
     </Card>
   </Tooltip>
@@ -159,7 +159,7 @@ export const NestedInPopover = () => {
   }
 
   return (
-    <SpaceVertical p="large">
+    <SpaceVertical p="u5">
       <Text>Last event: {lastEvent}</Text>
       <Space>
         <Popover content={<PopoverContent>Some content</PopoverContent>}>

--- a/packages/components/src/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/UnorderedList/UnorderedList.tsx
@@ -88,6 +88,6 @@ export const UnorderedList = styled.ul
   ${layout}
 
   li {
-    margin-bottom: ${({ theme }) => theme.space.xxsmall};
+    margin-bottom: ${({ theme }) => theme.space.u1};
   }
 `

--- a/packages/components/src/__mocks__/Constitution.tsx
+++ b/packages/components/src/__mocks__/Constitution.tsx
@@ -90,10 +90,10 @@ export const Constitution = () => (
 const Format = styled.article`
   ${Heading} {
     font-weight: ${({ theme }) => theme.fontWeights.semiBold};
-    margin-bottom: ${({ theme }) => theme.space.small};
+    margin-bottom: ${({ theme }) => theme.space.u3};
   }
 
   ${Paragraph} {
-    margin: ${({ theme }) => theme.space.small} 0;
+    margin: ${({ theme }) => theme.space.u3} 0;
   }
 `

--- a/packages/design-tokens/src/colors.story.tsx
+++ b/packages/design-tokens/src/colors.story.tsx
@@ -113,7 +113,7 @@ const CircleSwatch = styled.div<SwatchProps>`
   display: flex;
   height: 3rem;
   justify-content: space-between;
-  padding: ${({ theme }) => theme.space.xxsmall};
+  padding: ${({ theme }) => theme.space.u1};
   width: 3rem;
 `
 

--- a/packages/design-tokens/src/space/index.ts
+++ b/packages/design-tokens/src/space/index.ts
@@ -88,7 +88,7 @@ const legacySpacing: LegacySpaceRamp = {
 
 export const units: UnitRamp = {
   none: '0rem',
-  'u0.5': '0.125rem',
+  u05: '0.125rem',
   u1: '0.25rem',
   u2: '0.5rem',
   u3: '0.75rem',

--- a/packages/design-tokens/src/space/units.ts
+++ b/packages/design-tokens/src/space/units.ts
@@ -25,7 +25,7 @@
  */
 
 export type Unit0 = 'none'
-export type Unit05 = 'u0.5'
+export type Unit05 = 'u05'
 export type Unit1 = 'u1'
 export type Unit2 = 'u2'
 export type Unit3 = 'u3'

--- a/www/src/Layout/Documentation.tsx
+++ b/www/src/Layout/Documentation.tsx
@@ -149,12 +149,12 @@ const CustomTabs = styled(Space)`
   border-bottom: 1px solid ${({ theme }) => theme.colors.ui2};
   border-top: 1px solid ${({ theme }) => theme.colors.ui2};
   display: flex;
-  margin: ${({ theme: { space } }) => `${space.small} 0 ${space.large}`};
-  min-height: ${({ theme }) => theme.space.large};
+  margin: ${({ theme: { space } }) => `${space.u3} 0 ${space.u5}`};
+  min-height: ${({ theme }) => theme.space.u5};
 
   ${TabList} {
     margin-bottom: -1px;
-    margin-top: ${({ theme }) => theme.space.xsmall};
+    margin-top: ${({ theme }) => theme.space.u2};
   }
 `
 

--- a/www/src/MDX/Blockquote.tsx
+++ b/www/src/MDX/Blockquote.tsx
@@ -34,7 +34,7 @@ export const Blockquote = styled.blockquote`
     font-size: ${fontSizes.large};
     line-height: ${lineHeights.medium};
     margin: 0 0 ${lineHeights.medium} ${lineHeights.medium};
-    padding: 0 0 0 ${space.medium};
+    padding: 0 0 0 ${space.u4};
     border-left: 5px solid ${colors.key};
     color: ${colors.keyInteractive};
     border-radius: ${radii.medium};

--- a/www/src/MDX/Pre/CodeSandbox.tsx
+++ b/www/src/MDX/Pre/CodeSandbox.tsx
@@ -218,7 +218,7 @@ const ActionLayout = styled.div<ActionProps>`
   display: grid;
   grid-template-rows: auto auto 1fr;
   justify-content: right;
-  padding: ${({ theme }) => `${theme.space.xsmall}`};
+  padding: ${({ theme }) => `${theme.space.u2}`};
   transition: background 350ms;
   width: auto;
 `
@@ -235,7 +235,7 @@ const SandboxWrapper = styled.div`
 
 const PreviewWrapper = styled.div`
   color: ${({ theme }) => theme.colors.text};
-  padding: ${({ theme }) => theme.space.small};
+  padding: ${({ theme }) => theme.space.u3};
 `
 
 const EditorWrapper = styled.div`
@@ -246,7 +246,7 @@ const EditorWrapper = styled.div`
   textarea,
   pre {
     ${({ theme: { space } }) => `
-      padding: ${space.small} !important;
+      padding: ${space.u3} !important;
     `}
   }
 `
@@ -255,9 +255,9 @@ const ErrorWrapper = styled.div`
   display: grid;
   grid-template-columns: auto 1fr;
   ${({ theme: { colors, space } }) => `
-    grid-column-gap: ${space.small};
+    grid-column-gap: ${space.u3};
     color: ${colors.criticalInteractive};
-    padding: ${space.small};
+    padding: ${space.u3};
     background: ${colors.criticalAccent};
   `}
   pre {

--- a/www/src/MDX/Pre/CodeStatic.tsx
+++ b/www/src/MDX/Pre/CodeStatic.tsx
@@ -68,5 +68,5 @@ const PreWrapper = styled.pre`
   border-radius: ${({ theme }) => theme.radii.medium};
   line-height: ${({ theme }) => theme.lineHeights.medium};
   margin: ${({ theme }) => theme.lineHeights.medium} 0;
-  padding: ${({ theme }) => theme.space.medium};
+  padding: ${({ theme }) => theme.space.u4};
 `

--- a/www/src/components/DocTable.tsx
+++ b/www/src/components/DocTable.tsx
@@ -29,7 +29,7 @@ import { Code, Table } from '@looker/components'
 
 export const DocTable = styled(Table)`
   font-size: ${({ theme }) => theme.fontSizes.small};
-  margin-bottom: ${({ theme }) => theme.space.xlarge};
+  margin-bottom: ${({ theme }) => theme.space.u8};
 
   ${Code} {
     color: ${(props) => props.theme.colors.key};

--- a/www/src/components/HeaderContent/AppLogo.tsx
+++ b/www/src/components/HeaderContent/AppLogo.tsx
@@ -32,7 +32,7 @@ import logo from './logo.png'
 
 const AppLogoLayout: FC<{ className?: string }> = (props) => (
   <Link to="/" {...props}>
-    <Space gap="small">
+    <Space gap="u3">
       <img src={logo} alt="Looker" />
       <DividerVertical stretch my="none" mx="none" />
       <Heading fontSize="large" fontWeight="medium" color="text3" as="h1">

--- a/www/src/components/HeaderContent/HeaderContent.tsx
+++ b/www/src/components/HeaderContent/HeaderContent.tsx
@@ -91,7 +91,7 @@ export const HeaderContentLayout: FC<HeaderProps> = ({
       </Space>
       <Search />
       <NavigationList>
-        <Space as="ul" gap="xlarge" pr="large">
+        <Space as="ul" gap="u8" pr="large">
           {data.allMdx.edges.map(({ node: { slug } }) => {
             return (
               <li key={slug}>

--- a/www/src/components/Navigation/Page.tsx
+++ b/www/src/components/Navigation/Page.tsx
@@ -53,7 +53,7 @@ export const Page = styled(PageLayout)`
   a {
     color: ${({ theme }) => theme.colors.link};
     display: block;
-    padding: ${({ theme: { space } }) => `${space.xsmall} ${space.xlarge}`};
+    padding: ${({ theme: { space } }) => `${space.u2} ${space.u8}`};
     text-decoration: none;
 
     &:hover {

--- a/www/src/components/Navigation/Section.tsx
+++ b/www/src/components/Navigation/Section.tsx
@@ -69,5 +69,5 @@ export const Section: FC<SectionProps> = ({ section }) => {
 const PageList = styled.ul`
   font-size: ${({ theme }) => theme.fontSizes.small};
   list-style-type: none;
-  padding: 0 ${({ theme }) => theme.space.xsmall} 0 0;
+  padding: 0 ${({ theme }) => theme.space.u2} 0 0;
 `

--- a/www/src/documentation/components/content/demos/IconList.tsx
+++ b/www/src/documentation/components/content/demos/IconList.tsx
@@ -41,13 +41,7 @@ export const IconList = () => (
         onCopy={() => alert(`Copied icon "${name}" to clipboard.`)}
         key={name}
       >
-        <IconGridItem
-          p="small"
-          gap="xsmall"
-          align="center"
-          tabIndex={0}
-          role="button"
-        >
+        <IconGridItem p="u3" gap="u2" align="center" tabIndex={0} role="button">
           <Icon
             display="inline-flex"
             icon={AllIcons[name].render()}

--- a/www/src/documentation/components/layout/demos/BoxSpacingRecipeTable.tsx
+++ b/www/src/documentation/components/layout/demos/BoxSpacingRecipeTable.tsx
@@ -44,14 +44,14 @@ const spacingSides = [
 ]
 
 const spacingSizes = [
-  { label: '4px', value: 'xxsmall' },
-  { label: '8px', value: 'xsmall' },
-  { label: '12px', value: 'small' },
-  { label: '16px', value: 'medium' },
-  { label: '20px', value: 'large' },
-  { label: '32px', value: 'xlarge' },
-  { label: '40px', value: 'xxlarge' },
-  { label: '60px', value: 'xxxlarge' },
+  { label: '4px', value: 'u1' },
+  { label: '8px', value: 'u2' },
+  { label: '12px', value: 'u3' },
+  { label: '16px', value: 'u4' },
+  { label: '20px', value: 'u5' },
+  { label: '32px', value: 'u8' },
+  { label: '40px', value: 'u10' },
+  { label: '64px', value: 'u16' },
 ]
 
 export interface ColumnExample {

--- a/www/src/documentation/foundations/demos/BorderRender.tsx
+++ b/www/src/documentation/foundations/demos/BorderRender.tsx
@@ -87,7 +87,7 @@ const BorderExample = styled(Box)`
   border-color: ${({ theme }) => theme.colors.ui3};
   display: flex;
   justify-content: space-between;
-  padding: ${({ theme }) => theme.space.large};
+  padding: ${({ theme }) => theme.space.u5};
 
   &:not(:last-child) {
     border-bottom: none;

--- a/www/src/documentation/foundations/demos/ColorBlendsGrid.tsx
+++ b/www/src/documentation/foundations/demos/ColorBlendsGrid.tsx
@@ -50,7 +50,7 @@ const BlendColor = styled(
     display: block;
     flex-shrink: 0;
     height: 2.5rem;
-    margin-right: ${({ theme }) => theme.space.medium};
+    margin-right: ${({ theme }) => theme.space.u4};
     width: 5rem;
   }
 `
@@ -88,7 +88,7 @@ export const ColorBlendsGrid = ({
 }: {
   statefulColorGroups: StatefulColorGroups
 }) => (
-  <BlendGrid gap="large" maxWidth={1000}>
+  <BlendGrid gap="u5" maxWidth={1000}>
     {statefulColorGroups.map((group, index) => (
       <BlendList colors={group} key={index} />
     ))}

--- a/www/src/documentation/foundations/demos/ColorList.tsx
+++ b/www/src/documentation/foundations/demos/ColorList.tsx
@@ -45,7 +45,7 @@ const ColorSwatch = styled(({ name, color, ...props }: ColorSwatchProps) => (
     content: '';
     display: block;
     height: 4rem;
-    margin-bottom: ${({ theme }) => theme.space.xsmall};
+    margin-bottom: ${({ theme }) => theme.space.u2};
     width: 100%;
   }
 `
@@ -59,7 +59,7 @@ type ColorListProps = {
 }
 
 export const ColorList = ({ colors }: ColorListProps) => (
-  <ColorListGrid gap="large" maxWidth={600} pt="medium" pb="xxlarge">
+  <ColorListGrid gap="u5" maxWidth={600} pt="medium" pb="xxlarge">
     {Object.entries(colors).map(([title, color], key) => (
       <ColorSwatch name={title} color={color} key={key} />
     ))}

--- a/www/src/documentation/foundations/demos/DensityTable.tsx
+++ b/www/src/documentation/foundations/demos/DensityTable.tsx
@@ -43,7 +43,7 @@ import { DocTable } from '../../../components'
 const DensityRow = ({ density }: { density: DensityRamp }) => (
   <TableRow>
     <TableDataCell>
-      <Box bg="ui2" p="small" mr="large" borderRadius="medium">
+      <Box bg="ui2" p="u3" mr="large" borderRadius="medium">
         <Box bg="background">
           <List density={density}>
             <ListItem>Item 1</ListItem>

--- a/www/src/documentation/foundations/demos/SpacingOptionsTable.tsx
+++ b/www/src/documentation/foundations/demos/SpacingOptionsTable.tsx
@@ -39,6 +39,7 @@ import { DocTable } from '../../../components'
 import { convertRemToPx } from '@looker/design-tokens'
 
 const spacingExamples = [
+  { label: 'xxxsmall', px: '2', rem: '0.125rem' },
   { label: 'xxsmall', px: '4', rem: '0.25rem' },
   { label: 'xsmall', px: '8', rem: '0.5rem' },
   { label: 'small', px: '12', rem: '0.75rem' },

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -62,7 +62,7 @@ const Intro = () => {
     <>
       <Helmet title={title} />
       <Layout>
-        <Section as="main" p="xxlarge">
+        <Section as="main" p="u10">
           <Heading as="h1" fontWeight="semiBold" textAlign="center" mb="large">
             Looker UI Components
           </Heading>


### PR DESCRIPTION
Switch all "t-shirt size" usage to `uX` (unit size) usage within the product.

Checkout #2725 to see same code with the "legacy" t-shirt space-sizes removed for proof that this fully deprecates our _usage_ of these.


## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] 🖼 Image Snapshot coverage
