### PR TITLE
test: Improve CI job time

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,11 +26,18 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
 
       - name: Build documentation
         run: |
+          yarn install
           yarn website-canary
 
       - name: Deploy canary documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,54 +17,109 @@ jobs:
         with:
           all_but_latest: true
           access_token: ${{ github.token }}
+
+  install-cache:
+    runs-on: ubuntu-latest
+    needs: cancel
+    steps:
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+      - name: Install dependencies if cache invalid
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn
+
   lint:
     name: "Lint: ESLint + Prettier, Stylelint, Typescript"
     runs-on: ubuntu-latest
+    needs: install-cache
     steps:
-      - uses: actions/checkout@v2
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
       - run: yarn lint
   test:
     name: "Tests: Jest + RTL"
     runs-on: ubuntu-latest
+    needs: install-cache
     steps:
-      - uses: actions/checkout@v2
-      - uses: c-hive/gha-yarn-cache@v1
-      - run : yarn --silent
-      - run: yarn test
-      - uses: actions/upload-artifact@v2
-        if: always()
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
         with:
-          name: coverage
-          path: coverage
-          retention-days: 5
+          path: node_modules
+
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+      - run: yarn test --coverage=false
   build:
     name: "Build: ES & Typescript"
     runs-on: ubuntu-latest
+    needs: install-cache
     steps:
-      - uses: actions/checkout@v2
-      - uses: c-hive/gha-yarn-cache@v1
-      - run : yarn --silent
-      - run: yarn build
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+      - name: Build artifacts
+        run: yarn build
   gatsby:
     name: "Gatsby"
     runs-on: ubuntu-latest
+    needs: install-cache
     steps:
-      - uses: actions/checkout@v2
-      - uses: c-hive/gha-yarn-cache@v1
-      - run : yarn --silent
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
       - run: yarn workspace www build
   image-snapshots:
     name: "Image Snapshots"
     runs-on: ubuntu-latest
+    needs: install-cache
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - uses: c-hive/gha-yarn-cache@v1
-      - run : yarn --silent
-      - run: yarn test:image-snapshots
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+      - name: Run Image Snapshots
+        run: yarn test:image-snapshots
         id: snapshots
       # Upload snapshot diffs
       - uses: actions/upload-artifact@v2
@@ -73,18 +128,3 @@ jobs:
           name: snapshot-diffs
           path: snapshots/**/*-diff.png
           retention-days: 5
-      # If snapshots failed, build fresh ones and open a PR to help out our friends
-      - name: Fresh snapshots
-        if: ${{ always() && (steps.snapshots.outcome == 'failure') }}
-        run: yarn workspace storybook snapshots -u
-      - name: Create Pull Request
-        if: ${{ always() && (steps.snapshots-update.outcome == 'success') }}
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: "chore: image-snapshot updates"
-          branch: "${{ github.event.pull_request.head.ref }}-snapshot-updates"
-          delete-branch: true
-          title: "chore: snapshot-updates for \"${{ github.event.pull_request.title }}\""
-          body: Image snapshot updates for the PR \"${{ github.event.pull_request.title }}\""
-          labels: image-snapshots
-          reviewers: "${{ github.payload.pull_request.sender.login }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,13 +5,46 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  coverage:
+  install-cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: c-hive/gha-yarn-cache@v1
-      - uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+      - name: Install dependencies if cache invalid
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: install-cache
+    steps:
+      - name: Checkout Commit
+        uses: actions/checkout@v2
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+      - uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           package-manager: yarn
           threshold: 85
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: coverage
+          path: coverage
+          retention-days: 5

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -16,17 +16,24 @@ jobs:
   release-pull-request:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone repository
+      - name: Checkout Commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           ref: main
           fetch-depth: 0
 
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+
       - name: Fetch all tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install
 
       - name: Bump version
         run: yarn bumpversion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,28 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone repository
+      - name: Checkout Commit
         uses: actions/checkout@v2
         with:
           persist-credentials: false
           ref: main
           fetch-depth: 0
 
+      - name: Restore yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1
+
       - name: Fetch all tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - uses: c-hive/gha-yarn-cache@v1
-      - run: yarn install
-
       - name: Build web site
         run: |
+          yarn install
           yarn website-latest
 
       - name: Deploy canary documentation

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/jest-image-snapshot": "^4.3.1",
     "@types/lodash": "^4.14.172",
     "@types/node": "16.9.0",
+    "@types/puppeteer": "^5.4.4",
     "@types/react": "^17.0.9",
     "@types/react-dom": "^17.0.9",
     "@types/styled-components": "5.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,6 +4328,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/puppeteer@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.4.tgz#e92abeccc4f46207c3e1b38934a1246be080ccd0"
+  integrity sha512-3Nau+qi69CN55VwZb0ATtdUAlYlqOOQ3OfQfq0Hqgc4JMFXiQT/XInlwQ9g6LbicDslE6loIFsXFklGh5XmI6Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"


### PR DESCRIPTION
- Corrects caching for `node_nodules` in CI accelerating each job (30s - 1m savings)
- Moves Jest artifact upload to non-blocking `coverage` task (~2m savings)
- Removes Jest coverage check for core run - now run on separate coverage job (~4m savings)
- `image-snapshots` no longer re-runs on failure (~3m)

## Before

![image](https://user-images.githubusercontent.com/34253496/134620460-0cf1f6d4-412d-40aa-8444-34866dceb4ff.png)

## After

![image](https://user-images.githubusercontent.com/34253496/134625882-e65e42bd-30f3-40fe-84a6-a1749a1012b2.png)