### PR TITLE
fix(Popover): preventDefault on closing click

### DIFF
--- a/packages/components/src/Popover/Popover.spec.tsx
+++ b/packages/components/src/Popover/Popover.spec.tsx
@@ -72,6 +72,8 @@ describe('Popover', () => {
       'id',
       'a11y-heading'
     )
+
+    fireEvent.click(document)
   })
 
   test('cloneElement style opens and closes', () => {
@@ -114,24 +116,23 @@ describe('Popover', () => {
     expect(screen.queryByText('simple content')).not.toBeInTheDocument()
   })
 
-  test('cloneElement style opens and closes', () => {
+  test('preventDefault works on trigger 2nd click', () => {
+    // preventDefault here avoids JSDOM error
+    const mockFormSubmit = jest.fn((e) => e.preventDefault())
+
     renderWithTheme(
-      <Popover content={SimpleContent}>
-        <button>Test</button>
-      </Popover>
+      <form onSubmit={mockFormSubmit}>
+        <Popover content={SimpleContent}>
+          <button>Test</button>
+        </Popover>
+      </form>
     )
-
-    // Verify hidden
-    expect(screen.queryByText('simple content')).not.toBeInTheDocument()
-
     const trigger = screen.getByText('Test')
+    // Click to open
     fireEvent.click(trigger)
-
-    // Find content
-    expect(screen.getByText('simple content')).toBeInTheDocument()
-
+    // Then click to close
     fireEvent.click(trigger)
-    expect(screen.queryByText('simple content')).not.toBeInTheDocument()
+    expect(mockFormSubmit).not.toHaveBeenCalled()
   })
 
   test('stopPropagation works - event on container is not called', () => {

--- a/packages/components/src/Popover/usePopoverToggle.tsx
+++ b/packages/components/src/Popover/usePopoverToggle.tsx
@@ -133,6 +133,8 @@ export const usePopoverToggle = (
       if (clickedOnToggle) {
         // stopPropagation because instant Popover re-opening is silly
         event.stopPropagation()
+        // preventDefault for consistency because handleOpen does it
+        event.preventDefault()
         return
       }
 


### PR DESCRIPTION
`Popover` applies an `onClick` to its child that opens the popover and also calls `e.preventDefault` to avoid unintended actions, like a button submitting a form.

The "closing" click is  more complicated. Once open, a click listener is added to the document,  so that a click anywhere will close the popover. If that click happens to be on the trigger element, `event.stopPropagation` is called and then `return`, which avoids calling the original "opener" `onClick` and re-opening the popover, so `e.preventDefault` doesn't get called. This PR fixes that. 