### PR TITLE
refactor: Ripple effect

### DIFF
--- a/packages/components/src/Ripple/Ripple.story.tsx
+++ b/packages/components/src/Ripple/Ripple.story.tsx
@@ -26,58 +26,45 @@
 
 import React from 'react'
 import { Story } from '@storybook/react/types-6-0'
-import { shouldForwardProp } from '@looker/design-tokens'
 import styled from 'styled-components'
 import { simpleLayoutCSS, SimpleLayoutProps } from '../Layout'
-import {
-  useRipple,
-  useRippleHandlers,
-  UseRippleProps,
-  RippleColorProps,
-  rippleStyle,
-  RippleStyleProps,
-} from './'
+import { useRipple, useRippleHandlers, UseRippleProps, rippleStyle } from './'
 
-type RippleProps = SimpleLayoutProps & UseRippleProps & RippleColorProps
+type RippleProps = SimpleLayoutProps & UseRippleProps & { className: string }
 
-const Ripple = ({ bounded, ...props }: RippleProps) => {
-  const {
-    callbacks,
-    className: rippleClassName,
-    ...rippleProps
-  } = useRipple({
-    bounded,
-  })
+const Ripple = styled(
+  ({ className, bounded, color, ...props }: RippleProps) => {
+    const {
+      callbacks,
+      className: rippleClassName,
+      ...rippleProps
+    } = useRipple({
+      bounded,
+      color,
+    })
 
-  const rippleHandlers = useRippleHandlers(callbacks, {})
+    const rippleHandlers = useRippleHandlers(callbacks, {})
 
-  return (
-    <RippleStyle
-      className={rippleClassName}
-      tabIndex={0}
-      {...rippleProps}
-      {...rippleHandlers}
-      {...props}
-    >
-      click me
-    </RippleStyle>
-  )
-}
+    return (
+      <div
+        className={`${className} ${rippleClassName}`}
+        tabIndex={0}
+        {...rippleProps}
+        {...rippleHandlers}
+        {...props}
+      >
+        click me
+      </div>
+    )
+  }
+)<SimpleLayoutProps>`
+  ${simpleLayoutCSS}
+  ${rippleStyle}
 
-const RippleStyle = styled.div
-  .withConfig({
-    shouldForwardProp,
-  })
-  .attrs(({ color = 'neutral' }) => ({ color }))<
-  RippleStyleProps & SimpleLayoutProps
->`
-   ${simpleLayoutCSS}
-   ${rippleStyle}
-
-   align-items: center;
-   display: flex;
-   justify-content: center;
- `
+  align-items: center;
+  display: flex;
+  justify-content: center;
+`
 
 const Template: Story<RippleProps> = (args) => <Ripple {...args} />
 

--- a/packages/components/src/Ripple/rippleStyle.ts
+++ b/packages/components/src/Ripple/rippleStyle.ts
@@ -25,7 +25,6 @@
  */
 
 import { css, keyframes, Keyframes } from 'styled-components'
-import { RippleAnimationValues, RippleColorProps } from './types'
 
 const rippleRadiusIn: Keyframes = keyframes`
 from {
@@ -58,21 +57,10 @@ to {
 }
 `
 
-export type RippleStyleProps = RippleAnimationValues & RippleColorProps
-
 /**
  * Uses :before as fade-in overlay "background" and :after as rippling overlay
  */
-export const rippleStyle = ({
-  color = 'neutral',
-  rippleOffset,
-  rippleScaleRange,
-  rippleSize,
-}: RippleStyleProps) => css`
-  --ripple-scale-start: ${rippleScaleRange[0] || 1};
-  --ripple-scale-end: ${rippleScaleRange[1] || 1};
-  --ripple-translate: ${rippleOffset};
-
+export const rippleStyle = css`
   outline: none;
   overflow: hidden;
   position: relative;
