### PR TITLE
refactor: Consistent structure properties in styled-components interpolation blocks

### DIFF
--- a/packages/components-date/src/InputTime/InputTime.tsx
+++ b/packages/components-date/src/InputTime/InputTime.tsx
@@ -528,7 +528,7 @@ const StyledInput = styled.input
   }))`
   ${innerInputStyle}
   font-family: inherit;
-  font-size: ${(props) => props.theme.fontSizes.small};
+  font-size: ${({ theme }) => theme.fontSizes.small};
   height: 34px;
   line-height: ${({ theme }) => theme.lineHeights.medium};
   padding: 0;

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -127,7 +127,7 @@ export const ButtonItem = styled(ButtonLayout)`
   }
 
   &[disabled] {
-    color: ${(props) => props.theme.colors.text1};
+    color: ${({ theme }) => theme.colors.text1};
     cursor: default;
 
     &:hover {

--- a/packages/components/src/Button/ButtonTransparent.tsx
+++ b/packages/components/src/Button/ButtonTransparent.tsx
@@ -32,7 +32,7 @@ export const ButtonTransparent = styled(ButtonBase)`
   background: transparent;
   border: 1px solid transparent;
   color: ${({ theme, color = 'key' }) => theme.colors[color]};
-  padding: 0 ${(props) => props.theme.space.u2};
+  padding: 0 ${({ theme }) => theme.space.u2};
 
   &:hover,
   &:focus,

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -78,7 +78,7 @@ const ChipStyle = styled.span<FocusVisibleProps & MaxWidthProps>`
   &:active,
   &:focus,
   &[aria-selected='true'] {
-    background: ${(props) => props.theme.colors.keyAccent};
+    background: ${({ theme }) => theme.colors.keyAccent};
   }
 
   &.focus,

--- a/packages/components/src/DataTable/BulkActions/BulkActions.tsx
+++ b/packages/components/src/DataTable/BulkActions/BulkActions.tsx
@@ -110,7 +110,7 @@ const BulkActionsLayout: FC<BulkActionsProps> = ({
 export const BulkActions = styled(BulkActionsLayout)`
   align-items: center;
   background-color: ${({ theme }) => theme.colors.ui1};
-  border-bottom: solid 1px ${(props) => props.theme.colors.ui2};
+  border-bottom: solid 1px ${({ theme }) => theme.colors.ui2};
   display: flex;
   height: 3.25rem;
   justify-content: center;

--- a/packages/components/src/DataTable/Header/DataTableHeaderCell.tsx
+++ b/packages/components/src/DataTable/Header/DataTableHeaderCell.tsx
@@ -111,8 +111,8 @@ DataTableHeaderCellLayout.displayName = 'DataTableHeaderCellLayout'
 
 export const DataTableHeaderCell = styled(DataTableHeaderCellLayout)`
   ${columnSize}
-  border-bottom: solid 1px ${(props) => props.theme.colors.ui2};
-  color: ${(props) => props.theme.colors.text5};
-  font-weight: ${(props) => props.theme.fontWeights.semiBold};
+  border-bottom: solid 1px ${({ theme }) => theme.colors.ui2};
+  color: ${({ theme }) => theme.colors.text5};
+  font-weight: ${({ theme }) => theme.fontWeights.semiBold};
   text-align: left;
 `

--- a/packages/components/src/DataTable/Item/DataTableRow.tsx
+++ b/packages/components/src/DataTable/Item/DataTableRow.tsx
@@ -135,7 +135,7 @@ export const DataTableRow = styled(DataTableRowLayout)`
   th {
     background: ${({ checked, isHeaderRow, theme: { colors } }) =>
       checked && !isHeaderRow ? colors.keySubtle : colors.background};
-    border-bottom: solid 1px ${(props) => props.theme.colors.ui2};
+    border-bottom: solid 1px ${({ theme }) => theme.colors.ui2};
     &:first-of-type > div {
       border-left: 1px solid transparent;
       border-right: 1px solid transparent; /* Keeps checkbox centered */

--- a/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
+++ b/packages/components/src/Form/Inputs/InlineInputText/InlineInputText.tsx
@@ -103,8 +103,8 @@ const StyledInput = styled.input`
   }
 
   :disabled {
-    color: ${(props) => props.theme.colors.text1};
-    -webkit-text-fill-color: ${(props) => props.theme.colors.text1};
+    color: ${({ theme }) => theme.colors.text1};
+    -webkit-text-fill-color: ${({ theme }) => theme.colors.text1};
   }
 `
 

--- a/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
+++ b/packages/components/src/Form/Inputs/InlineTextArea/InlineTextArea.tsx
@@ -130,7 +130,7 @@ export const InlineTextArea = styled(InlineTextAreaLayout)`
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
-  min-height: ${(props) => props.theme.lineHeights.medium};
+  min-height: ${({ theme }) => theme.lineHeights.medium};
   min-width: 2rem;
   position: relative;
   text-align: inherit;
@@ -138,8 +138,8 @@ export const InlineTextArea = styled(InlineTextAreaLayout)`
 
   :focus,
   :hover {
-    background-color: ${(props) => props.theme.colors.ui1};
-    border-bottom-color: ${(props) => props.theme.colors.key};
+    background-color: ${({ theme }) => theme.colors.ui1};
+    border-bottom-color: ${({ theme }) => theme.colors.key};
     outline: none;
   }
 

--- a/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
+++ b/packages/components/src/Form/Inputs/InputColor/Swatch/Swatch.tsx
@@ -95,5 +95,5 @@ export const Swatch = styled.div
     ${inputTextHover}
   }
 
-  ${(props) => props.color === 'transparent' && emptySwatch}
+  ${({ color }) => color === 'transparent' && emptySwatch}
 `

--- a/packages/components/src/Form/Inputs/InputText/InputText.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.tsx
@@ -223,27 +223,27 @@ InputTextLayout.displayName = 'InputComponent'
 const StyledInput = styled.input`
   ${innerInputStyle}
   flex: 1;
-  font-size: ${(props) => props.theme.fontSizes.small};
+  font-size: ${({ theme }) => theme.fontSizes.small};
   max-width: 100%;
   min-width: 2rem;
   padding: 0 ${({ theme: { space } }) => space.u2};
 `
 
 export const inputTextHover = css`
-  border-color: ${(props) => props.theme.colors.ui3};
+  border-color: ${({ theme }) => theme.colors.ui3};
 `
 export const inputTextFocus = css`
-  border-color: ${(props) => props.theme.colors.keyFocus};
-  box-shadow: 0 0 0 2px ${(props) => props.theme.colors.keyAccent};
+  border-color: ${({ theme }) => theme.colors.keyFocus};
+  box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.keyAccent};
   outline: none;
 `
 export const inputTextDisabled = css`
-  background: ${(props) => props.theme.colors.ui1};
-  color: ${(props) => props.theme.colors.text1};
+  background: ${({ theme }) => theme.colors.ui1};
+  color: ${({ theme }) => theme.colors.text1};
   cursor: default;
-  -webkit-text-fill-color: ${(props) => props.theme.colors.text1};
+  -webkit-text-fill-color: ${({ theme }) => theme.colors.text1};
   &:hover {
-    border-color: ${(props) => props.theme.colors.ui2};
+    border-color: ${({ theme }) => theme.colors.ui2};
   }
 `
 
@@ -260,13 +260,13 @@ export const ErrorIcon = styled(Error)`
 export const InputTextContent = styled.div<SpaceProps>`
   ${space}
   align-items: center;
-  color: ${(props) => props.theme.colors.text1};
+  color: ${({ theme }) => theme.colors.text1};
   display: flex;
   height: 100%;
   pointer-events: none;
 
   ${StyledIconBase} {
-    color: ${(props) => props.theme.colors.text1};
+    color: ${({ theme }) => theme.colors.text1};
     ${InputIconSize}
   }
 
@@ -330,7 +330,7 @@ export const InputText = styled(InputTextLayout).attrs<InputTextProps>(
     width: 100%;
     input,
     span {
-      padding: 0 ${({ theme: { space } }) => space.u2};
+      padding: 0 ${({ theme }) => theme.space.u2};
     }
   }
 
@@ -341,6 +341,6 @@ export const InputText = styled(InputTextLayout).attrs<InputTextProps>(
   :focus-within {
     ${inputTextFocus}
   }
-  ${(props) => (props.disabled ? inputTextDisabled : '')}
+  ${({ disabled }) => (disabled ? inputTextDisabled : '')}
   ${inputTextValidation}
 `

--- a/packages/components/src/Form/Inputs/Radio/Radio.tsx
+++ b/packages/components/src/Form/Inputs/Radio/Radio.tsx
@@ -69,7 +69,7 @@ export const Radio = styled(RadioLayout)`
   position: relative;
   width: 1rem;
   input {
-    background: ${(props) => props.theme.colors.field};
+    background: ${({ theme }) => theme.colors.field};
     height: 100%;
     opacity: 0;
     position: absolute;

--- a/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
+++ b/packages/components/src/Form/Inputs/TextArea/TextArea.tsx
@@ -106,7 +106,7 @@ export const TextArea = styled(TextAreaLayout).attrs<TextAreaProps>(
     ${simpleLayoutCSS}
     ${inputCSS}
     padding: ${({ theme }) => `${theme.space.u2} ${theme.space.u3}`};
-    padding-right: ${(props) => props.theme.space.u8};
+    padding-right: ${({ theme }) => theme.space.u8};
     ${textAreaResize}
     vertical-align: top; /* textarea is inline-block so this removes 4px generated below */
     width: 100%;
@@ -120,7 +120,7 @@ export const TextArea = styled(TextAreaLayout).attrs<TextAreaProps>(
       ${inputTextFocus}
     }
 
-    ${(props) => (props.disabled ? inputTextDisabled : '')}
+    ${({ disabled }) => (disabled ? inputTextDisabled : '')}
 
     ${inputTextValidation}
   }

--- a/packages/components/src/Form/Inputs/innerInputStyle.ts
+++ b/packages/components/src/Form/Inputs/innerInputStyle.ts
@@ -43,6 +43,6 @@ export const innerInputStyle = css`
   }
 
   ::placeholder {
-    color: ${(props) => props.theme.colors.text1};
+    color: ${({ theme }) => theme.colors.text1};
   }
 `

--- a/packages/components/src/Form/ValidationMessage/ValidationMessage.tsx
+++ b/packages/components/src/Form/ValidationMessage/ValidationMessage.tsx
@@ -52,7 +52,7 @@ const ValidationMessageLayout: FC<ValidationMessageProps> = ({
 export const ValidationMessage = styled(ValidationMessageLayout)`
   ${reset}
 
-  font-size: ${(props) => props.theme.fontSizes.xsmall};
+  font-size: ${({ theme }) => theme.fontSizes.xsmall};
 
   ${({ theme, type }) => type === 'error' && `color: ${theme.colors.critical};`}
 `

--- a/packages/components/src/ProgressCircular/DeterminateProgress.tsx
+++ b/packages/components/src/ProgressCircular/DeterminateProgress.tsx
@@ -71,6 +71,6 @@ const DeterminateContainer = styled.div`
 `
 
 const DeterminateCircle = styled.circle`
-  stroke: ${(props) => props.theme.colors.key};
+  stroke: ${({ theme }) => theme.colors.key};
   transition: stroke-dashoffset 500ms;
 `

--- a/packages/components/src/ProgressCircular/ProgressSvg.tsx
+++ b/packages/components/src/ProgressCircular/ProgressSvg.tsx
@@ -30,6 +30,6 @@ export const CircleContainer = styled.svg`
   fill: transparent;
   height: 100%;
   position: absolute;
-  stroke: ${(props) => props.theme.colors.key};
+  stroke: ${({ theme }) => theme.colors.key};
   width: 100%;
 `

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -83,9 +83,9 @@ const Style = styled.div
   ${space}
   ${position}
 
-  height: ${(props) => props.size}px;
+  height: ${({ size }) => size}px;
   position: relative;
-  width: ${(props) => props.size}px;
+  width: ${({ size }) => size}px;
 `
 
 export const Spinner = styled(SpinnerFactory)``

--- a/packages/components/src/Table/TableCell/tableCell.ts
+++ b/packages/components/src/Table/TableCell/tableCell.ts
@@ -52,7 +52,7 @@ export interface TableCellProps
 
 export const tableCellCSS = css`
   ${reset}
-  padding: ${(props) => props.theme.space.u2} 0;
+  padding: ${({ theme }) => theme.space.u2} 0;
   ${border}
   ${color}
   ${layout}

--- a/packages/components/src/Tabs2/TabList2.tsx
+++ b/packages/components/src/Tabs2/TabList2.tsx
@@ -37,7 +37,7 @@ const defaultLayoutCSS = css`
     min-width: 3rem;
   }
   button + button {
-    margin-left: ${(props) => props.theme.space.xlarge};
+    margin-left: ${({ theme }) => theme.space.xlarge};
   }
 `
 

--- a/packages/components/src/utils/useFocusVisible.ts
+++ b/packages/components/src/utils/useFocusVisible.ts
@@ -51,7 +51,7 @@ export const focusVisibleCSSWrapper = <Props extends FocusVisibleProps>(
   &:focus-visible {
     ${styleFn}
   }
-  ${(props) => props.focusVisible && styleFn(props)}
+  ${({ focusVisible }) => focusVisible && styleFn}
 `
 
 export const useFocusVisible = <E extends HTMLElement = HTMLElement>({

--- a/packages/design-tokens/src/elevation/index.ts
+++ b/packages/design-tokens/src/elevation/index.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Elevations } from './types'
-export { Elevations } from './types'
+export { Elevations, ElevationRamp } from './types'
 
 const colorBase = '60, 64, 67'
 const baseShadowColor = `rgba(${colorBase}, .30)`

--- a/www/src/MDX/Link.tsx
+++ b/www/src/MDX/Link.tsx
@@ -29,6 +29,6 @@ import styled from 'styled-components'
 
 export const Link = styled(LookerLink)`
   &:visited {
-    color: ${(props) => props.theme.colors.keyInteractive};
+    color: ${({ theme }) => theme.colors.keyInteractive};
   }
 `

--- a/www/src/components/DocTable.tsx
+++ b/www/src/components/DocTable.tsx
@@ -32,6 +32,6 @@ export const DocTable = styled(Table)`
   margin-bottom: ${({ theme }) => theme.space.u8};
 
   ${Code} {
-    color: ${(props) => props.theme.colors.key};
+    color: ${({ theme }) => theme.colors.key};
   }
 `

--- a/www/src/documentation/components/layout/demos/BoxSpacingRecipeTable.tsx
+++ b/www/src/documentation/components/layout/demos/BoxSpacingRecipeTable.tsx
@@ -67,7 +67,7 @@ const SpacingTable = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   margin: 2rem 0;
   & > div {
-    border-right: 1px solid ${(props) => props.theme.colors.ui2};
+    border-right: 1px solid ${({ theme }) => theme.colors.ui2};
     &:last-child {
       border-right: none;
     }

--- a/www/src/documentation/develop/theme.mdx
+++ b/www/src/documentation/develop/theme.mdx
@@ -38,8 +38,8 @@ You can use the theme's properties within your custom components:
    **/
 
   const PositiveButton = styled(Button)`
-    border-color: ${(props) => props.theme.colors.positive};
-    background-color: ${(props) => props.theme.colors.positive};
+    border-color: ${({ theme }) => theme.colors.positive};
+    background-color: ${({ theme }) => theme.colors.positive};
   `
 
   return (
@@ -67,8 +67,8 @@ You can extend the theme provided by Looker Components by creating a copy and th
   }
 
   const PrettyButton = styled(Button)`
-    border-color: ${(props) => props.theme.myCustomAttribute};
-    background-color: ${(props) => props.theme.myCustomAttribute};
+    border-color: ${({ theme }) => theme.myCustomAttribute};
+    background-color: ${({ theme }) => theme.myCustomAttribute};
   `
 
   return (
@@ -98,8 +98,8 @@ NOTE: You'll also see that `PrettyButton` in the example simply falls back to `B
   }
 
   const PrettyButton = styled(Button)`
-    border-color: ${(props) => props.theme.myCustomAttribute};
-    background-color: ${(props) => props.theme.myCustomAttribute};
+    border-color: ${({ theme }) => theme.myCustomAttribute};
+    background-color: ${({ theme }) => theme.myCustomAttribute};
   `
 
   return (

--- a/www/src/documentation/foundations/breakpoints.mdx
+++ b/www/src/documentation/foundations/breakpoints.mdx
@@ -27,12 +27,12 @@ const ResponsiveBox = styled(Box)`
   background: green;
 
   // make the background red at breakpoint[0](480px)
-  @media (min-width ${(props) => props.theme.breakpoints[0]}) {
+  @media (min-width ${({ theme }) => theme.breakpoints[0]}) {
     background: red;
   }
 
   // make the background red at breakpoint[1](768x)
-  @media (min-width ${(props) => props.theme.breakpoints[1]}) {
+  @media (min-width ${({ theme }) => theme.breakpoints[1]}) {
     background: blue;
   }
 `

--- a/www/src/documentation/foundations/demos/ColorBlendsGrid.tsx
+++ b/www/src/documentation/foundations/demos/ColorBlendsGrid.tsx
@@ -74,7 +74,7 @@ const BlendList = styled(({ colors, ...props }: BlendListProps) => (
   }
 
   *:last-child::before {
-    border-bottom: solid 1px ${(props) => props.theme.colors.ui3};
+    border-bottom: solid 1px ${({ theme }) => theme.colors.ui3};
     border-radius: 0 0 4px 4px;
   }
 `

--- a/www/src/documentation/foundations/demos/ElevationList.tsx
+++ b/www/src/documentation/foundations/demos/ElevationList.tsx
@@ -24,36 +24,32 @@
 
  */
 
- import React from 'react'
- import {
-    Code,
-    Flex,
-    Space,
-    Text
- } from '@looker/components'
+import React from 'react'
+import { Code, Flex, Space, Text } from '@looker/components'
 import styled from 'styled-components'
 
+const ElevatedBox = styled(Flex)<{ level }>`
+  border-radius: ${({ theme }) => theme.radii.medium};
+  box-shadow: ${({ theme }) => theme.elevations[props.level]};
+  height: 125px;
+  width: 124px;
+`
 
- const ElevatedBox = styled(Flex)<{level}>`
-    border-radius: ${(props) => props.theme.radii.medium};
-    box-shadow: ${(props) => props.theme.elevations[props.level]};
-    height: 125px;
-    width: 124px;
- `
-
- export const ElevationList = () => (
-   <Space gap="u6">
-   {["plus0", "plus1", "plus2", "plus3", "plus4", "plus5"].map(e => {
-     return(
-      <ElevatedBox
-        key={e}
-        level={e}
-        alignItems="center"
-        justifyContent="center"
-      >
-        <Code fontSize="xsmall" color="text3">{e}</Code>
-      </ElevatedBox>
-    )
-   })}
-    </Space>
+export const ElevationList = () => (
+  <Space gap="u6">
+    {['plus0', 'plus1', 'plus2', 'plus3', 'plus4', 'plus5'].map((e) => {
+      return (
+        <ElevatedBox
+          key={e}
+          level={e}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Code fontSize="xsmall" color="text3">
+            {e}
+          </Code>
+        </ElevatedBox>
+      )
+    })}
+  </Space>
 )

--- a/www/src/documentation/foundations/demos/ElevationList.tsx
+++ b/www/src/documentation/foundations/demos/ElevationList.tsx
@@ -25,13 +25,17 @@
  */
 
 import React from 'react'
-import { Code, Flex, Space, Text } from '@looker/components'
+import { Code, Space } from '@looker/components'
+import type { ElevationRamp } from '@looker/design-tokens'
 import styled from 'styled-components'
 
-const ElevatedBox = styled(Flex)<{ level }>`
+const ElevatedBox = styled.div<{ level: ElevationRamp }>`
+  align-items: center;
   border-radius: ${({ theme }) => theme.radii.medium};
-  box-shadow: ${({ theme }) => theme.elevations[props.level]};
+  box-shadow: ${({ level, theme }) => theme.elevations[level]};
+  display: flex;
   height: 125px;
+  justify-content: center;
   width: 124px;
 `
 
@@ -39,12 +43,7 @@ export const ElevationList = () => (
   <Space gap="u6">
     {['plus0', 'plus1', 'plus2', 'plus3', 'plus4', 'plus5'].map((e) => {
       return (
-        <ElevatedBox
-          key={e}
-          level={e}
-          alignItems="center"
-          justifyContent="center"
-        >
+        <ElevatedBox key={e} level={e}>
           <Code fontSize="xsmall" color="text3">
             {e}
           </Code>


### PR DESCRIPTION
Makes our use of destructring within Styled Components interpolated strings (CSS blocks) consistent - primarily replacing `${(props) => props.theme` with `${({ theme }) => theme`