### PR TITLE
refactor(density): Consolidate default density in theme

### DIFF
--- a/packages/components/src/Accordion/Accordion.tsx
+++ b/packages/components/src/Accordion/Accordion.tsx
@@ -134,8 +134,10 @@ const AccordionInternal: FC<AccordionProps> = ({
  * @deprecated Use `Accordion2` instead
  */
 export const Accordion = styled(AccordionInternal)`
-  font-size: ${({ theme, density = 0 }) =>
-    theme.fontSizes[accordionDimensions(density).fontSize]};
+  font-size: ${({ theme, density }) =>
+    theme.fontSizes[
+      accordionDimensions(density || theme.defaults.density).fontSize
+    ]};
   width: 100%;
 
   ${AccordionDisclosure}, ${AccordionContent} {

--- a/packages/components/src/Accordion2/Accordion2.tsx
+++ b/packages/components/src/Accordion2/Accordion2.tsx
@@ -54,7 +54,9 @@ const Accordion2Internal = (props: Accordion2Props) => {
  * styling.
  */
 export const Accordion2 = styled(Accordion2Internal)<Accordion2Props>`
-  font-size: ${({ theme, density = 0 }) =>
-    theme.fontSizes[accordionDimensions(density).fontSize]};
+  font-size: ${({ theme, density }) =>
+    theme.fontSizes[
+      accordionDimensions(density || theme.defaults.density).fontSize
+    ]};
   width: 100%;
 `

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -30,6 +30,7 @@ import React, {
   isValidElement,
   ReactChild,
   Ref,
+  useContext,
   useMemo,
 } from 'react'
 import {
@@ -43,7 +44,7 @@ import {
   width,
   WidthProps,
 } from '@looker/design-tokens'
-import styled from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
 import { useArrowKeyNav, useWindow } from '../utils'
 import { ListItemContext, listItemDimensions } from '../ListItem'
 
@@ -107,7 +108,7 @@ export const ListInternal = forwardRef(
     {
       children,
       color,
-      density = 0,
+      density,
       disabled,
       disableKeyboardNav,
       height,
@@ -122,10 +123,8 @@ export const ListInternal = forwardRef(
     forwardedRef: Ref<HTMLUListElement>
   ) => {
     const childArray = useMemo(() => Children.toArray(children), [children])
-
-    const itemDimensions = listItemDimensions(
-      density !== undefined ? density : 0
-    )
+    const theme = useContext(ThemeContext)
+    const itemDimensions = listItemDimensions(density || theme.defaults.density)
 
     if (windowing === undefined) {
       windowing = childArray.length > 100

--- a/packages/components/src/ListItem/ListItemIcon.tsx
+++ b/packages/components/src/ListItem/ListItemIcon.tsx
@@ -24,7 +24,12 @@
 
  */
 
-import styled, { DefaultTheme, StyledComponent } from 'styled-components'
+import { useContext } from 'react'
+import styled, {
+  DefaultTheme,
+  StyledComponent,
+  ThemeContext,
+} from 'styled-components'
 import {
   color as colorHelper,
   DensityProp,
@@ -50,8 +55,11 @@ export const ListItemIcon: StyledComponent<
   DefaultTheme,
   ListItemIconProps
 > = styled.div.attrs<ListItemIconProps>(
-  ({ color, disabled, density = 0, ...props }) => {
-    const { iconGap, iconSize } = listItemDimensions(density)
+  ({ color, disabled, density, ...props }) => {
+    const theme = useContext(ThemeContext)
+    const { iconGap, iconSize } = listItemDimensions(
+      density || theme.defaults.density
+    )
 
     return {
       ...props,

--- a/packages/components/src/ListItem/ListItemLabel.tsx
+++ b/packages/components/src/ListItem/ListItemLabel.tsx
@@ -25,8 +25,8 @@
  */
 
 import { CompatibleHTMLProps, DensityProp } from '@looker/design-tokens'
-import React, { ReactNode } from 'react'
-import styled from 'styled-components'
+import React, { ReactNode, useContext } from 'react'
+import styled, { ThemeContext } from 'styled-components'
 import { TruncateConfigProp, TruncateOptionally } from '../Truncate'
 import { ListItemColorProp } from './types'
 import { listItemDimensions, listItemLabelColor } from './utils'
@@ -44,17 +44,18 @@ export const ListItemLabel = styled(
     color,
     children,
     disabled,
-    density = 0,
+    density,
     description,
     truncate,
     ...props
   }: ListItemLabelProps) => {
+    const theme = useContext(ThemeContext)
     const {
       descriptionFontSize,
       descriptionLineHeight,
       labelFontSize,
       labelLineHeight,
-    } = listItemDimensions(density)
+    } = listItemDimensions(density || theme.defaults.density)
 
     return (
       <div {...props}>

--- a/packages/components/src/ListItem/utils/createListItemPartitions.tsx
+++ b/packages/components/src/ListItem/utils/createListItemPartitions.tsx
@@ -47,7 +47,7 @@ export type CreateListItemPartitionsProps = {
 
 export const createListItemPartitions = ({
   color,
-  density = 0,
+  density,
   description,
   detail,
   disabled,

--- a/packages/components/src/ListItem/utils/listItemDimensions.ts
+++ b/packages/components/src/ListItem/utils/listItemDimensions.ts
@@ -85,6 +85,5 @@ export const densities = {
  * Returns an object with size and spacing scaled to "density" parameter value
  * @param density Accepts values from -3 (smallest) to 1 (largest)
  */
-export const listItemDimensions = (
-  density: DensityRamp = 0
-): ListItemDimensions => densities[density]
+export const listItemDimensions = (density: DensityRamp): ListItemDimensions =>
+  densities[density]

--- a/packages/components/src/Menu/MenuHeading.tsx
+++ b/packages/components/src/Menu/MenuHeading.tsx
@@ -25,7 +25,7 @@
  */
 
 import React, { FC, useContext, ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
 import {
   TextColorProps,
   TypographyProps,
@@ -49,10 +49,11 @@ const MenuHeadingInternal: FC<MenuHeadingProps> = ({
   className,
   ...restProps
 }) => {
+  const theme = useContext(ThemeContext)
   const [isLabelShimVisible, ref] = useElementVisibility()
 
   const { density } = useContext(ListItemContext)
-  const { px } = listItemDimensions(density)
+  const { px } = listItemDimensions(density || theme.defaults.density)
 
   return (
     <MenuHeadingWrapper

--- a/packages/components/src/Menu/MenuItem.tsx
+++ b/packages/components/src/Menu/MenuItem.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import styled from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
 import React, { forwardRef, MouseEvent, Ref, useContext } from 'react'
 import { shouldForwardProp, size } from '@looker/design-tokens'
 import { ArrowRight } from '@styled-icons/material/ArrowRight'
@@ -77,8 +77,9 @@ const MenuItemInternal = forwardRef(
 
     const ref = useForkedRef<HTMLLIElement>(nestedMenuRef, forwardedRef)
 
+    const theme = useContext(ThemeContext)
     const { density } = useContext(ListItemContext)
-    const { iconSize } = listItemDimensions(density)
+    const { iconSize } = listItemDimensions(density || theme.defaults.density)
 
     if (detail && nestedMenu) {
       // eslint-disable-next-line no-console

--- a/packages/components/src/NavTree/NavTree.tsx
+++ b/packages/components/src/NavTree/NavTree.tsx
@@ -254,10 +254,14 @@ export const NavTree = styled(NavTreeLayout)`
   ${AccordionIndicator} {
     padding-left: ${INDICATOR_SPACER};
     ${({ icon, theme }) =>
-      !icon && `margin-right: ${theme.space[listItemDimensions().iconGap]}`}
+      !icon &&
+      `margin-right: ${
+        theme.space[listItemDimensions(theme.defaults.density).iconGap]
+      }`}
   }
 
   ${ListItemDetail} {
-    padding-right: ${({ theme }) => theme.space[listItemDimensions().px]};
+    padding-right: ${({ theme }) =>
+      theme.space[listItemDimensions(theme.defaults.density).px]};
   }
 `

--- a/packages/components/src/NavTree/NavTreeItem.tsx
+++ b/packages/components/src/NavTree/NavTreeItem.tsx
@@ -25,7 +25,7 @@
  */
 
 import React, { useContext } from 'react'
-import styled from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
 import { SpacingSizes } from '@looker/design-tokens'
 import {
   generateIndentCalculation,
@@ -58,10 +58,10 @@ const IndentOverrideTreeItem = styled(TreeItem).withConfig<
     ].includes(prop),
 })`
   ${TreeItemContent} {
-    ${({ depth = 0, density = 0, iconGap, indicatorGap, parentIcon, theme }) =>
+    ${({ depth = 0, density, iconGap, indicatorGap, parentIcon, theme }) =>
       `padding-left: calc(${generateIndentCalculation(
         parentIcon ? depth + 1 : depth,
-        density,
+        density || theme.defaults.density,
         theme
       )} + ${theme.space[iconGap]} - ${
         theme.space[indicatorGap]
@@ -74,8 +74,9 @@ const IndentOverrideTreeItem = styled(TreeItem).withConfig<
 `
 
 export const NavTreeItem = styled((props: NavTreeItemProps) => {
+  const theme = useContext(ThemeContext)
   const { depth } = useContext(TreeContext)
-  const { iconGap, px } = listItemDimensions()
+  const { iconGap, px } = listItemDimensions(theme.defaults.density)
   const { indicatorGap } = accordionDimensions()
 
   return (

--- a/packages/components/src/Tree/utils/generateIndent.ts
+++ b/packages/components/src/Tree/utils/generateIndent.ts
@@ -50,8 +50,8 @@ export const generateIndentCalculation = (
  */
 export const generateIndent = ({
   depth = 0,
-  density = 0,
+  density,
 }: GenerateIndentProps) => css`
   padding-left: ${({ theme }) =>
-    generateIndentCalculation(depth, density, theme)};
+    generateIndentCalculation(depth, density || theme.defaults.density, theme)};
 `

--- a/packages/design-tokens/src/theme/theme.ts
+++ b/packages/design-tokens/src/theme/theme.ts
@@ -39,6 +39,7 @@ import {
   Shadows,
   TransitionRamp,
   FontSources,
+  DensityRamp,
 } from '../system'
 
 /**
@@ -74,11 +75,15 @@ export interface Theme {
   space: SpaceRamp
   transitions: TransitionRamp
   zIndexFloor: number
+  defaults: {
+    density: DensityRamp
+  }
 }
 
 export const theme: DefaultTheme = {
   breakpoints,
   colors,
+  defaults: { density: 0 },
   easings,
   elevations,
   fontSizes,


### PR DESCRIPTION
Refactors all locations that initialize `density` as `0` to instead leverage `theme.defaults.density`

This refactor will allow for easy theme-based override of density in applications.