### PR TITLE
fix(PopoverContent): Properly absorb `p` value (also `DialogContent`)

### DIFF
--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.spec.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.spec.tsx
@@ -45,11 +45,13 @@ describe('DialogContent', () => {
       '0.125rem'
     )
   })
+
   test('display correct padding if hasHeader', () => {
     renderWithTheme(<DialogContent hasHeader>Stuff</DialogContent>)
 
     expect(screen.getByText('Stuff')).toHaveStyleRule('padding-top', '0.125rem')
   })
+
   test('display correct padding if both  hasFooter & hasHeader', () => {
     renderWithTheme(
       <DialogContent hasFooter hasHeader>
@@ -62,5 +64,14 @@ describe('DialogContent', () => {
       '0.125rem'
     )
     expect(screen.getByText('Stuff')).toHaveStyleRule('padding-top', '0.125rem')
+  })
+
+  test('Custom padding `p`', () => {
+    renderWithTheme(<DialogContent p="u12">Hello world</DialogContent>)
+    const item = screen.getByText('Hello world')
+    expect(item).toHaveStyleRule('padding-left', '3rem')
+    expect(item).toHaveStyleRule('padding-right', '3rem')
+    expect(item).toHaveStyleRule('padding-top', '3rem')
+    expect(item).toHaveStyleRule('padding-bottom', '3rem')
   })
 })

--- a/packages/components/src/Dialog/Layout/DialogContent/DialogContent.tsx
+++ b/packages/components/src/Dialog/Layout/DialogContent/DialogContent.tsx
@@ -32,12 +32,14 @@ import { ModalContent } from '../../../Modal/ModalContent'
 
 export type DialogContentProps = ModalContentProps & LayoutProps
 
-export const DialogContent = styled(ModalContent).attrs(
-  ({ pb = 'large', pt = 'large', px = 'xlarge' }) => ({
-    pb,
-    pt,
-    px,
-  })
-)<DialogContentProps>`
+const dialogContentDefaults = {
+  px: 'u8',
+  py: 'u5',
+}
+
+export const DialogContent = styled(ModalContent).attrs(({ p, py, px }) => ({
+  px: p || px || dialogContentDefaults.px,
+  py: p || py || dialogContentDefaults.py,
+}))<DialogContentProps>`
   ${layout}
 `

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.spec.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.spec.tsx
@@ -50,4 +50,13 @@ describe('PopoverContent', () => {
     expect(item).toHaveStyleRule('padding-top', '2rem')
     expect(item).toHaveStyleRule('padding-bottom', '0.75rem')
   })
+
+  test('Custom padding `p`', () => {
+    renderWithTheme(<PopoverContent p="u12">Hello world</PopoverContent>)
+    const item = screen.getByText('Hello world')
+    expect(item).toHaveStyleRule('padding-left', '3rem')
+    expect(item).toHaveStyleRule('padding-right', '3rem')
+    expect(item).toHaveStyleRule('padding-top', '3rem')
+    expect(item).toHaveStyleRule('padding-bottom', '3rem')
+  })
 })

--- a/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
+++ b/packages/components/src/Popover/Layout/PopoverContent/PopoverContent.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import type { FC } from 'react'
 import React from 'react'
 import styled from 'styled-components'
 import type { LayoutProps } from '@looker/design-tokens'
@@ -34,17 +33,22 @@ import { ModalContent } from '../../../Modal/ModalContent'
 
 export type PopoverContentProps = ModalContentProps & LayoutProps
 
-const PopoverContentLayout: FC<PopoverContentProps> = ({
-  children,
-  ...props
-}) => {
-  return (
-    <ModalContent overflowVerticalPadding="u1" py="u4" px="u5" {...props}>
-      {children}
-    </ModalContent>
-  )
+const popoverContentDefaults = {
+  px: 'u5',
+  py: 'u4',
 }
 
-export const PopoverContent = styled(PopoverContentLayout)<PopoverContentProps>`
+export const PopoverContent = styled(
+  ({ children, p, py, px, ...props }: PopoverContentProps) => {
+    py = py || p || popoverContentDefaults.py
+    px = px || p || popoverContentDefaults.px
+
+    return (
+      <ModalContent overflowVerticalPadding="u1" py={py} px={px} {...props}>
+        {children}
+      </ModalContent>
+    )
+  }
+)<PopoverContentProps>`
   ${layout}
 `


### PR DESCRIPTION
Fixes the way `p` is absorbed into the `PopoverContent` and `DialogContent` so that it overrides any default values properly.

Before the fix: `<PopoverContent p="xxlarge">` the `xxlarge` padding wouldn't be applied at all because the component internally had more specific selectors/properties `px` & `py`. 

This changes alter the implementation of `PopoverContent` & `DialogContent` to consistent ingest padding values so that externally specified properties act in a predictable manner.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] 🖼 Image Snapshot coverage
