### PR TITLE
docs: typo `componentn` in Span documentation

### DIFF
--- a/www/src/documentation/components/text/span.mdx
+++ b/www/src/documentation/components/text/span.mdx
@@ -6,7 +6,7 @@ storybook: true
 
 By default the `<Span />` component will render text wrapped in a `<span>`, if you need another html element for semantic purposes you can use the `element` property.
 
-Note: `@looker/components` also exports a, now deprecated, `Text` componentn that is identical to `Span` except that it has a default `fontSize="medium"` rather than inheriting it's parent element's fontSize.
+Note: `@looker/components` also exports a, now deprecated, `Text` component that is identical to `Span` except that it has a default `fontSize="medium"` rather than inheriting it's parent element's fontSize.
 
 ```jsx
 <Span>By default I am a span</Span>


### PR DESCRIPTION
Simple typo fix
