### PR TITLE
refactor: Move ESLint configuration to a per-package key

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,37 +43,5 @@ module.exports = {
         ],
       },
     },
-    {
-      files: ['packages/demos/src/**/*.tsx', 'packages/demos/src/**/*.ts'],
-      rules: {
-        'i18next/no-literal-string': 'off',
-      },
-    },
-    {
-      files: [
-        '*.spec.*',
-        '*.stories.*',
-        '*.js',
-        '**/__mocks__/**',
-        '**/stories/**',
-        'packages/components-theme-editor/**',
-        'packages/design-tokens/**',
-        'www/**',
-      ],
-      rules: {
-        'i18next/no-literal-string': 'off',
-      },
-    },
   ],
-  rules: {
-    '@typescript-eslint/no-explicit-any': 'off',
-    'no-restricted-properties': [
-      2,
-      {
-        message:
-          'Specifying static properties such as defaultProps can break tree shaking. Use default parameter values instead. See http://es6-features.org/#DefaultParameterValues.',
-        property: 'defaultProps',
-      },
-    ],
-  },
 }

--- a/apps/storybook/src/stories.shots.ts
+++ b/apps/storybook/src/stories.shots.ts
@@ -59,6 +59,7 @@ const imageSnapshots = () => {
           await page.waitForTimeout(500)
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ;(context as any).clip = await page.evaluate(() => {
           const backdrop = document.querySelector(
             '#modal-root [data-testid="backdrop"]'
@@ -86,6 +87,7 @@ const imageSnapshots = () => {
         }
       },
       getScreenshotOptions: ({ context }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { clip } = context as any
 
         return { clip, encoding: 'base64', fullPage: false }

--- a/packages/components-date/.prettierrc.json
+++ b/packages/components-date/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/components-date/package.json
+++ b/packages/components-date/package.json
@@ -40,9 +40,17 @@
     "extends": [
      "@looker/eslint-config-oss"
     ],
-    "rules": {
-     "@typescript-eslint/no-explicit-any": "off"
-    }
+    "overrides": [
+      {
+        "files": [
+          "*.spec.*",
+          "*.stories.*"
+        ],
+        "rules": {
+          "@typescript-eslint/no-explicit-any": "off"
+        }
+      }
+    ]
    },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components-date/package.json
+++ b/packages/components-date/package.json
@@ -35,5 +35,14 @@
     "react-is": "^16.11",
     "styled-components": "^5"
   },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ],
+    "rules": {
+     "@typescript-eslint/no-explicit-any": "off"
+    }
+   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components-providers/.prettierrc.json
+++ b/packages/components-providers/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/components-providers/package.json
+++ b/packages/components-providers/package.json
@@ -27,5 +27,11 @@
     "react-is": "^16.11",
     "styled-components": "^5"
   },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ]
+   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components-providers/src/FontFaceLoader/FontFaceLoader.spec.tsx
+++ b/packages/components-providers/src/FontFaceLoader/FontFaceLoader.spec.tsx
@@ -70,6 +70,7 @@ describe('FontFaceLoader', () => {
   })
 
   it('Does nothing if fontSource undefined', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const context = {} as any
 
     render(
@@ -83,6 +84,7 @@ describe('FontFaceLoader', () => {
   })
 
   it('Does nothing if fontSource empty', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const context = {} as any
 
     render(
@@ -97,6 +99,7 @@ describe('FontFaceLoader', () => {
   })
 
   it('theme.fontSources has entries', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const context = {} as any
 
     render(

--- a/packages/components-test-utils/.prettierrc.json
+++ b/packages/components-test-utils/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/components-test-utils/package.json
+++ b/packages/components-test-utils/package.json
@@ -19,5 +19,11 @@
     "react": "^16.11",
     "react-is": "^16.11"
   },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ]
+  },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components-test-utils/src/create_with_theme.tsx
+++ b/packages/components-test-utils/src/create_with_theme.tsx
@@ -31,11 +31,13 @@ import 'jest-styled-components'
 import type { ReactElement } from 'react'
 import React from 'react'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const withThemeProvider = (Component: ReactElement<any>) => (
   <ComponentsProvider disableStyleDefender>{Component}</ComponentsProvider>
 )
 
 export const renderWithTheme = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Component: ReactElement<any>,
   options?: Omit<RenderOptions, 'queries'>
 ) => render(withThemeProvider(Component), options)

--- a/packages/components-theme-editor/.prettierrc.json
+++ b/packages/components-theme-editor/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/components-theme-editor/package.json
+++ b/packages/components-theme-editor/package.json
@@ -25,5 +25,14 @@
     "react": "^16.11",
     "react-is": "^16.11",
     "styled-components": "^5"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ],
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
   }
 }

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -25,8 +25,30 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const ignoreProps = require('./packages/eslint-config-oss/src/i18nIgnoredProps.js')
+const ignoreProps = require('../eslint-config-oss/src/i18nIgnoredProps.js')
 
 module.exports = {
   extends: ['@looker/eslint-config-oss'],
+  overrides: [
+    {
+      files: ['*.tsx', '*.ts'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+        'i18next/no-literal-string': [
+          2,
+          {
+            ignoreAttribute: ignoreProps,
+            ignoreComponent: ['HyphenWrapper', 'Icon', 'WarningIcon'],
+            markupOnly: true,
+          },
+        ],
+      },
+    },
+    {
+      files: ['*.spec.*', '*.stories.*', '**/__mocks__/**', '**/stories/**'],
+      rules: {
+        'i18next/no-literal-string': 'off',
+      },
+    },
+  ],
 }

