### PR TITLE
fix(useAccordion2): Ignore changes to defaultOpen

### DIFF
--- a/packages/components/src/Accordion2/Accordion2.spec.tsx
+++ b/packages/components/src/Accordion2/Accordion2.spec.tsx
@@ -111,4 +111,26 @@ describe('Accordion2', () => {
       <Accordion2 isOpen {...defaultProps} />
     )
   })
+
+  test('defaultOpen mutation should be ignored', () => {
+    const Example = () => {
+      const [defaultOpen, setDefaultOpen] = React.useState(true)
+
+      return (
+        <>
+          <button onClick={() => setDefaultOpen(!defaultOpen)}>Toggle</button>
+          <Accordion2 defaultOpen={defaultOpen} label="Hello">
+            World
+          </Accordion2>
+          )
+        </>
+      )
+    }
+
+    renderWithTheme(<Example />)
+    expect(screen.getByText('World')).toBeInTheDocument()
+    // Accordion should ignore change
+    fireEvent.click(screen.getByText('Toggle'))
+    expect(screen.getByText('World')).toBeInTheDocument()
+  })
 })

--- a/packages/components/src/Accordion2/useAccordion2.tsx
+++ b/packages/components/src/Accordion2/useAccordion2.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useClickable, useToggle, useWrapEvent } from '../utils'
 import { Accordion2Content } from './Accordion2Content'
 import { accordionDefaults, accordionLeftDefaults } from './accordionDefaults'
@@ -59,7 +59,12 @@ export const useAccordion2 = ({
   toggleOpen: propsToggleOpen,
   ...props
 }: Accordion2Props) => {
-  const { value, toggle } = useToggle(!!defaultOpen)
+  const { change, value, toggle } = useToggle()
+
+  useEffect(() => {
+    defaultOpen !== undefined && change(defaultOpen)
+  }, [])
+
   const isOpen = propsIsOpen !== undefined ? propsIsOpen : value
 
   const onClick = useWrapEvent(() => {

--- a/packages/components/src/Accordion2/useAccordion2.tsx
+++ b/packages/components/src/Accordion2/useAccordion2.tsx
@@ -24,8 +24,8 @@
 
  */
 
-import React, { useEffect } from 'react'
-import { useClickable, useToggle, useWrapEvent } from '../utils'
+import React, { useState } from 'react'
+import { useClickable, useWrapEvent } from '../utils'
 import { Accordion2Content } from './Accordion2Content'
 import { accordionDefaults, accordionLeftDefaults } from './accordionDefaults'
 import { AccordionIndicator } from './AccordionIndicator'
@@ -47,7 +47,7 @@ export const useAccordion2 = ({
   indicatorIcons = indicatorPosition === 'left'
     ? accordionLeftDefaults.indicatorIcons
     : accordionDefaults.indicatorIcons,
-  defaultOpen,
+  defaultOpen = false,
   isOpen: propsIsOpen,
   onBlur,
   onClick: propsOnClick,
@@ -59,11 +59,8 @@ export const useAccordion2 = ({
   toggleOpen: propsToggleOpen,
   ...props
 }: Accordion2Props) => {
-  const { change, value, toggle } = useToggle()
-
-  useEffect(() => {
-    defaultOpen !== undefined && change(defaultOpen)
-  }, [])
+  const [value, setValue] = useState(defaultOpen)
+  const toggle = () => setValue(!value)
 
   const isOpen = propsIsOpen !== undefined ? propsIsOpen : value
 


### PR DESCRIPTION
Currently `useAccordion2` (and by proxy `Accordion2` & `Accordion`) responds to mutations of the `defaultOpen` property. Instead it should be a one-and-done property – changes should be ignored.