### PR TITLE
chore(Filter Demo): support lookml dashboards, longer dashboard list

### DIFF
--- a/apps/filter-demo/src/DashboardEmbed.tsx
+++ b/apps/filter-demo/src/DashboardEmbed.tsx
@@ -57,7 +57,7 @@ export const DashboardEmbed: React.FC<DashboardEmbedProps> = ({
     if (el && hostUrl && dashboardId) {
       el.innerHTML = ''
       LookerEmbedSDK.init(hostUrl)
-      LookerEmbedSDK.createDashboardWithId(parseInt(dashboardId, 10))
+      LookerEmbedSDK.createDashboardWithId(dashboardId)
         .withNext()
         // This can be removed if using a theme that has this setting
         .withParams({ _theme: '{"show_filters_bar": false}' })

--- a/apps/filter-demo/src/DashboardList.tsx
+++ b/apps/filter-demo/src/DashboardList.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import type { IDashboard } from '@looker/sdk'
 import type { SelectOptionObject } from '@looker/components'
 import { FieldSelect } from '@looker/components'
@@ -42,29 +42,31 @@ export const DashboardList: React.FC<DashboardListProps> = ({
   dashboards,
   selectDashboard,
 }) => {
+  const [filter, setFilter] = useState('')
   const options = useMemo(
     () =>
       dashboards.reduce(
         (acc: SelectOptionObject[], { id, title }: IDashboard) => {
-          if (id) {
+          if (id && title?.toUpperCase().includes(filter.toUpperCase())) {
             acc = [...acc, { label: title, value: id }]
           }
           return acc
         },
         []
       ),
-    [dashboards]
+    [dashboards, filter]
   )
 
   return (
     <FieldSelect
       label="Select a Dashboard"
       inline={window.innerWidth > 768}
-      autoResize
       isLoading={loading}
       options={options}
       value={current}
       onChange={selectDashboard}
+      isFilterable
+      onFilter={setFilter}
     />
   )
 }

--- a/apps/filter-demo/src/FilterDemo.tsx
+++ b/apps/filter-demo/src/FilterDemo.tsx
@@ -67,7 +67,7 @@ const FilterDemoInternal: FC = () => {
         // Take up to the first 10 dashboards
         setDashboards(
           result
-            .slice(0, 100)
+            .slice(0, 99)
             .sort(({ title: aTitle = '' }, { title: bTitle = '' }) =>
               aTitle.localeCompare(bTitle)
             )

--- a/apps/filter-demo/src/FilterDemo.tsx
+++ b/apps/filter-demo/src/FilterDemo.tsx
@@ -65,7 +65,13 @@ const FilterDemoInternal: FC = () => {
       try {
         const result = await core40SDK.ok(core40SDK.all_dashboards())
         // Take up to the first 10 dashboards
-        setDashboards(result.slice(0, 9))
+        setDashboards(
+          result
+            .slice(0, 100)
+            .sort(({ title: aTitle = '' }, { title: bTitle = '' }) =>
+              aTitle.localeCompare(bTitle)
+            )
+        )
         setLoadingDashboards(false)
       } catch (error) {
         setDashboards([])
@@ -163,11 +169,7 @@ const FilterDemoInternal: FC = () => {
           <Space>
             <Heading>@looker/filter-components Demo</Heading>
           </Space>
-          <Space
-            between={!horizontal}
-            justify={horizontal ? 'end' : undefined}
-            align="end"
-          >
+          <Space justify={horizontal ? 'end' : undefined} align="end">
             <DashboardList
               dashboards={dashboards}
               loading={loadingDashboards}


### PR DESCRIPTION
- Remove `parseInt` for dashboard id – it's no longer necessary (better typing on the embed sdk) and breaks for lookml dashboards
- Take the 1st 100 dashboards instead of the 1st 10 (I was trying to view lookml dashboards on the lenslatest instance but there weren't any in the 1st 10)
- Add filtering in the dashboard `Select`
- For testing purposes, these changes are deployed on the lenslatest instance "Filter Demo" extension (not "Filter Demo Dev")
- Select the "Testing Filters Dash" dashboard to verify that lookml dashboards are now working