### PR TITLE
test: Remove unneeded eslint-disable react/display-name

### DIFF
--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.tsx
@@ -59,7 +59,6 @@ export interface CheckboxProps
 }
 
 export const Checkbox = styled(
-  // eslint-disable-next-line react/display-name
   forwardRef((props: CheckboxProps, ref: Ref<HTMLInputElement>) => {
     const {
       className,


### PR DESCRIPTION
I took at look at the cases where we've had to disable `react/display-name` – in the case of `Checkbox` it appears to be working properly without disabling the rule.