### PR TITLE
chore: Downgrade to prettier 2.2

### DIFF
--- a/apps/storybook/src/stories.shots.ts
+++ b/apps/storybook/src/stories.shots.ts
@@ -65,12 +65,9 @@ const imageSnapshots = () => {
             '#modal-root [data-testid="backdrop"]'
           )
 
-          const {
-            height,
-            width,
-            left: x,
-            top: y,
-          } = (backdrop || document.body).getBoundingClientRect()
+          const { height, width, left: x, top: y } = (
+            backdrop || document.body
+          ).getBoundingClientRect()
 
           return { height, width, x, y }
         })

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "node-fetch": "2.6.1",
     "npm-run-all": "^4.1.5",
     "pre-commit": "1.2.2",
-    "prettier": "2.3.1",
+    "prettier": "2.2.1",
     "puppeteer": "5.5.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/packages/components-date/src/FieldDateRange/FieldDateRange.stories.tsx
+++ b/packages/components-date/src/FieldDateRange/FieldDateRange.stories.tsx
@@ -45,14 +45,15 @@ export default {
   title: 'Date / FieldDateRange',
 }
 
-const Template: Story<FieldInputDateRangeProps & { externalLabel: boolean }> =
-  ({ externalLabel = true, ...args }) => (
-    <ExtendComponentsThemeProvider
-      themeCustomizations={{ defaults: { externalLabel } }}
-    >
-      <FieldDateRange {...args} />
-    </ExtendComponentsThemeProvider>
-  )
+const Template: Story<
+  FieldInputDateRangeProps & { externalLabel: boolean }
+> = ({ externalLabel = true, ...args }) => (
+  <ExtendComponentsThemeProvider
+    themeCustomizations={{ defaults: { externalLabel } }}
+  >
+    <FieldDateRange {...args} />
+  </ExtendComponentsThemeProvider>
+)
 
 export const Basic = Template.bind({})
 Basic.args = {

--- a/packages/components-date/src/InputDateRange/InputDateRange.stories.tsx
+++ b/packages/components-date/src/InputDateRange/InputDateRange.stories.tsx
@@ -102,8 +102,9 @@ export const TimeframeFilter = () => {
   const endDate = new Date()
   endDate.setDate(15)
 
-  const [controlledDateRange, setControlledDateRange] =
-    useState<Partial<RangeModifier>>()
+  const [controlledDateRange, setControlledDateRange] = useState<
+    Partial<RangeModifier>
+  >()
 
   return (
     <Popover

--- a/packages/components-date/src/InputTime/InputTime.spec.tsx
+++ b/packages/components-date/src/InputTime/InputTime.spec.tsx
@@ -33,10 +33,10 @@ import { InputTime } from './InputTime'
 const globalConsole = global.console
 
 beforeEach(() => {
-  global.console = {
+  global.console = ({
     error: jest.fn(),
     warn: jest.fn(),
-  } as unknown as Console
+  } as unknown) as Console
 })
 
 afterEach(() => {

--- a/packages/components-date/src/InputTimeSelect/InputTimeSelect.tsx
+++ b/packages/components-date/src/InputTimeSelect/InputTimeSelect.tsx
@@ -290,8 +290,10 @@ const InputTimeSelectLayout = forwardRef(
 
     const timeOptions = generateTimes(format, interval)
 
-    const [selectedOption, setSelectedOption] =
-      useState<MaybeComboboxOptionObject>()
+    const [
+      selectedOption,
+      setSelectedOption,
+    ] = useState<MaybeComboboxOptionObject>()
 
     const [inputTextValue, setInputTextValue] = useState('')
 

--- a/packages/components-providers/src/FontFaceLoader/FontFaceLoader.spec.tsx
+++ b/packages/components-providers/src/FontFaceLoader/FontFaceLoader.spec.tsx
@@ -75,7 +75,7 @@ describe('FontFaceLoader', () => {
 
     render(
       <HelmetProvider context={context}>
-        <ThemeProvider theme={{} as unknown as DefaultTheme}>
+        <ThemeProvider theme={({} as unknown) as DefaultTheme}>
           <FontFaceLoader />
         </ThemeProvider>
       </HelmetProvider>
@@ -89,7 +89,9 @@ describe('FontFaceLoader', () => {
 
     render(
       <HelmetProvider context={context}>
-        <ThemeProvider theme={{ themeSources: [] } as unknown as DefaultTheme}>
+        <ThemeProvider
+          theme={({ themeSources: [] } as unknown) as DefaultTheme}
+        >
           <FontFaceLoader />
         </ThemeProvider>
       </HelmetProvider>
@@ -106,9 +108,9 @@ describe('FontFaceLoader', () => {
       <HelmetProvider context={context}>
         <ThemeProvider
           theme={
-            {
+            ({
               fontSources,
-            } as unknown as DefaultTheme
+            } as unknown) as DefaultTheme
           }
         >
           <FontFaceLoader />

--- a/packages/components-theme-editor/src/ThemeEditorContent.tsx
+++ b/packages/components-theme-editor/src/ThemeEditorContent.tsx
@@ -56,11 +56,13 @@ export const ThemeEditorContent: FC<ThemeEditorContentProps> = ({
   const { closeModal } = useContext(DialogContext)
   const { colors, fonts } = useContext(ThemeContext)
 
-  const [themeCustomizations, setThemeCustomizations] =
-    useState<ThemeCustomizations>({
-      colors: pickSpecifiableColors(colors),
-      fontFamilies: { ...fonts },
-    })
+  const [
+    themeCustomizations,
+    setThemeCustomizations,
+  ] = useState<ThemeCustomizations>({
+    colors: pickSpecifiableColors(colors),
+    fontFamilies: { ...fonts },
+  })
 
   const saveChanges = () => {
     closeModal()

--- a/packages/components/src/Button/ButtonItem.tsx
+++ b/packages/components/src/Button/ButtonItem.tsx
@@ -44,11 +44,9 @@ const ButtonLayout = forwardRef(
     { children, onClick, value, onBlur, onKeyUp, ...props }: ButtonItemProps,
     ref: Ref<HTMLButtonElement>
   ) => {
-    const {
-      disabled,
-      value: contextValue,
-      onItemClick,
-    } = useContext(ButtonSetContext)
+    const { disabled, value: contextValue, onItemClick } = useContext(
+      ButtonSetContext
+    )
 
     const { focusVisible, ...focusVisibleProps } = useFocusVisible({
       onBlur,

--- a/packages/components/src/Button/ButtonSet.tsx
+++ b/packages/components/src/Button/ButtonSet.tsx
@@ -71,10 +71,11 @@ export interface ButtonGroupOrToggleBaseProps<
   onChange?: ButtonSetCallback<TValue>
 }
 
-export type ButtonSetType<TValue extends string | string[] = string[]> =
-  ForwardRefExoticComponent<
-    ButtonSetProps<TValue> & { ref: Ref<HTMLDivElement> }
-  >
+export type ButtonSetType<
+  TValue extends string | string[] = string[]
+> = ForwardRefExoticComponent<
+  ButtonSetProps<TValue> & { ref: Ref<HTMLDivElement> }
+>
 
 export const ButtonSetLayout = forwardRef(
   (

--- a/packages/components/src/DataTable/utils/dataTableFormatting.spec.ts
+++ b/packages/components/src/DataTable/utils/dataTableFormatting.spec.ts
@@ -48,7 +48,8 @@ describe('DataTable CSS Utils', () => {
 
   test('getNumericColumnIndices', () => {
     expect(getNumericColumnIndices(columns, ['id', 'name', 'age'])).toEqual([
-      1, 3,
+      1,
+      3,
     ])
   })
 })

--- a/packages/components/src/Dialog/Dialog.spec.tsx
+++ b/packages/components/src/Dialog/Dialog.spec.tsx
@@ -313,9 +313,9 @@ describe('Dialog', () => {
       const globalConsole = global.console
       const errorMock = jest.fn()
 
-      global.console = {
+      global.console = ({
         error: errorMock,
-      } as unknown as Console
+      } as unknown) as Console
 
       renderWithTheme(<Dialog />)
       expect(errorMock.mock.calls).toMatchInlineSnapshot(`

--- a/packages/components/src/Form/Fields/FieldChips/FieldChips.stories.tsx
+++ b/packages/components/src/Form/Fields/FieldChips/FieldChips.stories.tsx
@@ -160,8 +160,7 @@ Controlled.parameters = {
   storyshots: { disable: true },
 }
 
-const emailValidator =
-  /^(([^<>()[\]\\.,:\s@"]+(\.[^<>()[\]\\.,:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+const emailValidator = /^(([^<>()[\]\\.,:\s@"]+(\.[^<>()[\]\\.,:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 
 export const ValidationDuplicate = () => {
   const [values, setValues] = useState<string[]>(['bob@internet.com'])

--- a/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.stories.tsx
+++ b/packages/components/src/Form/Fields/FieldSelectMulti/FieldSelectMulti.stories.tsx
@@ -106,8 +106,7 @@ Error.args = {
   validationMessage: { message: 'validation Message', type: 'error' },
 }
 
-const emailValidator =
-  /^(([^<>()[\]\\.,:\s@"]+(\.[^<>()[\]\\.,:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+const emailValidator = /^(([^<>()[\]\\.,:\s@"]+(\.[^<>()[\]\\.,:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 const emails = [
   { label: 'Good Looker', value: 'good.looker@google.com' },
   { label: 'Components Team', value: 'lookercomponents@google.com' },

--- a/packages/components/src/Form/Fieldset/Fieldset.spec.tsx
+++ b/packages/components/src/Form/Fieldset/Fieldset.spec.tsx
@@ -44,9 +44,9 @@ const warnMock = jest.fn()
 
 beforeEach(() => {
   jest.useFakeTimers()
-  global.console = {
+  global.console = ({
     warn: warnMock,
-  } as unknown as Console
+  } as unknown) as Console
 })
 
 afterEach(() => {

--- a/packages/components/src/Form/Inputs/Checkbox/Checkbox.spec.tsx
+++ b/packages/components/src/Form/Inputs/Checkbox/Checkbox.spec.tsx
@@ -32,8 +32,14 @@ import { RIPPLE_RATIO } from '../../../Ripple'
 import type { CheckboxProps } from './Checkbox'
 import * as stories from './Checkbox.stories'
 
-const { Basic, Checked, Disabled, DisabledChecked, MixedChecked, ReadOnly } =
-  composeStories(stories)
+const {
+  Basic,
+  Checked,
+  Disabled,
+  DisabledChecked,
+  MixedChecked,
+  ReadOnly,
+} = composeStories(stories)
 
 beforeEach(() => {
   jest.useFakeTimers()

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.spec.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.spec.tsx
@@ -194,48 +194,48 @@ describe('<Combobox/> with children', () => {
   })
 
   /* eslint-disable react/display-name */
-  const GetIndicatorJSX =
-    (listLevel: boolean) => (indicator: ComboboxOptionIndicatorFunction) =>
-      (
-        <Combobox key="combobox" value={{ label: 'Foo', value: '101' }}>
-          <ComboboxInput placeholder="Type here" />
-          <ComboboxList indicator={listLevel ? indicator : undefined}>
-            <ComboboxOption
-              label="Foo"
-              value="101"
-              indicator={listLevel ? undefined : indicator}
-            />
-            <ComboboxOption
-              label="Bar"
-              value="102"
-              indicator={listLevel ? undefined : indicator}
-            />
-          </ComboboxList>
-        </Combobox>
-      )
+  const GetIndicatorJSX = (listLevel: boolean) => (
+    indicator: ComboboxOptionIndicatorFunction
+  ) => (
+    <Combobox key="combobox" value={{ label: 'Foo', value: '101' }}>
+      <ComboboxInput placeholder="Type here" />
+      <ComboboxList indicator={listLevel ? indicator : undefined}>
+        <ComboboxOption
+          label="Foo"
+          value="101"
+          indicator={listLevel ? undefined : indicator}
+        />
+        <ComboboxOption
+          label="Bar"
+          value="102"
+          indicator={listLevel ? undefined : indicator}
+        />
+      </ComboboxList>
+    </Combobox>
+  )
 
-  const GetIndicatorJSXMulti =
-    (listLevel: boolean) => (indicator: ComboboxOptionIndicatorFunction) =>
-      (
-        <ComboboxMulti
-          key="combobox-multi"
-          values={[{ label: 'Foo', value: '101' }]}
-        >
-          <ComboboxMultiInput placeholder="Type here" />
-          <ComboboxMultiList indicator={listLevel ? indicator : undefined}>
-            <ComboboxMultiOption
-              label="Foo"
-              value="101"
-              indicator={listLevel ? undefined : indicator}
-            />
-            <ComboboxMultiOption
-              label="Bar"
-              value="102"
-              indicator={listLevel ? undefined : indicator}
-            />
-          </ComboboxMultiList>
-        </ComboboxMulti>
-      )
+  const GetIndicatorJSXMulti = (listLevel: boolean) => (
+    indicator: ComboboxOptionIndicatorFunction
+  ) => (
+    <ComboboxMulti
+      key="combobox-multi"
+      values={[{ label: 'Foo', value: '101' }]}
+    >
+      <ComboboxMultiInput placeholder="Type here" />
+      <ComboboxMultiList indicator={listLevel ? indicator : undefined}>
+        <ComboboxMultiOption
+          label="Foo"
+          value="101"
+          indicator={listLevel ? undefined : indicator}
+        />
+        <ComboboxMultiOption
+          label="Bar"
+          value="102"
+          indicator={listLevel ? undefined : indicator}
+        />
+      </ComboboxMultiList>
+    </ComboboxMulti>
+  )
   /* eslint-enable react/display-name */
 
   test.each([

--- a/packages/components/src/Form/Inputs/Combobox/Combobox.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/Combobox.tsx
@@ -196,6 +196,6 @@ export const ComboboxWrapper = forwardRef(
 
 ComboboxWrapper.displayName = 'ComboboxWrapper'
 
-export const Combobox = styled(ComboboxInternal).attrs(
-  ({ display = 'flex' }) => ({ display })
-)``
+export const Combobox = styled(
+  ComboboxInternal
+).attrs(({ display = 'flex' }) => ({ display }))``

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiInput.tsx
@@ -278,9 +278,9 @@ export const ComboboxMultiInputInternal = forwardRef(
 
 ComboboxMultiInputInternal.displayName = 'ComboboxMultiInputInternal'
 
-export const ComboboxMultiInput = styled(ComboboxMultiInputInternal).attrs(
-  ({ width = '100%' }) => ({ width })
-)`
+export const ComboboxMultiInput = styled(
+  ComboboxMultiInputInternal
+).attrs(({ width = '100%' }) => ({ width }))`
   ${comboboxStyles}
   padding-right: 0;
 `

--- a/packages/components/src/Form/Inputs/Combobox/ComboboxMultiOption.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/ComboboxMultiOption.tsx
@@ -72,8 +72,13 @@ export const ComboboxMultiOption = styled(
         props,
         ComboboxMultiContext
       )
-      const { isActive, isSelected } =
-        useOptionStatus<ComboboxMultiContextProps>(ComboboxMultiContext, value)
+      const {
+        isActive,
+        isSelected,
+      } = useOptionStatus<ComboboxMultiContextProps>(
+        ComboboxMultiContext,
+        value
+      )
 
       const scrollRef = useOptionScroll(
         ComboboxMultiContext,

--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputEvents.ts
@@ -160,8 +160,10 @@ export function useInputEvents<
     [inputElement, selectText]
   )
 
-  const { onMouseDown: handleMouseDown, onClick: handleClick } =
-    useMouseDownClick(handleMouseDownClick, handleMouseUp)
+  const {
+    onMouseDown: handleMouseDown,
+    onClick: handleClick,
+  } = useMouseDownClick(handleMouseDownClick, handleMouseUp)
 
   const wrappedOnBlur = useWrapEvent(handleBlur, onBlur)
   const wrappedOnClick = useWrapEvent(handleClick, onClick)

--- a/packages/components/src/Form/Inputs/Combobox/utils/useInputPropRefs.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useInputPropRefs.ts
@@ -42,8 +42,11 @@ export function useInputPropRefs<
   { autoComplete = true, freeInput = false, inputReadOnly = false }: TProps,
   context: Context<TContext>
 ) {
-  const { autoCompletePropRef, freeInputPropRef, inputReadOnlyPropRef } =
-    useContext(context)
+  const {
+    autoCompletePropRef,
+    freeInputPropRef,
+    inputReadOnlyPropRef,
+  } = useContext(context)
 
   useLayoutEffect(() => {
     if (autoCompletePropRef) autoCompletePropRef.current = autoComplete

--- a/packages/components/src/Form/Inputs/Combobox/utils/useListWidths.spec.tsx
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useListWidths.spec.tsx
@@ -31,9 +31,9 @@ import { useListWidths } from './useListWidths'
 
 const getBoundingClientRectMock = jest.fn()
 
-const mockWrapper = {
+const mockWrapper = ({
   getBoundingClientRect: getBoundingClientRectMock,
-} as unknown as HTMLElement
+} as unknown) as HTMLElement
 
 function TestComponent(props: UseListWidthProps) {
   const { minWidth, width } = useListWidths({

--- a/packages/components/src/Form/Inputs/Combobox/utils/useOptionEvents.ts
+++ b/packages/components/src/Form/Inputs/Combobox/utils/useOptionEvents.ts
@@ -44,8 +44,13 @@ export function useOptionEvents<
   CProps extends ComboboxContextProps | ComboboxMultiContextProps
 >(props: ComboboxOptionProps, context: Context<CProps>) {
   const { label, value, onClick, onMouseEnter } = props
-  const { data, onChange, transition, closeOnSelectPropRef, isScrollingRef } =
-    useContext(context)
+  const {
+    data,
+    onChange,
+    transition,
+    closeOnSelectPropRef,
+    isScrollingRef,
+  } = useContext(context)
   const { options } = data as ComboboxMultiData
 
   function handleClick() {

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.tsx
@@ -174,8 +174,12 @@ export const InputChips = styled(
 
       const updateValues = (newInputValue?: string) => {
         const inputValues = parseInputValue(newInputValue || inputValue)
-        const { duplicateValues, invalidValues, unusedValues, validValues } =
-          validateValues(inputValues, values, validate, formatInputValue)
+        const {
+          duplicateValues,
+          invalidValues,
+          unusedValues,
+          validValues,
+        } = validateValues(inputValues, values, validate, formatInputValue)
 
         // Save valid values and keep invalid ones in the input
         const updatedInputValue = unusedValues.join(', ')

--- a/packages/components/src/Form/Inputs/InputText/InputText.spec.tsx
+++ b/packages/components/src/Form/Inputs/InputText/InputText.spec.tsx
@@ -38,9 +38,9 @@ const warnMock = jest.fn()
 
 beforeEach(() => {
   jest.useFakeTimers()
-  global.console = {
+  global.console = ({
     warn: warnMock,
-  } as unknown as Console
+  } as unknown) as Console
 })
 
 afterEach(() => {

--- a/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
+++ b/packages/components/src/Form/Inputs/RangeSlider/RangeSlider.tsx
@@ -347,14 +347,12 @@ export const InternalRangeSlider = forwardRef(
       ]
     )
 
-    const handleMouseDown = useMemo(
-      () => partial(handleMouseEvent, false),
-      [handleMouseEvent]
-    )
-    const handleMouseDrag = useMemo(
-      () => partial(handleMouseEvent, true),
-      [handleMouseEvent]
-    )
+    const handleMouseDown = useMemo(() => partial(handleMouseEvent, false), [
+      handleMouseEvent,
+    ])
+    const handleMouseDrag = useMemo(() => partial(handleMouseEvent, true), [
+      handleMouseEvent,
+    ])
 
     /*
      * Mouse down event (and re-measure the client rectangle values before calculating value).

--- a/packages/components/src/Form/Inputs/Select/Select.spec.tsx
+++ b/packages/components/src/Form/Inputs/Select/Select.spec.tsx
@@ -296,35 +296,35 @@ describe('Select / SelectMulti', () => {
   })
 
   /* eslint-disable react/display-name */
-  const GetIndicatorJSX =
-    (listLevel: boolean) => (indicator: ComboboxOptionIndicatorFunction) =>
-      (
-        <Select
-          options={options.map(opt => ({
-            ...opt,
-            ...(listLevel ? {} : { indicator }),
-          }))}
-          value="FOO"
-          placeholder="Search"
-          indicator={listLevel ? indicator : undefined}
-          key="select"
-        />
-      )
+  const GetIndicatorJSX = (listLevel: boolean) => (
+    indicator: ComboboxOptionIndicatorFunction
+  ) => (
+    <Select
+      options={options.map(opt => ({
+        ...opt,
+        ...(listLevel ? {} : { indicator }),
+      }))}
+      value="FOO"
+      placeholder="Search"
+      indicator={listLevel ? indicator : undefined}
+      key="select"
+    />
+  )
 
-  const GetIndicatorJSXMulti =
-    (listLevel: boolean) => (indicator: ComboboxOptionIndicatorFunction) =>
-      (
-        <SelectMulti
-          options={options.map(opt => ({
-            ...opt,
-            ...(listLevel ? {} : { indicator }),
-          }))}
-          values={['FOO']}
-          placeholder="Search"
-          indicator={listLevel ? indicator : undefined}
-          key="select-multi"
-        />
-      )
+  const GetIndicatorJSXMulti = (listLevel: boolean) => (
+    indicator: ComboboxOptionIndicatorFunction
+  ) => (
+    <SelectMulti
+      options={options.map(opt => ({
+        ...opt,
+        ...(listLevel ? {} : { indicator }),
+      }))}
+      values={['FOO']}
+      placeholder="Search"
+      indicator={listLevel ? indicator : undefined}
+      key="select-multi"
+    />
+  )
   /* eslint-enable react/display-name */
 
   test.each([
@@ -797,9 +797,9 @@ describe('Select', () => {
   const warnMock = jest.fn()
 
   beforeEach(() => {
-    global.console = {
+    global.console = ({
       warn: warnMock,
-    } as unknown as Console
+    } as unknown) as Console
   })
 
   afterEach(() => {

--- a/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
+++ b/packages/components/src/Form/Inputs/Select/SelectOptions.tsx
@@ -216,14 +216,19 @@ export const SelectOptions = (props: SelectOptionsProps) => {
     isLoading,
   } = props
 
-  const { start, end, before, after, scrollToFirst, scrollToLast } =
-    useWindowedOptions(windowing, flatOptions, navigationOptions, isMulti)
+  const {
+    start,
+    end,
+    before,
+    after,
+    scrollToFirst,
+    scrollToLast,
+  } = useWindowedOptions(windowing, flatOptions, navigationOptions, isMulti)
   const keyPrefix = useID(flatOptions?.length.toString())
 
-  const hasIcons = useMemo(
-    () => optionsHaveIcons(navigationOptions),
-    [navigationOptions]
-  )
+  const hasIcons = useMemo(() => optionsHaveIcons(navigationOptions), [
+    navigationOptions,
+  ])
 
   if (isLoading) {
     return (

--- a/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/components/src/Form/Inputs/ToggleSwitch/ToggleSwitch.tsx
@@ -66,11 +66,7 @@ export const ToggleSwitch = styled(
       }: ToggleSwitchProps,
       ref: Ref<HTMLInputElement>
     ) => {
-      const {
-        callbacks,
-        className: rippleClassName,
-        style,
-      } = useRipple({
+      const { callbacks, className: rippleClassName, style } = useRipple({
         color: inputRippleColor(!!on, validationType === 'error'),
         // Only define size for density -6,
         // to make the halo slightly bigger than the container

--- a/packages/components/src/ListItem/ListItem.spec.tsx
+++ b/packages/components/src/ListItem/ListItem.spec.tsx
@@ -293,9 +293,9 @@ describe('ListItem', () => {
     const globalConsole = global.console
     const warnMock = jest.fn()
 
-    global.console = {
+    global.console = ({
       warn: warnMock,
-    } as unknown as Console
+    } as unknown) as Console
 
     renderWithTheme(
       <ListItem itemRole="link" disabled>

--- a/packages/components/src/LkFieldTree/LkFieldTree.tsx
+++ b/packages/components/src/LkFieldTree/LkFieldTree.tsx
@@ -63,8 +63,9 @@ const LkFieldTreeLayout = ({
   ...restProps
 }: LkFieldTreeProps) => {
   const density = lkFieldItemDensity
-  const [treeItemInnerProps, accordionInnerProps] =
-    partitionTreeProps(restProps)
+  const [treeItemInnerProps, accordionInnerProps] = partitionTreeProps(
+    restProps
+  )
 
   const { hovered, contentHandlers, wrapperHandlers } = useTreeHandlers({
     onFocus,
@@ -72,19 +73,21 @@ const LkFieldTreeLayout = ({
     onMouseLeave,
   })
 
-  const { color, disabled, icon, selected } =
-    treeItemInnerProps as Partial<ListItemProps>
+  const {
+    color,
+    disabled,
+    icon,
+    selected,
+  } = treeItemInnerProps as Partial<ListItemProps>
   const [ariaProps] = partitionAriaProps(restProps)
   const treeContext = useContext(TreeContext)
 
   // Context for supporting windowing
   // - opened / closed state must be managed at the collection level for accurate item count
   // - partialRender to hide the accordion disclosure if it's above the window
-  const {
-    isOpen: contextIsOpen,
-    toggleNode,
-    partialRender,
-  } = useContext(WindowedTreeContext)
+  const { isOpen: contextIsOpen, toggleNode, partialRender } = useContext(
+    WindowedTreeContext
+  )
 
   const isOpen = contextIsOpen ?? propsIsOpen
   const toggleOpen = toggleNode ?? propsToggleOpen

--- a/packages/components/src/Menu/MenuItem.spec.tsx
+++ b/packages/components/src/Menu/MenuItem.spec.tsx
@@ -37,9 +37,9 @@ const warnMock = jest.fn()
 
 beforeEach(() => {
   jest.useFakeTimers()
-  global.console = {
+  global.console = ({
     warn: warnMock,
-  } as unknown as Console
+  } as unknown) as Console
 })
 
 afterEach(() => {
@@ -161,9 +161,9 @@ describe('MenuItem', () => {
   test('warns on nested menu item w/ detail', () => {
     const warnMock = jest.fn()
 
-    global.console = {
+    global.console = ({
       warn: warnMock,
-    } as unknown as Console
+    } as unknown) as Console
 
     renderWithTheme(
       <MenuItem detail="Something" nestedMenu>

--- a/packages/components/src/Menu/useNestedMenu.tsx
+++ b/packages/components/src/Menu/useNestedMenu.tsx
@@ -95,8 +95,9 @@ export const useNestedMenu = ({
 }: UseNestedMenuProps) => {
   const mousePosition = useRef<MousePosition>()
   const focusRef = useRef<Element | null>(null)
-  const { value, change, delayChange, waitChange } =
-    useContext(NestedMenuContext)
+  const { value, change, delayChange, waitChange } = useContext(
+    NestedMenuContext
+  )
 
   const { closeModal } = useContext(DialogContext)
   const { density } = useContext(ListItemContext)

--- a/packages/components/src/NavTree/NavTree.tsx
+++ b/packages/components/src/NavTree/NavTree.tsx
@@ -80,8 +80,9 @@ export const NavTree = styled(
      */
     const isIndicatorToggleOnly = !!restProps.href
 
-    const [treeItemInnerProps, accordionInnerProps] =
-      partitionTreeProps(restProps)
+    const [treeItemInnerProps, accordionInnerProps] = partitionTreeProps(
+      restProps
+    )
 
     const { hovered, contentHandlers, wrapperHandlers } = useTreeHandlers({
       onFocus,
@@ -89,8 +90,14 @@ export const NavTree = styled(
       onMouseLeave,
     })
 
-    const { disabled, href, icon, rel, selected, target } =
-      treeItemInnerProps as Partial<ListItemProps>
+    const {
+      disabled,
+      href,
+      icon,
+      rel,
+      selected,
+      target,
+    } = treeItemInnerProps as Partial<ListItemProps>
     const [ariaProps] = partitionAriaProps(restProps)
 
     const treeContext = useContext(TreeContext)
@@ -99,11 +106,9 @@ export const NavTree = styled(
     // - density must be defined at the collection level for consistent child height
     // - opened / closed state must be managed at the collection level for accurate item count
     // - partialRender to hide the accordion disclosure if it's above the window
-    const {
-      isOpen: contextIsOpen,
-      toggleNode,
-      partialRender,
-    } = useContext(WindowedTreeContext)
+    const { isOpen: contextIsOpen, toggleNode, partialRender } = useContext(
+      WindowedTreeContext
+    )
 
     const isOpen = contextIsOpen ?? propsIsOpen
     const toggleOpen = toggleNode ?? propsToggleOpen

--- a/packages/components/src/Popover/Layout/PopoverLayout.spec.tsx
+++ b/packages/components/src/Popover/Layout/PopoverLayout.spec.tsx
@@ -30,8 +30,13 @@ import { composeStories } from '@storybook/testing-react'
 import { screen } from '@testing-library/react'
 import * as stories from './PopoverLayout.stories'
 
-const { Basic, FooterCloseButton, Full, Header, HeaderHideHeading } =
-  composeStories(stories)
+const {
+  Basic,
+  FooterCloseButton,
+  Full,
+  Header,
+  HeaderHideHeading,
+} = composeStories(stories)
 
 describe('PopoverLayout', () => {
   test('basic display has footer ', () => {

--- a/packages/components/src/Popover/stories/Popover.stories.tsx
+++ b/packages/components/src/Popover/stories/Popover.stories.tsx
@@ -296,8 +296,9 @@ const DialogInner = () => {
       enableCurrentLock?.()
     }
   }
-  const { activeTrapRef, disableCurrentTrap, enableCurrentTrap } =
-    useContext(FocusTrapContext)
+  const { activeTrapRef, disableCurrentTrap, enableCurrentTrap } = useContext(
+    FocusTrapContext
+  )
   const toggleFocusTrap = () => {
     if (activeTrapRef && activeTrapRef.current) {
       disableCurrentTrap?.()

--- a/packages/components/src/Popover/usePopover.tsx
+++ b/packages/components/src/Popover/usePopover.tsx
@@ -217,8 +217,9 @@ export const usePopover = ({
     }),
     [element, pin, propsPlacement]
   )
-  const { placement, popperInstanceRef, style, targetRef } =
-    usePopper(usePopperProps)
+  const { placement, popperInstanceRef, style, targetRef } = usePopper(
+    usePopperProps
+  )
 
   const verticalSpace = useVerticalSpace(
     element,

--- a/packages/components/src/Ripple/Ripple.stories.tsx
+++ b/packages/components/src/Ripple/Ripple.stories.tsx
@@ -36,16 +36,14 @@ type RippleProps = SimpleLayoutProps & UseRippleProps & { className?: string }
 
 const Ripple = styled(
   ({ className, bounded, color, height, width, ...props }: RippleProps) => {
-    const {
-      callbacks,
-      className: rippleClassName,
-      ...rippleProps
-    } = useRipple({
-      bounded,
-      color,
-      height,
-      width,
-    })
+    const { callbacks, className: rippleClassName, ...rippleProps } = useRipple(
+      {
+        bounded,
+        color,
+        height,
+        width,
+      }
+    )
 
     const rippleHandlers = useRippleHandlers(callbacks, {})
 

--- a/packages/components/src/Tabs2/Tabs2.tsx
+++ b/packages/components/src/Tabs2/Tabs2.tsx
@@ -100,7 +100,7 @@ export const Tabs2 = ({
       <TabList2 distribute={distributed}>{labels}</TabList2>
       {currentTab && (
         <TabPanels2 id={currentTab.id}>
-          {currentTab.children as any as JSX.Element}
+          {(currentTab.children as any) as JSX.Element}
         </TabPanels2>
       )}
     </>

--- a/packages/components/src/Tooltip/useTooltip.tsx
+++ b/packages/components/src/Tooltip/useTooltip.tsx
@@ -121,8 +121,9 @@ export const useTooltip = ({
     [element, propsPlacement]
   )
 
-  const { placement, popperInstanceRef, style, targetRef } =
-    usePopper(usePopperProps)
+  const { placement, popperInstanceRef, style, targetRef } = usePopper(
+    usePopperProps
+  )
 
   const ref = useForkedRef(targetRef, surfaceCallbackRef)
 

--- a/packages/components/src/Tree/Tree.tsx
+++ b/packages/components/src/Tree/Tree.tsx
@@ -77,8 +77,9 @@ const TreeLayout = ({
   toggleOpen: propsToggleOpen,
   ...restProps
 }: TreeProps) => {
-  const [treeItemInnerProps, accordionInnerProps] =
-    partitionTreeProps(restProps)
+  const [treeItemInnerProps, accordionInnerProps] = partitionTreeProps(
+    restProps
+  )
 
   const { hovered, contentHandlers, wrapperHandlers } = useTreeHandlers({
     onFocus,

--- a/packages/components/src/Tree/stories/Windowing.stories.tsx
+++ b/packages/components/src/Tree/stories/Windowing.stories.tsx
@@ -107,14 +107,14 @@ const getTrees = (labelLength: number): WindowedTreeNodeProps[] =>
 const treesRandomText = getTrees(50)
 const treesNoText = getTrees(0)
 
-const getUpdater =
-  (isOpen: boolean) =>
-  (tree: WindowedTreeNodeProps): WindowedTreeNodeProps => {
-    if (tree.items) {
-      return { ...tree, isOpen, items: tree.items.map(getUpdater(isOpen)) }
-    }
-    return { ...tree, isOpen }
+const getUpdater = (isOpen: boolean) => (
+  tree: WindowedTreeNodeProps
+): WindowedTreeNodeProps => {
+  if (tree.items) {
+    return { ...tree, isOpen, items: tree.items.map(getUpdater(isOpen)) }
   }
+  return { ...tree, isOpen }
+}
 
 export const Windowing = ({ noText }: { noText?: boolean }) => {
   const { value, toggle, setOn } = useToggle()

--- a/packages/components/src/Tree/utils/getWindowedTreeNodeFilterer.ts
+++ b/packages/components/src/Tree/utils/getWindowedTreeNodeFilterer.ts
@@ -46,47 +46,45 @@ const getTreeWindowIntersection = (
   return 'before'
 }
 
-export const getWindowedTreeNodeFilterer =
-  (
-    filteredList: WindowedTreeNodeIDProps[],
-    firstIDinWindow: number,
-    lastIDinWindow: number
-  ) =>
-  (
-    node: WindowedTreeNodeIDProps,
-    index: number,
-    list: WindowedTreeNodeIDProps[]
-  ) => {
-    const intersection = getTreeWindowIntersection(
-      list,
-      index,
-      firstIDinWindow,
-      lastIDinWindow
-    )
-    // If the node is after the window, stop looping
-    if (intersection === 'after') return false
+export const getWindowedTreeNodeFilterer = (
+  filteredList: WindowedTreeNodeIDProps[],
+  firstIDinWindow: number,
+  lastIDinWindow: number
+) => (
+  node: WindowedTreeNodeIDProps,
+  index: number,
+  list: WindowedTreeNodeIDProps[]
+) => {
+  const intersection = getTreeWindowIntersection(
+    list,
+    index,
+    firstIDinWindow,
+    lastIDinWindow
+  )
+  // If the node is after the window, stop looping
+  if (intersection === 'after') return false
 
-    if (intersection === 'intersects') {
-      const treeItems = node.items
-      if (treeItems) {
-        // Recursively filter the tree's items
-        const filteredItems: WindowedTreeNodeIDProps[] = []
-        treeItems.every(
-          getWindowedTreeNodeFilterer(
-            filteredItems,
-            firstIDinWindow,
-            lastIDinWindow
-          )
+  if (intersection === 'intersects') {
+    const treeItems = node.items
+    if (treeItems) {
+      // Recursively filter the tree's items
+      const filteredItems: WindowedTreeNodeIDProps[] = []
+      treeItems.every(
+        getWindowedTreeNodeFilterer(
+          filteredItems,
+          firstIDinWindow,
+          lastIDinWindow
         )
-        const treeWithFilteredItems = { ...node, items: filteredItems }
-        filteredList.push(treeWithFilteredItems)
-      } else {
-        // This is an item (not a tree) within the window
-        filteredList.push(node)
-      }
+      )
+      const treeWithFilteredItems = { ...node, items: filteredItems }
+      filteredList.push(treeWithFilteredItems)
+    } else {
+      // This is an item (not a tree) within the window
+      filteredList.push(node)
     }
-    // Return true to keep looping for either 'before' or 'intersects'
-    // 'before': we need to keep checking to find the first intersecting tree
-    // 'intersects': the next tree may also intersect the window
-    return true
   }
+  // Return true to keep looping for either 'before' or 'intersects'
+  // 'before': we need to keep checking to find the first intersecting tree
+  // 'intersects': the next tree may also intersect the window
+  return true
+}

--- a/packages/components/src/Tree/utils/windowedTreeReducer.ts
+++ b/packages/components/src/Tree/utils/windowedTreeReducer.ts
@@ -74,28 +74,28 @@ export const windowedTreeReducer: Reducer<
       // auto-increment-style ID for each item
       let id = 0
 
-      const processTree =
-        (parentOpen?: boolean) =>
-        (tree: WindowedTreeNodeProps): WindowedTreeNodeIDProps => {
-          id++
-          if (parentOpen) {
-            shownIDs.push(id)
-          }
-          if (tree.items) {
-            map[id] = {
-              isOpen: tree.isOpen || false,
-              length: tree.items.length,
-            }
-            return {
-              ...tree,
-              id,
-              items: tree.items.map(
-                processTree(parentOpen ? tree.isOpen : false)
-              ),
-            }
-          }
-          return { content: tree.content, id }
+      const processTree = (parentOpen?: boolean) => (
+        tree: WindowedTreeNodeProps
+      ): WindowedTreeNodeIDProps => {
+        id++
+        if (parentOpen) {
+          shownIDs.push(id)
         }
+        if (tree.items) {
+          map[id] = {
+            isOpen: tree.isOpen || false,
+            length: tree.items.length,
+          }
+          return {
+            ...tree,
+            id,
+            items: tree.items.map(
+              processTree(parentOpen ? tree.isOpen : false)
+            ),
+          }
+        }
+        return { content: tree.content, id }
+      }
 
       const treesWithIDs = trees.map(processTree(true))
 

--- a/packages/components/src/utils/mergeHandlers.ts
+++ b/packages/components/src/utils/mergeHandlers.ts
@@ -31,14 +31,12 @@ import type { SyntheticEvent } from 'react'
  * @param newHandler called 2nd, if the 1st does not call preventDefault()
  * @param existingHandler called 1st, use preventDefault() to avoid calling the 2nd
  */
-export const mergeHandlers =
-  <E extends SyntheticEvent>(
-    newHandler?: (e: E) => void,
-    existingHandler?: (e: E) => void
-  ) =>
-  (event: E) => {
-    existingHandler?.(event)
-    if (!event.defaultPrevented) {
-      newHandler?.(event)
-    }
+export const mergeHandlers = <E extends SyntheticEvent>(
+  newHandler?: (e: E) => void,
+  existingHandler?: (e: E) => void
+) => (event: E) => {
+  existingHandler?.(event)
+  if (!event.defaultPrevented) {
+    newHandler?.(event)
   }
+}

--- a/packages/components/src/utils/useFocusTrap.ts
+++ b/packages/components/src/utils/useFocusTrap.ts
@@ -35,10 +35,10 @@ export const useFocusTrap = <E extends HTMLElement = HTMLElement>({
   ...props
 }: UseTrapStackBaseProps<E> & { clickOutsideDeactivates?: boolean }) => {
   const returnFocusRef = useRef<Element>(null)
-  const options = useMemo(
-    () => ({ clickOutsideDeactivates, returnFocusRef }),
-    [returnFocusRef, clickOutsideDeactivates]
-  )
+  const options = useMemo(() => ({ clickOutsideDeactivates, returnFocusRef }), [
+    returnFocusRef,
+    clickOutsideDeactivates,
+  ])
   return useTrapStack<E, FocusTrapOptions>({
     context: FocusTrapContext,
     // If options.returnFocusRef is set, it will override this one

--- a/packages/components/src/utils/useIsTruncated.ts
+++ b/packages/components/src/utils/useIsTruncated.ts
@@ -56,7 +56,7 @@ export const useIsTruncated = (
 
     const resizeObserver = new ResizeObserver(() => handleResize())
     if (element) {
-      resizeObserver.observe(element as unknown as HTMLElement)
+      resizeObserver.observe((element as unknown) as HTMLElement)
     }
 
     return () => {

--- a/packages/components/src/utils/useResize.ts
+++ b/packages/components/src/utils/useResize.ts
@@ -46,7 +46,7 @@ export const useResize = (element: HTMLElement | null, handler: () => void) => {
     const resizeObserver = new ResizeObserver(() => throttledHandler())
 
     if (element) {
-      resizeObserver.observe(element as unknown as HTMLElement)
+      resizeObserver.observe((element as unknown) as HTMLElement)
     }
 
     window.addEventListener('resize', throttledHandler)

--- a/packages/components/src/utils/useScrollLock.spec.tsx
+++ b/packages/components/src/utils/useScrollLock.spec.tsx
@@ -34,10 +34,10 @@ const warnMock = jest.fn()
 const paddingSpy = jest.spyOn(document.body.style, 'paddingRight', 'set')
 
 beforeEach(() => {
-  global.console = {
+  global.console = ({
     ...globalConsole,
     warn: warnMock,
-  } as unknown as Console
+  } as unknown) as Console
 })
 
 afterEach(() => {

--- a/packages/components/src/utils/useTrapStack.ts
+++ b/packages/components/src/utils/useTrapStack.ts
@@ -68,8 +68,12 @@ export const useTrapStack = <
 }: UseTrapStackProps<E, O>): [E | null, (node: E | null) => void] => {
   const id = useID()
   const [element, callbackRef] = useCallbackRef(ref)
-  const { addTrap, removeTrap, disableCurrentTrap, enableCurrentTrap } =
-    useContext(context)
+  const {
+    addTrap,
+    removeTrap,
+    disableCurrentTrap,
+    enableCurrentTrap,
+  } = useContext(context)
 
   useEffect(() => {
     if (!addTrap) {

--- a/packages/demos/src/design-tokens/SpacingOptionsTable.tsx
+++ b/packages/demos/src/design-tokens/SpacingOptionsTable.tsx
@@ -53,9 +53,9 @@ const spacingExamples = [
 
 const spacingLabels = ['Size', 'Theme Value', 'PX Value', 'Rem Value']
 
-const unitValues: Array<string[]> = Object.entries(theme.space).filter(
-  ([key]) => key.startsWith('u')
-)
+const unitValues: Array<string[]> = Object.entries(
+  theme.space
+).filter(([key]) => key.startsWith('u'))
 
 const lookupLegacyValue = (remValue: string) => {
   const validSpace = spacingExamples.find(item => item.rem === remValue)

--- a/packages/eslint-config-oss/README.md
+++ b/packages/eslint-config-oss/README.md
@@ -41,7 +41,6 @@ module.exports = {
 }
 ```
 
-
 NOTE: Adding an `eslint.config.js` file will allow you to add your own rules to so that your package can add (or disable) additional lint rules as needed:
 
 ```js
@@ -65,6 +64,7 @@ Need to customize the prettier configuration? Add a `.prettierrc.json` to the ro
   "singleQuote": true
 }
 ```
+
 ## LICENCE
 
 [MIT](LICENCE)

--- a/packages/icons/bin/build.js
+++ b/packages/icons/bin/build.js
@@ -79,9 +79,7 @@ export * from './${name}'
 
 const generate = async () => {
   const files = await fg(['svg/*.svg'])
-  const icons = files.map((icon) =>
-    icon.replace('.svg', '').replace('svg/', '')
-  )
+  const icons = files.map(icon => icon.replace('.svg', '').replace('svg/', ''))
 
   if (icons.length === 0) {
     console.error('Error reading icons from source')
@@ -145,12 +143,12 @@ const generate = async () => {
       path.join(buildDir, 'index.ts'),
       `${license}
 export const iconsList = [
-${icons.map((icon) => `  '${icon}'`).join(',\n')},
+${icons.map(icon => `  '${icon}'`).join(',\n')},
 ]
 
 ${icons
-  .map((icon) => `export { ${icon} } from './${icon}'`)
-  .filter((lines) => lines)
+  .map(icon => `export { ${icon} } from './${icon}'`)
+  .filter(lines => lines)
   .join('\n')}
 `
     )
@@ -159,7 +157,7 @@ ${icons
   console.log(`${totalIcons} icons generated!`)
 }
 
-generate().catch((err) => {
+generate().catch(err => {
   console.error(err.stack)
   process.exit(1)
 })

--- a/packages/icons/bin/h2x.js
+++ b/packages/icons/bin/h2x.js
@@ -57,7 +57,7 @@ const replaceChildren = () => ({
   },
 })
 
-const stripAttribute = (attribute) => () => ({
+const stripAttribute = attribute => () => ({
   visitor: {
     JSXAttribute: {
       enter(path) {
@@ -104,13 +104,11 @@ const processSVG = () => ({
           )
 
           const heightAttribute = attributes.find(
-            (attr) => attr.name === 'height'
+            attr => attr.name === 'height'
           )
-          const widthAttribute = attributes.find(
-            (attr) => attr.name === 'width'
-          )
+          const widthAttribute = attributes.find(attr => attr.name === 'width')
           const viewBoxAttribute = attributes.find(
-            (attr) => attr.name === 'viewBox'
+            attr => attr.name === 'viewBox'
           )
 
           state.height = heightAttribute ? heightAttribute.value : null
@@ -129,7 +127,7 @@ module.exports = (code, state) => {
   transform(code, { plugins: [extractChildren, processSVG], state })
 
   // Second pass over the extracted children
-  return state.children.map((replacement) =>
+  return state.children.map(replacement =>
     transform('<svg />', {
       plugins: [
         replaceChildren,

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -8,7 +8,7 @@
   "version": "1.5.1",
   "sideEffects": false,
   "dependencies": {
-    "prettier": "2.3.1",
+    "prettier": "2.2.1",
     "stylelint": "^13.13.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-recommended": "^5.0.0",

--- a/www/src/documentation/components/content/data-table.mdx
+++ b/www/src/documentation/components/content/data-table.mdx
@@ -462,8 +462,9 @@ The `useSelectManager` hook can be used to quickly create the standard building 
 
   const allSelectableItems = data.map(({ id }) => String(id))
 
-  const { onSelect, onSelectAll, selections, setSelections } =
-    useSelectManager(allSelectableItems)
+  const { onSelect, onSelectAll, selections, setSelections } = useSelectManager(
+    allSelectableItems
+  )
 
   const items = data.map(({ id, name }) => (
     <DataTableItem
@@ -571,8 +572,9 @@ The `bulk` prop is used to configure a `DataTable`'s control bar. The object pas
     </DataTableItem>
   ))
 
-  const { onSelect, onSelectAll, selections, setSelections } =
-    useSelectManager(pageItemIds)
+  const { onSelect, onSelectAll, selections, setSelections } = useSelectManager(
+    pageItemIds
+  )
 
   const allItems = [...data].map(({ id }) => String(id))
   const onTotalSelectAll = () => setSelections(allItems)

--- a/www/src/documentation/components/dialogs/index.mdx
+++ b/www/src/documentation/components/dialogs/index.mdx
@@ -192,8 +192,9 @@ In rare cases, such as nesting a popover from another library inside a `Dialog`,
 import { ScrollLockContext } from '@looker/components-providers'
 import { useContext } from 'react'
 
-const { activeTrapRef, disableCurrentTrap, enableCurrentTrap } =
-  useContext(ScrollLockContext)
+const { activeTrapRef, disableCurrentTrap, enableCurrentTrap } = useContext(
+  ScrollLockContext
+)
 
 function toggleScrollLock() {
   if (activeTrapRef && activeTrapRef.current) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16848,15 +16848,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier@2.2.1, prettier@~2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 prettier@2.3.1, prettier@^2.0.5, prettier@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
   integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
-
-prettier@~2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.4.1"


### PR DESCRIPTION
To get total consistency we need to pull back on our prettier version (from 2.3 => 2.2) as the logic around position some whitespace changed between versions.