### PR TITLE
fix(Dialog): Animation delay on open

### DIFF
--- a/packages/components/src/Dialog/Backdrop.tsx
+++ b/packages/components/src/Dialog/Backdrop.tsx
@@ -30,8 +30,8 @@ import type {
   OpacityProps,
 } from '@looker/design-tokens'
 import { color, reset, shouldForwardProp } from '@looker/design-tokens'
-import type { CSSObject } from 'styled-components'
-import styled from 'styled-components'
+import type { CSSObject, Keyframes } from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 export interface BackdropProps
   extends CompatibleHTMLProps<HTMLDivElement>,
@@ -40,6 +40,25 @@ export interface BackdropProps
   visible?: boolean
   inlineStyle?: CSSObject
 }
+// We have to use animation/keyframes here instead of transition
+// transition starts after the class changes from entering to entered
+// but animation/keyframes starts as soon as the element is rendered
+const fadeIn: Keyframes = keyframes`
+from {
+  opacity: 0.01;
+}
+to {
+  opacity: 0.6;
+}
+`
+const fadeOut: Keyframes = keyframes`
+from {
+  opacity: 0.6;
+}
+to {
+  opacity: 0.01;
+}
+`
 
 // Backdrop styles are applied here (rather than using the inline `style={...}` prop) to ensure that
 // transitions will still apply to backdrop
@@ -51,6 +70,8 @@ export const Backdrop = styled.div
   ${reset}
   ${color}
 
+  animation-duration: ${({ theme }) => theme.transitions.simple}ms;
+  animation-fill-mode: forwards;
   background: ${({ theme }) => theme.colors.ui5};
   bottom: 0;
   cursor: default;
@@ -59,10 +80,11 @@ export const Backdrop = styled.div
   position: fixed;
   right: 0;
   top: 0;
-  transition: opacity ${({ theme }) => theme.transitions.simple}ms;
 
