### PR TITLE
fix(LkFieldGroupTree): Import path issue for CodeSandbox

### DIFF
--- a/packages/components/src/Button/MultiFunctionButton.stories.tsx
+++ b/packages/components/src/Button/MultiFunctionButton.stories.tsx
@@ -30,7 +30,9 @@ import { Add } from '@styled-icons/material/Add'
 import { Check } from '@styled-icons/material/Check'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
 import { MultiFunctionButton } from './MultiFunctionButton'
-import { Button, ButtonOutline, ButtonTransparent } from '.'
+import { Button } from './Button'
+import { ButtonOutline } from './ButtonOutline'
+import { ButtonTransparent } from './ButtonTransparent'
 
 export default {
   argTypes,

--- a/packages/components/src/Button/MultiFunctionButton.tsx
+++ b/packages/components/src/Button/MultiFunctionButton.tsx
@@ -34,7 +34,8 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 import { useForkedRef } from '../utils'
-import type { ButtonProps, IconButtonProps } from '.'
+import type { IconButtonProps } from './IconButton'
+import type { ButtonProps } from './types'
 
 export type MultiFunctionButtonProps = {
   alternate: ReactElement<

--- a/packages/components/src/Button/MultiFunctionButton.tsx
+++ b/packages/components/src/Button/MultiFunctionButton.tsx
@@ -34,7 +34,7 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 import { useForkedRef } from '../utils'
-import type { IconButtonProps } from './IconButton'
+import type { IconButtonProps } from './iconButtonTypes'
 import type { ButtonProps } from './types'
 
 export type MultiFunctionButtonProps = {

--- a/packages/components/src/DataTable/utils/useDataTable.tsx
+++ b/packages/components/src/DataTable/utils/useDataTable.tsx
@@ -29,7 +29,7 @@ import { DataTable } from '../DataTable'
 import { DataTableItem } from '../Item'
 import type { DataTableColumns } from '../Column'
 import { DataTableCell } from '../Column'
-import type { DataTableData } from '.'
+import type { DataTableData } from './sort_utils'
 
 export const useDataTable = (
   data: DataTableData,

--- a/packages/components/src/DataTable/utils/useDataTableSortManager.tsx
+++ b/packages/components/src/DataTable/utils/useDataTableSortManager.tsx
@@ -31,7 +31,7 @@ import { DataTableItem } from '../Item'
 import type { DataTableColumns } from '../Column'
 import { DataTableCell } from '../Column'
 import { doDataTableSort } from './sort_utils'
-import type { DataTableDatum, DataTableData } from '.'
+import type { DataTableDatum, DataTableData } from './sort_utils'
 
 export const useDataTableSortManager = (
   caption: string,

--- a/packages/components/src/Dialog/Layout/DialogLayout.stories.tsx
+++ b/packages/components/src/Dialog/Layout/DialogLayout.stories.tsx
@@ -28,8 +28,9 @@ import type { Story } from '@storybook/react/types-6-0'
 import { defaultArgTypes as argTypes } from '../../../../../storybook/src/defaultArgTypes'
 import { ConstitutionShort } from '../../__mocks__/Constitution'
 import { Box2 } from '../../Layout'
-import type { DialogLayoutProps } from '.'
-import { DialogContent, DialogLayout } from '.'
+import type { DialogLayoutProps } from './DialogLayout'
+import { DialogLayout } from './DialogLayout'
+import { DialogContent } from './DialogContent'
 
 const Template: Story<DialogLayoutProps> = (args) => (
   <Box2 bg="ui1">

--- a/packages/components/src/Layout/Box/Box.stories.tsx
+++ b/packages/components/src/Layout/Box/Box.stories.tsx
@@ -30,8 +30,8 @@ import React from 'react'
 import { VIEWPORT_MAP } from '../../utils-storybook'
 import { Icon } from '../../Icon'
 import { defaultArgTypes as argTypes } from '../../../../../storybook/src/defaultArgTypes'
-import type { BoxProps } from '.'
-import { Box } from '.'
+import type { BoxProps } from './Box'
+import { Box } from './Box'
 
 export default {
   argTypes,

--- a/packages/components/src/Layout/Semantics/Semantics.stories.tsx
+++ b/packages/components/src/Layout/Semantics/Semantics.stories.tsx
@@ -27,7 +27,11 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Grid } from '../Grid'
-import { Layout, Header, Aside, Footer, Section } from '.'
+import { Aside } from './Aside'
+import { Footer } from './Footer'
+import { Header } from './Header'
+import { Layout } from './Layout'
+import { Section } from './Section'
 
 export default {
   title: 'Semantics Layout',

--- a/packages/components/src/LkFieldTree/LkFieldGroupTree.tsx
+++ b/packages/components/src/LkFieldTree/LkFieldGroupTree.tsx
@@ -26,7 +26,7 @@
 
 import styled from 'styled-components'
 import { LkFieldTreeAccordionDisclosure } from './LkFieldTreeAccordionDisclosure'
-import { LkFieldTree } from '.'
+import { LkFieldTree } from './LkFieldTree'
 
 /**
  * LkFieldGroupTree is typically used to represent a group of Looker fields

--- a/packages/components/src/LkFieldTree/LkFieldViewTree.tsx
+++ b/packages/components/src/LkFieldTree/LkFieldViewTree.tsx
@@ -26,7 +26,7 @@
 
 import styled from 'styled-components'
 import { LkFieldTreeAccordionContent } from './LkFieldTreeAccordionContent'
-import { LkFieldTree } from '.'
+import { LkFieldTree } from './LkFieldTree'
 
 /**
  * LkFieldViewTree is used to represent a Looker View and is expected to be

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -59,7 +59,11 @@ import { Heading, Text, Paragraph } from '../Text'
 import { Tooltip } from '../Tooltip'
 import { useToggle } from '../utils'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
-import { Menu, MenuDivider, MenuItem, MenuList, MenuHeading } from '.'
+import { Menu } from './Menu'
+import { MenuDivider } from './MenuDivider'
+import { MenuItem } from './MenuItem'
+import { MenuList } from './MenuList'
+import { MenuHeading } from './MenuHeading'
 
 export default {
   argTypes,

--- a/packages/components/src/Menu/MenuList.stories.tsx
+++ b/packages/components/src/Menu/MenuList.stories.tsx
@@ -33,8 +33,11 @@ import type { FC } from 'react'
 import React, { Fragment } from 'react'
 import { Box2, Grid, Space } from '../Layout'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
-import type { MenuItemProps } from '.'
-import { MenuHeading, MenuList, MenuItem, MenuDivider } from '.'
+import type { MenuItemProps } from './MenuItem'
+import { MenuDivider } from './MenuDivider'
+import { MenuItem } from './MenuItem'
+import { MenuList } from './MenuList'
+import { MenuHeading } from './MenuHeading'
 
 const groups: { label?: string; items: MenuItemProps[] }[] = [
   {

--- a/packages/components/src/NavTree/NavTree.stories.tsx
+++ b/packages/components/src/NavTree/NavTree.stories.tsx
@@ -32,7 +32,7 @@ import { NavList } from '../NavList'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
 import { NavTree } from './NavTree'
 import { NavTreeItem } from './NavTreeItem'
-import type { NavTreeProps } from './NavTree'
+import type { NavTreeProps } from './types'
 
 export default {
   argTypes,

--- a/packages/components/src/NavTree/NavTree.stories.tsx
+++ b/packages/components/src/NavTree/NavTree.stories.tsx
@@ -32,7 +32,7 @@ import { NavList } from '../NavList'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
 import { NavTree } from './NavTree'
 import { NavTreeItem } from './NavTreeItem'
-import type { NavTreeProps } from '.'
+import type { NavTreeProps } from './NavTree'
 
 export default {
   argTypes,

--- a/packages/components/src/OrderedList/OrderedList.stories.tsx
+++ b/packages/components/src/OrderedList/OrderedList.stories.tsx
@@ -27,8 +27,8 @@
 import React from 'react'
 import type { Story } from '@storybook/react/types-6-0'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
-import type { OrderedListProps } from '.'
-import { OrderedList } from '.'
+import type { OrderedListProps } from './OrderedList'
+import { OrderedList } from './OrderedList'
 
 export default {
   argTypes,

--- a/packages/components/src/PageSize/PageSize.stories.tsx
+++ b/packages/components/src/PageSize/PageSize.stories.tsx
@@ -27,7 +27,7 @@
 import React, { useState } from 'react'
 import type { Story } from '@storybook/react/types-6-0'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
-import type { PageSizeProps } from './PageSizeProps'
+import type { PageSizeProps } from './PageSize'
 import { PageSize } from './PageSize'
 
 const Template: Story<PageSizeProps> = (args) => <PageSize {...args} />

--- a/packages/components/src/PageSize/PageSize.stories.tsx
+++ b/packages/components/src/PageSize/PageSize.stories.tsx
@@ -27,8 +27,8 @@
 import React, { useState } from 'react'
 import type { Story } from '@storybook/react/types-6-0'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
-import type { PageSizeProps } from '.'
-import { PageSize } from '.'
+import type { PageSizeProps } from './PageSizeProps'
+import { PageSize } from './PageSize'
 
 const Template: Story<PageSizeProps> = (args) => <PageSize {...args} />
 

--- a/packages/components/src/UnorderedList/UnorderedList.stories.tsx
+++ b/packages/components/src/UnorderedList/UnorderedList.stories.tsx
@@ -27,8 +27,8 @@
 import React from 'react'
 import type { Story } from '@storybook/react/types-6-0'
 import { defaultArgTypes as argTypes } from '../../../../storybook/src/defaultArgTypes'
-import type { UnorderedListProps } from '.'
-import { UnorderedList } from '.'
+import type { UnorderedListProps } from './UnorderedList'
+import { UnorderedList } from './UnorderedList'
 
 export default {
   argTypes,


### PR DESCRIPTION
CodeSandbox does not seem to like the `'.'` import path used in `LkFieldGroupTree.tsx`.

It thinks `LkFieldTree` is undefined when `styled` gets to it on [this line](https://github.com/looker-open-source/components/blob/main/packages/components/src/LkFieldTree/LkFieldGroupTree.tsx#L37), and I can't think of any other explanation besides it not liking the import path.

![image](https://user-images.githubusercontent.com/53451193/133840009-437cf294-2247-4897-98e4-d0597615f4c7.png)
