### PR TITLE
feat: Support specification of `brandAnimation` and `density` via `themeCustomizations`

### DIFF
--- a/packages/design-tokens/src/defaults/generateDefaults.spec.ts
+++ b/packages/design-tokens/src/defaults/generateDefaults.spec.ts
@@ -24,44 +24,31 @@
 
  */
 
-import { generateColors } from '../../color'
-import type { Theme } from '../theme'
-import { defaultFontFallbacks } from '../../tokens'
-import { generateDefaults } from '../../defaults'
-import type { ThemeCustomizations } from '../ThemeCustomizations'
-import { generateFontFamilies } from '../../utils/typography'
+import { generateDefaults } from './generateDefaults'
+import { themeDefaults } from './index'
 
-export const generateTheme = (
-  theme: Theme,
-  customizations?: ThemeCustomizations
-): Theme => {
-  if (!customizations) {
-    return theme
-  }
+describe('generateDefaults', () => {
+  test('none', () => {
+    const defaults = generateDefaults(themeDefaults)
 
-  const { fontSources } = customizations
+    expect(defaults.brandAnimation).toEqual(false)
+    expect(defaults.density).toEqual(0)
+  })
 
-  const fonts = customizations.fontFamilies
-    ? generateFontFamilies(
-        theme.fonts,
-        defaultFontFallbacks,
-        customizations.fontFamilies
-      )
-    : theme.fonts
+  test('empty', () => {
+    const defaults = generateDefaults(themeDefaults, {})
 
-  const colors = customizations.colors
-    ? generateColors(theme.colors, customizations.colors)
-    : theme.colors
+    expect(defaults.brandAnimation).toEqual(themeDefaults.brandAnimation)
+    expect(defaults.density).toEqual(themeDefaults.density)
+  })
 
-  const defaults = customizations.defaults
-    ? generateDefaults(theme.defaults, customizations.defaults)
-    : theme.defaults
+  test('overwrite', () => {
+    const defaults = generateDefaults(themeDefaults, {
+      brandAnimation: true,
+      density: -1,
+    })
 
-  return {
-    ...theme,
-    colors,
-    defaults,
-    fontSources,
-    fonts,
-  }
-}
+    expect(defaults.brandAnimation).toEqual(true)
+    expect(defaults.density).toEqual(-1)
+  })
+})

--- a/packages/design-tokens/src/defaults/generateDefaults.spec.ts
+++ b/packages/design-tokens/src/defaults/generateDefaults.spec.ts
@@ -25,25 +25,27 @@
  */
 
 import { generateDefaults } from './generateDefaults'