@@ -80,17 +68,17 @@ export const rippleStyle = ({
 
   &::before,
   &::after {
-    background-color: ${({ theme }) => theme.colors[color]};
+    background-color: var(--ripple-color, #000000);
     border-radius: 50%;
     content: '';
-    height: ${rippleSize};
+    height: var(--ripple-size, 100%);
     left: 0;
     opacity: 0;
     pointer-events: none;
     position: absolute;
     top: 0;
     transform-origin: center center;
-    width: ${rippleSize};
+    width: var(--ripple-size, 100%);
   }
 
   &::before {

--- a/packages/components/src/Ripple/types.ts
+++ b/packages/components/src/Ripple/types.ts
@@ -24,25 +24,9 @@
 
  */
 
-import { ExtendedStatefulColor } from '@looker/design-tokens'
-
 export type RippleCallbacks = {
   endBG: () => void
   endFG: () => void
   startBG: () => void
   startFG: () => void
-}
-
-export type RippleAnimationValues = {
-  rippleSize: string
-  rippleScaleRange: [number, number]
-  rippleOffset: string
-}
-
-export type RippleColorProps = {
-  /**
-   * Change the color of the ripple background and foreground
-   * @default neutral
-   */
-  color?: ExtendedStatefulColor
 }

--- a/packages/components/src/Ripple/useRipple.test.tsx
+++ b/packages/components/src/Ripple/useRipple.test.tsx
@@ -34,9 +34,7 @@ const RippleComponent = (props: UseRippleProps) => {
     callbacks: { startBG, endBG, startFG, endFG },
     className,
     ref,
-    rippleOffset,
-    rippleScaleRange,
-    rippleSize,
+    style,
   } = useRipple(props)
   return (
     <div ref={ref}>
@@ -45,9 +43,7 @@ const RippleComponent = (props: UseRippleProps) => {
       <div data-testid="startFG" onClick={startFG} />
       <div data-testid="endFG" onClick={endFG} />
       <div data-testid="className">{className}</div>
-      <div data-testid="rippleOffset">{rippleOffset}</div>
-      <div data-testid="rippleScaleRange">{rippleScaleRange.join('-')}</div>
-      <div data-testid="rippleSize">{rippleSize}</div>
+      <div style={style}>style</div>
     </div>
   )
 }

--- a/packages/components/src/Ripple/useRipple.test.tsx
+++ b/packages/components/src/Ripple/useRipple.test.tsx
@@ -85,18 +85,35 @@ const runTimers = () =>
 describe('useRipple', () => {
   test('animation values', () => {
     renderWithTheme(<RippleComponent />)
-    expect(screen.getByTestId('rippleOffset')).toHaveTextContent('0, 0')
-    expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent('0.1-1')
-    expect(screen.getByTestId('rippleSize')).toHaveTextContent('100%')
+    expect(screen.getByText('style')).toHaveStyle({
+      '--ripple-color': '#71767a',
+      '--ripple-scale-end': '1',
+      '--ripple-scale-start': '0.1',
+      '--ripple-size': '100%',
+      '--ripple-translate': '0, 0',
+    })
   })
 
   test('bounded animation values', () => {
     renderWithTheme(<RippleComponent bounded />)
-    expect(screen.getByTestId('rippleOffset')).toHaveTextContent('165px, 0')
-    expect(screen.getByTestId('rippleScaleRange')).toHaveTextContent(
-      '1-12.041594578792294'
-    )
-    expect(screen.getByTestId('rippleSize')).toHaveTextContent('30px')
+    expect(screen.getByText('style')).toHaveStyle({
+      '--ripple-color': '#71767a',
+      '--ripple-scale-end': '12.041594578792294',
+      '--ripple-scale-start': '1',
+      '--ripple-size': '30px',
+      '--ripple-translate': '165px, 0',
+    })
+  })
+
+  test('color animation values', () => {
+    renderWithTheme(<RippleComponent color="key" />)
+    expect(screen.getByText('style')).toHaveStyle({
+      '--ripple-color': '#6C43E0',
+      '--ripple-scale-end': '1',
+      '--ripple-scale-start': '0.1',
+      '--ripple-size': '100%',
+      '--ripple-translate': '0, 0',
+    })
   })
 
   test('callbacks control className', () => {

--- a/packages/components/src/Ripple/useRipple.tsx
+++ b/packages/components/src/Ripple/useRipple.tsx
@@ -24,8 +24,11 @@
 
  */
 
+import { ExtendedStatefulColor } from '@looker/design-tokens'
+import { CSSProperties, useContext } from 'react'
+import { ThemeContext } from 'styled-components'
 import { useMeasuredElement, useCallbackRef } from '../utils'
-import { RippleAnimationValues, RippleCallbacks } from './types'
+import { RippleCallbacks } from './types'
 import { useRippleState } from './useRippleState'
 import { useRippleStateBG } from './useRippleStateBG'
 
@@ -35,9 +38,14 @@ export type UseRippleProps = {
    * a visible rectangle, e.g. a default Button
    */
   bounded?: boolean
+  /**
+   * Change the color of the ripple background and foreground
+   * @default neutral
+   */
+  color?: ExtendedStatefulColor
 }
 
-export type UseRippleResponse = RippleAnimationValues & {
+export type UseRippleResponse = {
   /**
    * The start and end functions for the background and foreground
    */
@@ -50,6 +58,7 @@ export type UseRippleResponse = RippleAnimationValues & {
    * ref is only used for bounded ripple, to detect element dimensions
    */
   ref?: (node: HTMLElement | null) => void
+  style: CSSProperties
 }
 
 const getMinMaxDimensions = (width: number, height: number) => {
@@ -92,11 +101,16 @@ const getRippleOffset = (min: number, max: number, bounded?: boolean) => {
  * @returns callbacks should be mapped to DOM event handlers (see useRippleHandlers)
  * and remaining props should be passed to an internal element that includes rippleStyle
  */
-export const useRipple = ({ bounded }: UseRippleProps): UseRippleResponse => {
+export const useRipple = ({
+  bounded,
+  color = 'neutral',
+}: UseRippleProps): UseRippleResponse => {
   // ref is actually only used for bounded, when dimensions are needed
   // otherwise ref is wasteful since it triggers a state update & re-render
   const [element, ref] = useCallbackRef()
   const [{ width, height }] = useMeasuredElement(element)
+  // Get the transitions to match the ripple-in & -out animation durations
+  const { colors } = useContext(ThemeContext)
 
   // Get values for animation – bounded uses dimensions, otherwise they're static
   const [min, max] = getMinMaxDimensions(width, height)
@@ -106,6 +120,17 @@ export const useRipple = ({ bounded }: UseRippleProps): UseRippleResponse => {
   // Background (hover, focus) and foreground (press) ripple states
   const { start: startBG, end: endBG, className: bgClass } = useRippleStateBG()
   const { start: startFG, end: endFG, className: fgClass } = useRippleState()
+  // bounded needs an explicit size, otherwise just fill the whole area
+
+  // Limitations of style/CSSProperties type
+  // https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+  const style = {
+    ['--ripple-color' as any]: colors[color],
+    ['--ripple-scale-end' as any]: rippleScaleRange[1] || 1,
+    ['--ripple-scale-start' as any]: rippleScaleRange[0] || 1,
+    ['--ripple-size' as any]: bounded ? `${min}px` : '100%',
+    ['--ripple-translate' as any]: rippleOffset,
+  }
 
   return {
     // Functions to be called from event handlers
@@ -120,9 +145,6 @@ export const useRipple = ({ bounded }: UseRippleProps): UseRippleResponse => {
     className: `${bgClass} ${fgClass}`,
     // bounded needs to get the element size
     ref: bounded ? ref : undefined,
-    rippleOffset,
-    rippleScaleRange,
-    // bounded needs an explicit size, otherwise just fill the whole area
-    rippleSize: bounded ? `${min}px` : '100%',
+    style,
   }
 }

--- a/packages/components/src/Ripple/useRipple.tsx
+++ b/packages/components/src/Ripple/useRipple.tsx
@@ -109,7 +109,7 @@ export const useRipple = ({
   // otherwise ref is wasteful since it triggers a state update & re-render
   const [element, ref] = useCallbackRef()
   const [{ width, height }] = useMeasuredElement(element)
-  // Get the transitions to match the ripple-in & -out animation durations
+  // Get the theme colors to apply the right value for the color prop
   const { colors } = useContext(ThemeContext)
 
   // Get values for animation – bounded uses dimensions, otherwise they're static

--- a/packages/components/src/Ripple/useRipple.tsx
+++ b/packages/components/src/Ripple/useRipple.tsx
@@ -127,7 +127,7 @@ export const useRipple = ({
   const style = {
     ['--ripple-color' as any]: colors[color],
     ['--ripple-scale-end' as any]: rippleScaleRange[1] || 1,
-    ['--ripple-scale-start' as any]: rippleScaleRange[0] || 1,
+    ['--ripple-scale-start' as any]: rippleScaleRange[0],
     ['--ripple-size' as any]: bounded ? `${min}px` : '100%',
     ['--ripple-translate' as any]: rippleOffset,
   }


### PR DESCRIPTION
Adjust the hook & style functions so they can both be applied to the same component instead of the style needing to be applied to a child component.