-  &.entering,
+  &.entering {
+    animation-name: ${fadeIn};
+  }
   &.exiting {
-    opacity: 0.01;
+    animation-name: ${fadeOut};
   }
 `

--- a/packages/components/src/Dialog/Backdrop.tsx
+++ b/packages/components/src/Dialog/Backdrop.tsx
@@ -40,9 +40,7 @@ export interface BackdropProps
   visible?: boolean
   inlineStyle?: CSSObject
 }
-// We have to use animation/keyframes here instead of transition
-// transition starts after the class changes from entering to entered
-// but animation/keyframes starts as soon as the element is rendered
+
 const fadeIn: Keyframes = keyframes`
 from {
   opacity: 0.01;

--- a/packages/components/src/Dialog/DialogSurface.tsx
+++ b/packages/components/src/Dialog/DialogSurface.tsx
@@ -117,9 +117,6 @@ const placements = {
 
 const defaultDialogSurfacePlacement = 'center'
 
-// We have to use animation/keyframes here instead of transition
-// transition starts after the class changes from entering to entered
-// but animation/keyframes starts as soon as the element is rendered
 const dialogIn: Keyframes = keyframes`
 from {
   opacity: 0.01;

--- a/packages/components/src/Dialog/DialogSurface.tsx
+++ b/packages/components/src/Dialog/DialogSurface.tsx
@@ -24,7 +24,8 @@
 
  */
 
-import styled, { css } from 'styled-components'
+import type { Keyframes } from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 import type { ResponsiveValue } from '@looker/design-tokens'
 import { height, theme } from '@looker/design-tokens'
 import { SurfaceBase, surfaceTransition } from '../Dialog/SurfaceBase'
@@ -116,6 +117,30 @@ const placements = {
 
 const defaultDialogSurfacePlacement = 'center'
 
+// We have to use animation/keyframes here instead of transition
+// transition starts after the class changes from entering to entered
+// but animation/keyframes starts as soon as the element is rendered
+const dialogIn: Keyframes = keyframes`
+from {
+  opacity: 0.01;
+  transform: translateY(100%);
+}
+to {
+  opacity: 1;
+  transform: translate(0);
+}
+`
+const dialogOut: Keyframes = keyframes`
+from {
+  opacity: 1;
+  transform: translate(0);
+}
+to {
+  opacity: 0.01;
+  transform: translateY(100%);
+}
+`
+
 export const DialogSurface = styled(SurfaceBase).attrs<DialogSurfaceProps>(
   ({ placement = defaultDialogSurfacePlacement, width = 'medium' }) => ({
     placement,
@@ -124,7 +149,6 @@ export const DialogSurface = styled(SurfaceBase).attrs<DialogSurfaceProps>(
 )<DialogSurfaceProps>`
   box-shadow: ${({ theme }) => theme.elevations.plus3};
   position: relative;
-  transition: transform ${surfaceTransition}, opacity ${surfaceTransition};
 
   ${dialogWidth}
   ${({ placement }) => placements[placement || defaultDialogSurfacePlacement]}
@@ -134,9 +158,10 @@ export const DialogSurface = styled(SurfaceBase).attrs<DialogSurfaceProps>(
     border-radius: ${({ theme }) => theme.radii.medium};
   }
 
-  &.entering,
+  &.entering {
+    animation: ${dialogIn} ${surfaceTransition};
+  }
   &.exiting {
-    opacity: 0.01;
-    transform: translateY(100%);
+    animation: ${dialogOut} ${surfaceTransition};
   }
 `

--- a/packages/components/src/Drawer/DrawerSurface.tsx
+++ b/packages/components/src/Drawer/DrawerSurface.tsx
@@ -24,7 +24,8 @@
 
  */
 
-import styled from 'styled-components'
+import type { Keyframes } from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import type { ResponsiveValue } from '@looker/design-tokens'
 import { variant, system } from '@looker/design-tokens'
 import { SurfaceBase, surfaceTransition } from '../Dialog/SurfaceBase'
@@ -83,25 +84,47 @@ const drawerWidth = () => {
   })
 }
 
+const slideIn: Keyframes = keyframes`
+from {
+  opacity: 0.01;
+  transform: translate(var(--direction-translate, 0), 0);
+}
+to {
+  opacity: 1;
+  transform: translate(0);
+}
+`
+const slideOut: Keyframes = keyframes`
+  from {
+    opacity: 1;
+    transform: translate(0);
+  }
+  to {
+    opacity: 0.01;
+    transform: translate(var(--direction-translate, 0), 0);
+  }
+`
+
 export const DrawerSurface = styled(SurfaceBase).attrs<DrawerSurfaceProps>(
   ({ placement = 'right', width = 'small' }) => ({
     placement,
     width,
   })
 )<DrawerSurfaceProps>`
+  --direction-translate: ${({ placement }) =>
+    placement === 'left' ? '-100%' : '100%'};
+
   /* Shadow designed to match theme.elevations.plus3 but with a single left-side shadow */
   height: 100%;
   position: absolute;
-  transition: transform ${surfaceTransition}, opacity ${surfaceTransition};
 
   ${placement}
   ${drawerWidth}
 
-  &.entering,
+  &.entering {
+    animation: ${slideIn} ${surfaceTransition};
+  }
   &.exiting {
-    opacity: 0.01;
-    transform: translateX(
-      ${({ placement }) => (placement === 'left' ? '-100%' : '100%')}
-    );
+    animation: ${slideOut} ${surfaceTransition};
   }
 `


### PR DESCRIPTION
Previously, `DialogSurface`, `DrawerSurface`, and `Backlog` were using CSS transition to animate in and out. The problem with this is that the transition _starts_ when the className changes from `'entering'` to `'entered'` which is 300ms after the click to open. The dialog renders immediately on click, then sits hidden for 300ms before animating in.

We want the animation to begin immediately on render, so we have to use CSS animation instead. `PanelSurface` was already doing this.

- [x] 👾 Browsers tested
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] IE11