-import { themeDefaults } from './index'
+import { componentSettingsDefaults } from './index'
 
 describe('generateDefaults', () => {
   test('none', () => {
-    const defaults = generateDefaults(themeDefaults)
+    const defaults = generateDefaults(componentSettingsDefaults)
 
     expect(defaults.brandAnimation).toEqual(false)
     expect(defaults.density).toEqual(0)
   })
 
   test('empty', () => {
-    const defaults = generateDefaults(themeDefaults, {})
+    const defaults = generateDefaults(componentSettingsDefaults, {})
 
-    expect(defaults.brandAnimation).toEqual(themeDefaults.brandAnimation)
-    expect(defaults.density).toEqual(themeDefaults.density)
+    expect(defaults.brandAnimation).toEqual(
+      componentSettingsDefaults.brandAnimation
+    )
+    expect(defaults.density).toEqual(componentSettingsDefaults.density)
   })
 
   test('overwrite', () => {
-    const defaults = generateDefaults(themeDefaults, {
+    const defaults = generateDefaults(componentSettingsDefaults, {
       brandAnimation: true,
       density: -1,
     })

--- a/packages/design-tokens/src/defaults/generateDefaults.ts
+++ b/packages/design-tokens/src/defaults/generateDefaults.ts
@@ -24,44 +24,12 @@
 
  */
 
-import { generateColors } from '../../color'
-import type { Theme } from '../theme'
-import { defaultFontFallbacks } from '../../tokens'
-import { generateDefaults } from '../../defaults'
-import type { ThemeCustomizations } from '../ThemeCustomizations'
-import { generateFontFamilies } from '../../utils/typography'
+import type { ThemeDefaults } from './types'
 
-export const generateTheme = (
-  theme: Theme,
-  customizations?: ThemeCustomizations
-): Theme => {
-  if (!customizations) {
-    return theme
-  }
-
-  const { fontSources } = customizations
-
-  const fonts = customizations.fontFamilies
-    ? generateFontFamilies(
-        theme.fonts,
-        defaultFontFallbacks,
-        customizations.fontFamilies
-      )
-    : theme.fonts
-
-  const colors = customizations.colors
-    ? generateColors(theme.colors, customizations.colors)
-    : theme.colors
-
-  const defaults = customizations.defaults
-    ? generateDefaults(theme.defaults, customizations.defaults)
-    : theme.defaults
-
-  return {
-    ...theme,
-    colors,
-    defaults,
-    fontSources,
-    fonts,
-  }
-}
+export const generateDefaults = (
+  theme: ThemeDefaults,
+  custom?: Partial<ThemeDefaults>
+) => ({
+  ...theme,
+  ...custom,
+})

--- a/packages/design-tokens/src/defaults/generateDefaults.ts
+++ b/packages/design-tokens/src/defaults/generateDefaults.ts
@@ -24,11 +24,11 @@
 
  */
 
-import type { ThemeDefaults } from './types'
+import type { ComponentSettingsDefaults } from './types'
 
 export const generateDefaults = (
-  theme: ThemeDefaults,
-  custom?: Partial<ThemeDefaults>
+  theme: ComponentSettingsDefaults,
+  custom?: Partial<ComponentSettingsDefaults>
 ) => ({
   ...theme,
   ...custom,

--- a/packages/design-tokens/src/defaults/index.ts
+++ b/packages/design-tokens/src/defaults/index.ts
@@ -24,44 +24,11 @@
 
  */
 
-import { generateColors } from '../../color'
-import type { Theme } from '../theme'
-import { defaultFontFallbacks } from '../../tokens'
-import { generateDefaults } from '../../defaults'
-import type { ThemeCustomizations } from '../ThemeCustomizations'
-import { generateFontFamilies } from '../../utils/typography'
+import type { ThemeDefaults } from './types'
+export { generateDefaults } from './generateDefaults'
+export type { ThemeDefaults } from './types'
 
-export const generateTheme = (
-  theme: Theme,
-  customizations?: ThemeCustomizations
-): Theme => {
-  if (!customizations) {
-    return theme
-  }
-
-  const { fontSources } = customizations
-
-  const fonts = customizations.fontFamilies
-    ? generateFontFamilies(
-        theme.fonts,
-        defaultFontFallbacks,
-        customizations.fontFamilies
-      )
-    : theme.fonts
-
-  const colors = customizations.colors
-    ? generateColors(theme.colors, customizations.colors)
-    : theme.colors
-
-  const defaults = customizations.defaults
-    ? generateDefaults(theme.defaults, customizations.defaults)
-    : theme.defaults
-
-  return {
-    ...theme,
-    colors,
-    defaults,
-    fontSources,
-    fonts,
-  }
+export const themeDefaults: ThemeDefaults = {
+  brandAnimation: false,
+  density: 0,
 }

--- a/packages/design-tokens/src/defaults/index.ts
+++ b/packages/design-tokens/src/defaults/index.ts
@@ -24,11 +24,11 @@
 
  */
 
-import type { ThemeDefaults } from './types'
+import type { ComponentSettingsDefaults } from './types'
 export { generateDefaults } from './generateDefaults'
-export type { ThemeDefaults } from './types'
+export type { ComponentSettingsDefaults } from './types'
 
-export const themeDefaults: ThemeDefaults = {
+export const componentSettingsDefaults: ComponentSettingsDefaults = {
   brandAnimation: false,
   density: 0,
 }

--- a/packages/design-tokens/src/defaults/types.ts
+++ b/packages/design-tokens/src/defaults/types.ts
@@ -26,7 +26,7 @@
 
 import type { DensityRamp } from '../system/density'
 
-export type ThemeDefaults = {
+export type ComponentSettingsDefaults = {
   /**
    * Enable the Material "Ripple" animation on components that support it.
    * Current affects: IconButton, Checkbox, Radio & ToggleSwitch

--- a/packages/design-tokens/src/defaults/types.ts
+++ b/packages/design-tokens/src/defaults/types.ts
@@ -24,44 +24,22 @@
 
  */
 
-import { generateColors } from '../../color'
-import type { Theme } from '../theme'
-import { defaultFontFallbacks } from '../../tokens'
-import { generateDefaults } from '../../defaults'
-import type { ThemeCustomizations } from '../ThemeCustomizations'
-import { generateFontFamilies } from '../../utils/typography'
+import type { DensityRamp } from '../system/density'
 
-export const generateTheme = (
-  theme: Theme,
-  customizations?: ThemeCustomizations
-): Theme => {
-  if (!customizations) {
-    return theme
-  }
+export type ThemeDefaults = {
+  /**
+   * Enable the Material "Ripple" animation on components that support it.
+   * Current affects: IconButton, Checkbox, Radio & ToggleSwitch
+   * Future: Button*, Tab & ListItem
+   * @default false
+   */
+  brandAnimation: boolean
 
-  const { fontSources } = customizations
-
-  const fonts = customizations.fontFamilies
-    ? generateFontFamilies(
-        theme.fonts,
-        defaultFontFallbacks,
-        customizations.fontFamilies
-      )
-    : theme.fonts
-
-  const colors = customizations.colors
-    ? generateColors(theme.colors, customizations.colors)
-    : theme.colors
-
-  const defaults = customizations.defaults
-    ? generateDefaults(theme.defaults, customizations.defaults)
-    : theme.defaults
-
-  return {
-    ...theme,
-    colors,
-    defaults,
-    fontSources,
-    fonts,
-  }
+  /**
+   * Default density to use for density-supporting components
+   *
+   * NOTE: This not implementented broadly yet. Altering this value is not recommended
+   * at this time.
+   */
+  density: DensityRamp
 }

--- a/packages/design-tokens/src/theme/ThemeCustomizations.spec.ts
+++ b/packages/design-tokens/src/theme/ThemeCustomizations.spec.ts
@@ -24,27 +24,16 @@
 
  */
 
-import type { SpecifiableColors } from '../color'
-import type { FontFamilyChoices, FontSources } from '../system'
-import type { ThemeDefaults } from '../defaults'
+import type { ThemeCustomizations } from './ThemeCustomizations'
 
-export interface ThemeCustomizations {
-  /**
-   * Override default color specifications
-   */
-  colors?: Partial<SpecifiableColors>
-  /**
-   *
-   */
-  defaults?: Partial<ThemeDefaults>
-  /**
-   * Override default font-family specifications. Specified fonts will have our built-in
-   * font-stack appended. Built-in font stacks are designed to provide i18n character
-   * support and fallbacks for browsers that can't load web fonts.
-   */
-  fontFamilies?: Partial<FontFamilyChoices>
-  /**
-   * Specify font sources
-   */
-  fontSources?: FontSources
-}
+describe('ThemeCustomizations', () => {
+  test('Allows partial defaults', () => {
+    const customizations: ThemeCustomizations = {
+      defaults: {
+        brandAnimation: true,
+      },
+    }
+
+    expect(customizations.defaults?.brandAnimation).toBeTruthy()
+  })
+})

--- a/packages/design-tokens/src/theme/ThemeCustomizations.ts
+++ b/packages/design-tokens/src/theme/ThemeCustomizations.ts
@@ -26,12 +26,17 @@
 
 import type { SpecifiableColors } from '../color'
 import type { FontFamilyChoices, FontSources } from '../system'
+import type { ThemeDefaults } from '../defaults'
 
 export interface ThemeCustomizations {
   /**
    * Override default color specifications
    */
   colors?: Partial<SpecifiableColors>
+  /**
+   *
+   */
+  defaults?: ThemeDefaults
   /**
    * Override default font-family specifications. Specified fonts will have our built-in
    * font-stack appended. Built-in font stacks are designed to provide i18n character

--- a/packages/design-tokens/src/theme/ThemeCustomizations.ts
+++ b/packages/design-tokens/src/theme/ThemeCustomizations.ts
@@ -26,7 +26,7 @@
 
 import type { SpecifiableColors } from '../color'
 import type { FontFamilyChoices, FontSources } from '../system'
-import type { ThemeDefaults } from '../defaults'
+import type { ComponentSettingsDefaults } from '../defaults'
 
 export interface ThemeCustomizations {
   /**
@@ -36,7 +36,7 @@ export interface ThemeCustomizations {
   /**
    *
    */
-  defaults?: Partial<ThemeDefaults>
+  defaults?: Partial<ComponentSettingsDefaults>
   /**
    * Override default font-family specifications. Specified fonts will have our built-in
    * font-stack appended. Built-in font stacks are designed to provide i18n character

--- a/packages/design-tokens/src/theme/theme.ts
+++ b/packages/design-tokens/src/theme/theme.ts
@@ -44,8 +44,8 @@ import type {
   FontSources,
 } from '../system'
 
-import { themeDefaults } from '../defaults'
-import type { ThemeDefaults } from '../defaults'
+import { componentSettingsDefaults } from '../defaults'
+import type { ComponentSettingsDefaults } from '../defaults'
 
 /**
  * Theme attributes shouldn't be exported as they should be consumed via `theme` rather than via
@@ -67,7 +67,7 @@ import {
 export interface Theme {
   breakpoints: string[]
   colors: Colors
-  defaults: ThemeDefaults
+  defaults: ComponentSettingsDefaults
   easings: Easings
   elevations: Elevations
   fontSizes: FontSizeRamp
@@ -86,7 +86,7 @@ export interface Theme {
 export const theme: DefaultTheme = {
   breakpoints,
   colors,
-  defaults: themeDefaults,
+  defaults: componentSettingsDefaults,
   easings,
   elevations,
   fontSizes,

--- a/packages/design-tokens/src/theme/theme.ts
+++ b/packages/design-tokens/src/theme/theme.ts
@@ -42,8 +42,10 @@ import type {
   Shadows,
   TransitionRamp,
   FontSources,
-  DensityRamp,
 } from '../system'
+
+import { themeDefaults } from '../defaults'
+import type { ThemeDefaults } from '../defaults'
 
 /**
  * Theme attributes shouldn't be exported as they should be consumed via `theme` rather than via
@@ -65,6 +67,7 @@ import {
 export interface Theme {
   breakpoints: string[]
   colors: Colors
+  defaults: ThemeDefaults
   easings: Easings
   elevations: Elevations
   fontSizes: FontSizeRamp
@@ -78,16 +81,12 @@ export interface Theme {
   space: SpaceRamp
   transitions: TransitionRamp
   zIndexFloor: number
-  defaults: {
-    brandAnimation: boolean
-    density: DensityRamp
-  }
 }
 
 export const theme: DefaultTheme = {
   breakpoints,
   colors,
-  defaults: { brandAnimation: false, density: 0 },
+  defaults: themeDefaults,
   easings,
   elevations,
   fontSizes,


### PR DESCRIPTION
Introduce support for `themeDefaults` to be specified via `themeCustomizations` so that consumers have a consistent interface to use for overriding these settings going forward.