### PR TITLE
docs: Correct color documentation presentation

### DIFF
--- a/packages/design-tokens/src/color/types/specifiable.ts
+++ b/packages/design-tokens/src/color/types/specifiable.ts
@@ -24,7 +24,12 @@
 
  */
 
-export const coreColors: Array<keyof CoreColors> = ['key', 'background', 'text']
+export const coreColors: Array<keyof CoreColors> = [
+  'key',
+  'background',
+  'pageBackground',
+  'text',
+]
 
 export interface TextColor {
   /**

--- a/packages/design-tokens/src/color/utils/colorBreakdown.ts
+++ b/packages/design-tokens/src/color/utils/colorBreakdown.ts
@@ -67,7 +67,9 @@ export const colorBreakdown = (colors: Colors): ColorBreakdown => {
 
   for (const [key, value] of Object.entries(colors)) {
     if ((coreColors as string[]).includes(key)) {
-      divided.core[key] = value
+      if (key !== 'pageBackground') {
+        divided.core[key] = value
+      }
     } else if ((intentColors as string[]).includes(key)) {
       divided.intent[key] = value
     } else if ((derivativeColors as string[]).includes(key)) {

--- a/packages/design-tokens/src/color/utils/pickSpecifiableColors.spec.ts
+++ b/packages/design-tokens/src/color/utils/pickSpecifiableColors.spec.ts
@@ -41,6 +41,7 @@ describe('pickSpecifiableColors', () => {
         "key": "#6C43E0",
         "link": "#0059b2",
         "measure": "#C2772E",
+        "pageBackground": "#FFFFFF",
         "positive": "#24b25f",
         "text": "#262D33",
         "warn": "#FFA800",


### PR DESCRIPTION
Correct's the "shape" of the color breakdown output.

Follow-up at b/199927358 to address documenting `pageBackground` publicly.