--- a/packages/components/.prettierrc.json
+++ b/packages/components/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -46,5 +46,14 @@
     "react-is": "^16.11",
     "styled-components": "^5"
   },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ],
+    "rules": {
+     "@typescript-eslint/no-explicit-any": "off"
+    }
+   },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -46,14 +46,6 @@
     "react-is": "^16.11",
     "styled-components": "^5"
   },
-  "eslintConfig": {
-    "root": true,
-    "extends": [
-      "@looker/eslint-config-oss"
-    ],
-    "rules": {
-      "@typescript-eslint/no-explicit-any": "off"
-    }
-   },
+
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,10 +49,10 @@
   "eslintConfig": {
     "root": true,
     "extends": [
-     "@looker/eslint-config-oss"
+      "@looker/eslint-config-oss"
     ],
     "rules": {
-     "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off"
     }
    },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"

--- a/packages/demos/.prettierrc.json
+++ b/packages/demos/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -15,5 +15,14 @@
     "react-copy-to-clipboard": "^5.0.3",
     "react-is": "^16.13.1",
     "styled-components": "^5.3.0"
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ],
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
   }
 }

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -29,5 +29,14 @@
     "react-is": "^16.11",
     "styled-components": "^5"
   },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ],
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+  },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/eslint-config-oss/src/index.js
+++ b/packages/eslint-config-oss/src/index.js
@@ -50,6 +50,18 @@ module.exports = {
         'react/jsx-no-undef': 'off',
       },
     },
+    {
+      files: [
+        '*.spec.*',
+        '*.stories.*',
+        '**/stories/**',
+        '*.js',
+        '**/__mocks__/**',
+      ],
+      rules: {
+        'i18next/no-literal-string': 'off',
+      },
+    },
   ],
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   plugins: [
@@ -66,8 +78,8 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-redeclare': ['error'],
-    '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
     'header/header': [
       2,
       'block',
@@ -129,14 +141,24 @@ module.exports = {
         ],
       },
     ],
+    'no-restricted-properties': [
+      2,
+      {
+        message:
+          'Specifying static properties such as defaultProps can break tree shaking. Use default parameter values instead. See http://es6-features.org/#DefaultParameterValues.',
+        property: 'defaultProps',
+      },
+    ],
     'no-use-before-define': 'off',
     'react/no-unescaped-entities': 'off',
     'react/prop-types': 'off',
     'sort-keys': 'off',
     'sort-keys-fix/sort-keys-fix': 'error',
-    '@typescript-eslint/no-unused-vars': 'off',
+
     // Work to enable these soon-ish
     'testing-library/no-node-access': 'off',
+    // eslint-disable-next-line sort-keys-fix/sort-keys-fix
+    '@typescript-eslint/no-explicit-any': 'off',
   },
 
   settings: {

--- a/packages/eslint-config-oss/src/index.js
+++ b/packages/eslint-config-oss/src/index.js
@@ -157,8 +157,6 @@ module.exports = {
 
     // Work to enable these soon-ish
     'testing-library/no-node-access': 'off',
-    // eslint-disable-next-line sort-keys-fix/sort-keys-fix
-    '@typescript-eslint/no-explicit-any': 'off',
   },
 
   settings: {

--- a/packages/icons/.prettierrc.json
+++ b/packages/icons/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -31,5 +31,11 @@
     "react-is": "^16.11",
     "styled-components": "^5"
   },
+  "eslintConfig": {
+    "root": true,
+    "extends": [
+     "@looker/eslint-config-oss"
+    ]
+  },
   "gitHead": "62febc162e3e45124f403e2c84fc741f68fe6714"
 }

--- a/packages/stylelint-config/.prettierrc.json
+++ b/packages/stylelint-config/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "semi": false,
+  "singleQuote": true
+}

--- a/www/package.json
+++ b/www/package.json
@@ -48,6 +48,9 @@
   "eslintConfig": {
     "extends": [
       "@looker/eslint-config-oss"
-    ]
+    ],
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
   }
 }


### PR DESCRIPTION
To support parity with core-product monorepo move to using `eslintConfig` key in each `package.json` and move package-specific to those blocks as well.

Move 1 set of rules to core `eslint-config-oss` since it's broadly applied.