### PR TITLE
fix(Tab2): `Tabs` should be output with `type="button"` to prevent accidental form submission

### DIFF
--- a/packages/components/src/ListItem/ListItem.spec.tsx
+++ b/packages/components/src/ListItem/ListItem.spec.tsx
@@ -170,6 +170,7 @@ describe('ListItem', () => {
     )
 
     const item = screen.getByText('Item')
+    expect(item.closest('button')).toHaveAttribute('type', 'button')
     fireEvent.click(item)
 
     expect(callbackFn).toHaveBeenCalledTimes(0)

--- a/packages/components/src/ListItem/ListItemContent.tsx
+++ b/packages/components/src/ListItem/ListItemContent.tsx
@@ -40,7 +40,9 @@ import type {
 } from './types'
 import { listItemBackgroundColor, listItemPaddingX } from './utils'
 
-const Button = styled.button`
+const Button = styled.button.attrs(({ type = 'button' }) => ({
+  type,
+}))`
   font-family: inherit;
 `
 const Link = styled.a``

--- a/packages/components/src/Tabs/Tab.tsx
+++ b/packages/components/src/Tabs/Tab.tsx
@@ -83,6 +83,7 @@ export const Tab = styled(
         role="tab"
         selected={selected}
         tabIndex={-1}
+        type="button"
         {...focusVisibleProps}
         {...restProps}
       />

--- a/packages/components/src/Tabs/Tabs.spec.tsx
+++ b/packages/components/src/Tabs/Tabs.spec.tsx
@@ -254,4 +254,10 @@ describe('focus behavior', () => {
     fireEvent.keyDown(tab1, { code: 39, key: 'ArrowRight' })
     expect(screen.getByText('tab2')).toHaveFocus()
   })
+
+  test('Tab has type attribute', () => {
+    renderWithTheme(<TabTest />)
+    fireEvent.click(screen.getByText('tab1'))
+    expect(screen.getByText('tab1')).toHaveAttribute('type', 'button')
+  })
 })


### PR DESCRIPTION
Addresses a similar issue with `ListItemContent` as well.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/components/blob/main//CONTRIBUTING.md#developer-checklist)

- [x] ♿️ Accessibility addressed
- [x] 🖼 Image Snapshot coverage