### PR TITLE
feat(SelectMulti & InputChips): Support value formatting

### DIFF
--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
@@ -108,6 +108,7 @@ export const ComboboxMultiInputInternal = forwardRef(
       // free form input
       freeInput = false,
       validate,
+      trimInputValues,
       onValidationFail,
       onDuplicate,
 
@@ -263,6 +264,7 @@ export const ComboboxMultiInputInternal = forwardRef(
       <InputChips
         {...commonProps}
         validate={validate}
+        trimInputValues={trimInputValues}
         onValidationFail={onValidationFail}
         onDuplicate={onDuplicate}
         parseInputValue={parseInputValue}

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
@@ -108,7 +108,7 @@ export const ComboboxMultiInputInternal = forwardRef(
       // free form input
       freeInput = false,
       validate,
-      trimInputValues,
+      formatInputValue,
       onValidationFail,
       onDuplicate,
 
@@ -264,7 +264,7 @@ export const ComboboxMultiInputInternal = forwardRef(
       <InputChips
         {...commonProps}
         validate={validate}
-        trimInputValues={trimInputValues}
+        formatInputValue={formatInputValue}
         onValidationFail={onValidationFail}
         onDuplicate={onDuplicate}
         parseInputValue={parseInputValue}

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
@@ -190,7 +190,7 @@ tag2`
     expect(input).toHaveValue('')
   })
 
-  test('trimInputValues false', () => {
+  test('formatInputValue false', () => {
     const onChangeMock = jest.fn()
 
     renderWithTheme(
@@ -198,7 +198,7 @@ tag2`
         onChange={onChangeMock}
         values={[]}
         placeholder="type here"
-        trimInputValues={false}
+        formatInputValue={false}
       />
     )
     const input = screen.getByPlaceholderText('type here')

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
@@ -190,21 +190,40 @@ tag2`
     expect(input).toHaveValue('')
   })
 
-  test('formatInputValue false', () => {
-    const onChangeMock = jest.fn()
+  describe('formatInputValue', () => {
+    test('false', () => {
+      const onChangeMock = jest.fn()
 
-    renderWithTheme(
-      <InputChips
-        onChange={onChangeMock}
-        values={[]}
-        placeholder="type here"
-        formatInputValue={false}
-      />
-    )
-    const input = screen.getByPlaceholderText('type here')
-    fireEvent.change(input, { target: { value: '  no trim  ,' } })
-    expect(onChangeMock).toHaveBeenCalledWith(['  no trim  '])
-    expect(input).toHaveValue('')
+      renderWithTheme(
+        <InputChips
+          onChange={onChangeMock}
+          values={[]}
+          placeholder="type here"
+          formatInputValue={false}
+        />
+      )
+      const input = screen.getByPlaceholderText('type here')
+      fireEvent.change(input, { target: { value: '  no trim  ,' } })
+      expect(onChangeMock).toHaveBeenCalledWith(['  no trim  '])
+      expect(input).toHaveValue('')
+    })
+
+    test('custom', () => {
+      const onChangeMock = jest.fn()
+
+      renderWithTheme(
+        <InputChips
+          onChange={onChangeMock}
+          values={[]}
+          placeholder="type here"
+          formatInputValue={(value: string) => value.toUpperCase()}
+        />
+      )
+      const input = screen.getByPlaceholderText('type here')
+      fireEvent.change(input, { target: { value: '  no trim  ,' } })
+      expect(onChangeMock).toHaveBeenCalledWith(['  NO TRIM  '])
+      expect(input).toHaveValue('')
+    })
   })
 
   test('duplicate values are not added', () => {

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
@@ -190,6 +190,23 @@ tag2`
     expect(input).toHaveValue('')
   })
 
+  test('trimInputValues false', () => {
+    const onChangeMock = jest.fn()
+
+    renderWithTheme(
+      <InputChips
+        onChange={onChangeMock}
+        values={[]}
+        placeholder="type here"
+        trimInputValues={false}
+      />
+    )
+    const input = screen.getByPlaceholderText('type here')
+    fireEvent.change(input, { target: { value: '  no trim  ,' } })
+    expect(onChangeMock).toHaveBeenCalledWith(['  no trim  '])
+    expect(input).toHaveValue('')
+  })
+
   test('duplicate values are not added', () => {
     const onChangeMock = jest.fn()
     const onDuplicateMock = jest.fn()

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
@@ -27,6 +27,7 @@
 import React, { useState } from 'react'
 import type { Story } from '@storybook/react/types-6-0'
 import { defaultArgTypes as argTypes } from '../../../../../../storybook/src/defaultArgTypes'
+import { Space } from '../../../Layout'
 import type { InputChipsProps } from './InputChips'
 import { InputChips } from './InputChips'
 
@@ -97,6 +98,24 @@ ReadOnly.args = {
   readOnly: true,
 }
 ReadOnly.parameters = {
+  storyshots: { disable: true },
+}
+
+export const TrimInputValuesFalse = () => {
+  const [chips, setChips] = useState(['initial', 'values'])
+  return (
+    <Space>
+      <InputChips
+        values={chips}
+        onChange={setChips}
+        trimInputValues={false}
+        width={400}
+      />
+      <pre data-testid="pre">{JSON.stringify(chips)}</pre>
+    </Space>
+  )
+}
+TrimInputValuesFalse.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
@@ -108,7 +108,7 @@ export const TrimInputValuesFalse = () => {
       <InputChips
         values={chips}
         onChange={setChips}
-        trimInputValues={false}
+        formatInputValue={false}
         width={400}
       />
       <pre data-testid="pre">{JSON.stringify(chips)}</pre>

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.story.tsx
@@ -101,7 +101,7 @@ ReadOnly.parameters = {
   storyshots: { disable: true },
 }
 
-export const TrimInputValuesFalse = () => {
+export const FormatInputValuesFalse = () => {
   const [chips, setChips] = useState(['initial', 'values'])
   return (
     <Space>
@@ -115,7 +115,7 @@ export const TrimInputValuesFalse = () => {
     </Space>
   )
 }
-TrimInputValuesFalse.parameters = {
+FormatInputValuesFalse.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -48,8 +48,8 @@ export interface InputChipsValidationProps {
    */
   validate?: (value: string) => boolean
   /**
-   * Format each value entered, before validation, defaults to `value.trim()`,
-   * set to `false` to avoid trimming whitespace
+   * Callback to format each value entered, before validation.
+   * Defaults to `value.trim()`, set to `false` to avoid trimming whitespace.
    */
   formatInputValue?: FormatInputValue
   /**

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -61,7 +61,7 @@ export interface InputChipsValidationProps {
   onDuplicate?: (values: string[]) => void
 }
 
-export function splitInputValue(inputValue: string) {
+export const splitInputValue = (inputValue: string) => {
   // Preserve escaped commas & tabs using these strings produced by a random string generator
   const commaKey = '0UX1bJKsFBFQonIIXq9oyeV40ITHwtew'
   const tabKey = 'heF6X4qMBtIti8c8U9nMhskYOQUQiXqx'
@@ -120,134 +120,132 @@ export const validateValues = (
   return { duplicateValues, invalidValues, unusedValues, validValues }
 }
 
-export const InputChipsInternal = forwardRef(
-  (
-    {
-      values,
-      onChange,
-      chipIconLabel,
-      clearIconLabel,
-      inputValue: controlledInputValue,
-      onInputChange,
-      parseInputValue = splitInputValue,
-      validate,
-      trimInputValues = true,
-      onValidationFail,
-      onDuplicate,
+export const InputChips = styled(
+  forwardRef(
+    (
+      {
+        values,
+        onChange,
+        chipIconLabel,
+        clearIconLabel,
+        inputValue: controlledInputValue,
+        onInputChange,
+        parseInputValue = splitInputValue,
+        validate,
+        trimInputValues = true,
+        onValidationFail,
+        onDuplicate,
 
-      // event handlers needing to be wrapped
-      onBlur,
-      onKeyDown,
-      onPaste,
+        // event handlers needing to be wrapped
+        onBlur,
+        onKeyDown,
+        onPaste,
 
-      ...props
-    }: InputChipsProps,
-    ref: Ref<HTMLInputElement>
-  ) => {
-    const isControlled = useControlWarn({
-      controllingProps: ['inputValue', 'onInputChange'],
-      isControlledCheck: () =>
-        controlledInputValue !== undefined && onInputChange !== undefined,
-      name: 'InputChips',
-    })
-
-    const [uncontrolledValue, setUncontrolledValue] = useState('')
-    const inputValue = isControlled
-      ? controlledInputValue || ''
-      : uncontrolledValue
-
-    const setInputValue = (
-      val: string,
-      event?: FormEvent<HTMLInputElement>
+        ...props
+      }: InputChipsProps,
+      ref: Ref<HTMLInputElement>
     ) => {
-      if (!isControlled) {
-        setUncontrolledValue(val)
-      }
-      if (val !== inputValue) {
-        onInputChange && onInputChange(val, event)
-      }
-    }
+      const isControlled = useControlWarn({
+        controllingProps: ['inputValue', 'onInputChange'],
+        isControlledCheck: () =>
+          controlledInputValue !== undefined && onInputChange !== undefined,
+        name: 'InputChips',
+      })
 
-    function updateValues(newInputValue?: string) {
-      const inputValues = parseInputValue(newInputValue || inputValue)
-      const { duplicateValues, invalidValues, unusedValues, validValues } =
-        validateValues(inputValues, values, validate, trimInputValues)
+      const [uncontrolledValue, setUncontrolledValue] = useState('')
+      const inputValue = isControlled
+        ? controlledInputValue || ''
+        : uncontrolledValue
 
-      // Save valid values and keep invalid ones in the input
-      const updatedInputValue = unusedValues.join(', ')
-      const updatedValues = validValues.length && [...values, ...validValues]
-      if (updatedValues) {
-        onChange(updatedValues)
-      }
-
-      if (invalidValues.length > 0) {
-        onValidationFail && onValidationFail(invalidValues)
-      }
-      if (duplicateValues.length > 0) {
-        onDuplicate && onDuplicate(duplicateValues)
+      const setInputValue = (
+        val: string,
+        event?: FormEvent<HTMLInputElement>
+      ) => {
+        if (!isControlled) {
+          setUncontrolledValue(val)
+        }
+        if (val !== inputValue) {
+          onInputChange && onInputChange(val, event)
+        }
       }
 
-      setInputValue(updatedInputValue)
-    }
+      const updateValues = (newInputValue?: string) => {
+        const inputValues = parseInputValue(newInputValue || inputValue)
+        const { duplicateValues, invalidValues, unusedValues, validValues } =
+          validateValues(inputValues, values, validate, trimInputValues)
 
-    function handleBlur() {
-      updateValues()
-    }
+        // Save valid values and keep invalid ones in the input
+        const updatedInputValue = unusedValues.join(', ')
+        const updatedValues = validValues.length && [...values, ...validValues]
+        if (updatedValues) {
+          onChange(updatedValues)
+        }
 
-    function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
-      if (e.key === 'Enter') {
-        // Don't submit a form if there is one
-        e.preventDefault()
-        // Update values when the user hits return
+        if (invalidValues.length > 0) {
+          onValidationFail && onValidationFail(invalidValues)
+        }
+        if (duplicateValues.length > 0) {
+          onDuplicate && onDuplicate(duplicateValues)
+        }
+
+        setInputValue(updatedInputValue)
+      }
+
+      const handleBlur = () => {
         updateValues()
       }
-    }
 
-    const pastedValue = useRef<string | null>()
-    function handlePaste(e: ClipboardEvent<HTMLInputElement>) {
-      // Save the pasted value to detect newlines before the browser strips them
-      pastedValue.current = e.clipboardData.getData('Text')
-    }
-
-    function handleInputChange(
-      value: string,
-      event?: FormEvent<HTMLInputElement>
-    ) {
-      // If the last character is a comma, update the values
-      // Or, if the user pastes content, we assume that the final value is complete
-      // even if there's no comma at the end
-      if (pastedValue.current || value.endsWith(',')) {
-        // Use the pasted value if there is one
-        // (before newlines are stripped by the browser)
-        updateValues(pastedValue.current || value)
-        pastedValue.current = null
-      } else {
-        setInputValue(value, event)
+      const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+          // Don't submit a form if there is one
+          e.preventDefault()
+          // Update values when the user hits return
+          updateValues()
+        }
       }
+
+      const pastedValue = useRef<string | null>()
+      const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+        // Save the pasted value to detect newlines before the browser strips them
+        pastedValue.current = e.clipboardData.getData('Text')
+      }
+
+      const handleInputChange = (
+        value: string,
+        event?: FormEvent<HTMLInputElement>
+      ) => {
+        // If the last character is a comma, update the values
+        // Or, if the user pastes content, we assume that the final value is complete
+        // even if there's no comma at the end
+        if (pastedValue.current || value.endsWith(',')) {
+          // Use the pasted value if there is one
+          // (before newlines are stripped by the browser)
+          updateValues(pastedValue.current || value)
+          pastedValue.current = null
+        } else {
+          setInputValue(value, event)
+        }
+      }
+
+      const wrappedEvents = {
+        onBlur: useWrapEvent(handleBlur, onBlur),
+        onKeyDown: useWrapEvent(handleKeyDown, onKeyDown),
+        onPaste: useWrapEvent(handlePaste, onPaste),
+      }
+
+      return (
+        <InputChipsBase
+          ref={ref}
+          values={values}
+          onChange={onChange}
+          chipIconLabel={chipIconLabel}
+          clearIconLabel={clearIconLabel}
+          inputValue={inputValue}
+          onInputChange={handleInputChange}
+          {...wrappedEvents}
+          {...props}
+        />
+      )
     }
-
-    const wrappedEvents = {
-      onBlur: useWrapEvent(handleBlur, onBlur),
-      onKeyDown: useWrapEvent(handleKeyDown, onKeyDown),
-      onPaste: useWrapEvent(handlePaste, onPaste),
-    }
-
-    return (
-      <InputChipsBase
-        ref={ref}
-        values={values}
-        onChange={onChange}
-        chipIconLabel={chipIconLabel}
-        clearIconLabel={clearIconLabel}
-        inputValue={inputValue}
-        onInputChange={handleInputChange}
-        {...wrappedEvents}
-        {...props}
-      />
-    )
-  }
-)
-
-InputChipsInternal.displayName = 'InputChipsInternal'
-
-export const InputChips = styled(InputChipsInternal)``
+  )
+)``

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -47,6 +47,11 @@ export interface InputChipsValidationProps {
    */
   validate?: (value: string) => boolean
   /**
+   * Trim whitespace from entered values (before validation)
+   * @default true
+   */
+  trimInputValues?: boolean
+  /**
    * callback when values fail validation
    */
   onValidationFail?: (values: string[]) => void
@@ -86,18 +91,19 @@ export interface InputChipsProps
   parseInputValue?: (value: string) => string[]
 }
 
-export function validateValues(
+export const validateValues = (
   newValues: string[],
   currentValues: string[],
-  validate?: (value: string) => boolean
-) {
+  validate?: (value: string) => boolean,
+  trimInputValues?: boolean
+) => {
   const duplicateValues: string[] = []
   const invalidValues: string[] = []
   const unusedValues: string[] = []
   const validValues: string[] = []
 
   newValues.forEach((val: string) => {
-    const trimmedValue = val.trim()
+    const trimmedValue = trimInputValues ? val.trim() : val
     if (trimmedValue === '') return
     // Make sure each value is valid and doesn't already exist
     if (validate && !validate(trimmedValue)) {
@@ -125,6 +131,7 @@ export const InputChipsInternal = forwardRef(
       onInputChange,
       parseInputValue = splitInputValue,
       validate,
+      trimInputValues = true,
       onValidationFail,
       onDuplicate,
 
@@ -164,7 +171,7 @@ export const InputChipsInternal = forwardRef(
     function updateValues(newInputValue?: string) {
       const inputValues = parseInputValue(newInputValue || inputValue)
       const { duplicateValues, invalidValues, unusedValues, validValues } =
-        validateValues(inputValues, values, validate)
+        validateValues(inputValues, values, validate, trimInputValues)
 
       // Save valid values and keep invalid ones in the input
       const updatedInputValue = unusedValues.join(', ')

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.spec.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.spec.tsx
@@ -292,7 +292,7 @@ describe('closeOnSelect', () => {
       fireEvent.click(document)
     })
 
-    test('trimInputValues false', () => {
+    test('formatInputValue false', () => {
       const onChangeMock = jest.fn()
       renderWithTheme(
         <SelectMulti
@@ -301,7 +301,7 @@ describe('closeOnSelect', () => {
           placeholder="Search"
           onChange={onChangeMock}
           freeInput
-          trimInputValues={false}
+          formatInputValue={false}
         />
       )
 

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.spec.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.spec.tsx
@@ -282,9 +282,33 @@ describe('closeOnSelect', () => {
       )
 
       const input = screen.getByPlaceholderText('Search')
-      fireEvent.change(input, { target: { value: 'baz,qux,' } })
+
+      // Whitespace trimmed by default
+      fireEvent.change(input, { target: { value: ' baz , qux,' } })
 
       expect(onChangeMock).toHaveBeenCalledWith(['FOO', 'BAR', 'baz', 'qux'])
+      expect(input).toHaveValue('')
+
+      fireEvent.click(document)
+    })
+
+    test('trimInputValues false', () => {
+      const onChangeMock = jest.fn()
+      renderWithTheme(
+        <SelectMulti
+          options={basicOptions}
+          defaultValues={['FOO', 'BAR']}
+          placeholder="Search"
+          onChange={onChangeMock}
+          freeInput
+          trimInputValues={false}
+        />
+      )
+
+      const input = screen.getByPlaceholderText('Search')
+      fireEvent.change(input, { target: { value: ' baz , qux,' } })
+
+      expect(onChangeMock).toHaveBeenCalledWith(['FOO', 'BAR', ' baz ', ' qux'])
       expect(input).toHaveValue('')
 
       fireEvent.click(document)

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -100,7 +100,7 @@ const SelectMultiComponent = forwardRef(
       placeholder,
       removeOnBackspace = true,
       showCreate = false,
-      trimInputValues,
+      formatInputValue,
       validate,
       values,
       windowing: windowingProp,
@@ -147,7 +147,7 @@ const SelectMultiComponent = forwardRef(
           selectOnClick={isFilterable}
           freeInput={freeInput}
           validate={validate}
-          trimInputValues={trimInputValues}
+          formatInputValue={formatInputValue}
           onValidationFail={onValidationFail}
           onDuplicate={onDuplicate}
           ref={ref}

--- a/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectMulti.tsx
@@ -100,6 +100,7 @@ const SelectMultiComponent = forwardRef(
       placeholder,
       removeOnBackspace = true,
       showCreate = false,
+      trimInputValues,
       validate,
       values,
       windowing: windowingProp,
@@ -146,6 +147,7 @@ const SelectMultiComponent = forwardRef(
           selectOnClick={isFilterable}
           freeInput={freeInput}
           validate={validate}
+          trimInputValues={trimInputValues}
           onValidationFail={onValidationFail}
           onDuplicate={onDuplicate}
           ref={ref}

--- a/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
+++ b/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
@@ -26,20 +26,23 @@
 
 import type { Story } from '@storybook/react/types-6-0'
 import React from 'react'
+import { defaultArgTypes as argTypes } from '../../../../../../../storybook/src/defaultArgTypes'
+import { Space } from '../../../../Layout'
 import type { SelectMultiProps } from '../SelectMulti'
 import { SelectMulti } from '../SelectMulti'
-import { defaultArgTypes as argTypes } from '../../../../../../../storybook/src/defaultArgTypes'
 import { options1kGrouped } from './options1k'
 
 const Template: Story<SelectMultiProps> = (args) => <SelectMulti {...args} />
 
+const cheeses = [
+  { label: 'Cheddar', value: 'cheddar' },
+  { label: 'Gouda', value: 'gouda' },
+  { label: 'Swiss', value: 'swiss' },
+]
+
 export const Basic = Template.bind({})
 Basic.args = {
-  options: [
-    { label: 'Cheddar', value: 'cheddar' },
-    { label: 'Gouda', value: 'gouda' },
-    { label: 'Swiss', value: 'swiss' },
-  ],
+  options: cheeses,
 }
 
 export const Placeholder = Template.bind({})
@@ -112,6 +115,27 @@ GroupedWindowing.args = {
 }
 
 GroupedWindowing.parameters = {
+  storyshots: { disable: true },
+}
+
+export const TrimInputValuesFalse = () => {
+  const [values, setValues] = useState<string[]>()
+  return (
+    <Space>
+      <SelectMulti
+        values={values}
+        onChange={setValues}
+        options={cheeses}
+        freeInput
+        trimInputValues={false}
+        placeholder="Free input values are not trimmed"
+        width={400}
+      />
+      <pre data-testid="pre">{JSON.stringify(values)}</pre>
+    </Space>
+  )
+}
+TrimInputValuesFalse.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
+++ b/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
@@ -118,7 +118,7 @@ GroupedWindowing.parameters = {
   storyshots: { disable: true },
 }
 
-export const TrimInputValuesFalse = () => {
+export const FormatInputValuesFalse = () => {
   const [values, setValues] = useState<string[]>()
   return (
     <Space>
@@ -135,7 +135,7 @@ export const TrimInputValuesFalse = () => {
     </Space>
   )
 }
-TrimInputValuesFalse.parameters = {
+FormatInputValuesFalse.parameters = {
   storyshots: { disable: true },
 }
 

--- a/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
+++ b/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
@@ -127,7 +127,7 @@ export const TrimInputValuesFalse = () => {
         onChange={setValues}
         options={cheeses}
         freeInput
-        trimInputValues={false}
+        formatInputValue={false}
         placeholder="Free input values are not trimmed"
         width={400}
       />

--- a/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
+++ b/packages/components/src/Form/Inputs/Select/stories/SelectMulti.story.tsx
@@ -25,7 +25,7 @@
  */
 
 import type { Story } from '@storybook/react/types-6-0'
-import React from 'react'
+import React, { useState } from 'react'
 import { defaultArgTypes as argTypes } from '../../../../../../../storybook/src/defaultArgTypes'
 import { Space } from '../../../../Layout'
 import type { SelectMultiProps } from '../SelectMulti'

--- a/www/src/documentation/components/forms/input-chips.mdx
+++ b/www/src/documentation/components/forms/input-chips.mdx
@@ -145,8 +145,9 @@ invalid and duplicate values are entered.
 
 ## formatInputValue
 
-By default, any leading or trailing whitespace will be trimmed from
-entered values, before validation. To avoid this, use `formatInputValue={false}`.
+Use this callback to format values after there are entered, before validation.
+By default, any leading or trailing whitespace will be trimmed – to avoid this,
+use `formatInputValue={false}`.
 
 ```jsx
 ;() => {

--- a/www/src/documentation/components/forms/input-chips.mdx
+++ b/www/src/documentation/components/forms/input-chips.mdx
@@ -143,10 +143,10 @@ invalid and duplicate values are entered.
 }
 ```
 
-## trimInputValues
+## formatInputValue
 
 By default, any leading or trailing whitespace will be trimmed from
-entered values, before validation. To avoid this, use `trimInputValues={false}`.
+entered values, before validation. To avoid this, use `formatInputValue={false}`.
 
 ```jsx
 ;() => {
@@ -157,7 +157,7 @@ entered values, before validation. To avoid this, use `trimInputValues={false}`.
         placeholder="Values are not trimmed"
         values={values}
         onChange={setValues}
-        trimInputValues={false}
+        formatInputValue={false}
         width="50%"
       />
       <pre>{JSON.stringify(values)}</pre>

--- a/www/src/documentation/components/forms/input-chips.mdx
+++ b/www/src/documentation/components/forms/input-chips.mdx
@@ -143,6 +143,29 @@ invalid and duplicate values are entered.
 }
 ```
 
+## trimInputValues
+
+By default, any leading or trailing whitespace will be trimmed from
+entered values, before validation. To avoid this, use `trimInputValues={false}`.
+
+```jsx
+;() => {
+  const [values, setValues] = React.useState([])
+  return (
+    <Space>
+      <InputChips
+        placeholder="Values are not trimmed"
+        values={values}
+        onChange={setValues}
+        trimInputValues={false}
+        width="50%"
+      />
+      <pre>{JSON.stringify(values)}</pre>
+    </Space>
+  )
+}
+```
+
 ## removeOnBackspace
 
 The `removeOnBackspace` prop defaults to true.

--- a/www/src/documentation/components/forms/select-multi.mdx
+++ b/www/src/documentation/components/forms/select-multi.mdx
@@ -74,7 +74,7 @@ by the enter key, comma, or tab or newline character when pasting. This prop als
 
 Use the `validate` callback to ensure that values entered via `freeInput` are valid, and the `onValidationFail` and `onDuplicate`
 callbacks to handle invalid values. By default, any leading or trailing whitespace will be trimmed from
-entered values, before validation. To avoid this, use `formatInputValue={false}`.
+entered values, before validation. To avoid this, use `formatInputValue={false}`, or provide a callback for custom formatting.
 
 ```jsx
 ;() => {

--- a/www/src/documentation/components/forms/select-multi.mdx
+++ b/www/src/documentation/components/forms/select-multi.mdx
@@ -74,7 +74,7 @@ by the enter key, comma, or tab or newline character when pasting. This prop als
 
 Use the `validate` callback to ensure that values entered via `freeInput` are valid, and the `onValidationFail` and `onDuplicate`
 callbacks to handle invalid values. By default, any leading or trailing whitespace will be trimmed from
-entered values, before validation. To avoid this, use `trimInputValues={false}`.
+entered values, before validation. To avoid this, use `formatInputValue={false}`.
 
 ```jsx
 ;() => {

--- a/www/src/documentation/components/forms/select-multi.mdx
+++ b/www/src/documentation/components/forms/select-multi.mdx
@@ -73,7 +73,8 @@ This enables the inputting behavior of [`InputChips`](/components/forms/input-ch
 by the enter key, comma, or tab or newline character when pasting. This prop also supports accepting values copy-pasted in from another `SelectMulti`.
 
 Use the `validate` callback to ensure that values entered via `freeInput` are valid, and the `onValidationFail` and `onDuplicate`
-callbacks to handle invalid values.
+callbacks to handle invalid values. By default, any leading or trailing whitespace will be trimmed from
+entered values, before validation. To avoid this, use `trimInputValues={false}`.
 
 ```jsx
 ;() => {
@@ -88,7 +89,7 @@ callbacks to handle invalid values.
     setMessage('')
   }
   return (
-    <SpaceVertical>
+    <SpaceVertical align="stretch">
       <SelectMulti
         options={[
           { value: 'Cheddar' },


### PR DESCRIPTION
Adds a `formatInputValues` prop to `InputChips` and `SelectMulti` (which contains `InputChips`). 

The default is `value.trim()`, to match the current behavior, which trims whitespace from inputted values before validating them – `false` will leave the whitespace intact.