### PR TITLE
fix(Menu): Error when nesting 3 levels deep

### DIFF
--- a/packages/components/src/Menu/Menu.spec.tsx
+++ b/packages/components/src/Menu/Menu.spec.tsx
@@ -413,6 +413,45 @@ describe('<Menu />', () => {
       expect(onClickMock).toHaveBeenCalledTimes(1)
       expect(child).toBeVisible()
       expect(parent).toBeVisible()
+
+      fireEvent.click(document)
+    })
+
+    test('3 levels deep', () => {
+      const onClickMock = jest.fn()
+      renderWithTheme(
+        <Menu
+          content={
+            <MenuItem
+              nestedMenu={
+                <MenuItem
+                  nestedMenu={
+                    <MenuItem onClick={onClickMock}>Camembert</MenuItem>
+                  }
+                >
+                  Stinky
+                </MenuItem>
+              }
+            >
+              French
+            </MenuItem>
+          }
+        >
+          <Button>Cheese</Button>
+        </Menu>
+      )
+
+      // Open three levels of nesting
+      userEvent.click(screen.getByText('Cheese'))
+      const first = screen.getByText('French')
+      userEvent.click(first)
+      const second = screen.getByText('Stinky')
+      userEvent.click(second)
+      const third = screen.getByText('Camembert')
+      userEvent.click(third)
+
+      // All levels close
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -629,7 +629,16 @@ export const NestedMenu = () => {
 
   const nestedMenu = (
     <>
-      <MenuItem onClick={getOnClick('Sub Item')}>Sub Item</MenuItem>
+      <MenuItem
+        nestedMenu={
+          <MenuItem onClick={getOnClick('Another Level')}>
+            Another Level
+          </MenuItem>
+        }
+        onClick={getOnClick('Sub Item')}
+      >
+        Sub Item
+      </MenuItem>
       <MenuItem onClick={getOnClick('Another Sub Item')}>
         Another Sub Item
       </MenuItem>

--- a/packages/components/src/Menu/NestedMenuProvider.tsx
+++ b/packages/components/src/Menu/NestedMenuProvider.tsx
@@ -52,8 +52,9 @@ export const NestedMenuProvider: FC<CloseParentMenuProps> = ({
   closeParentMenu,
 }) => {
   const delayedStateProps = useDelayedState<string>('')
-  const { closeParentMenu: closeGrandparentMenu } =
-    useContext(NestedMenuContext)
+  const { closeParentMenu: closeGrandparentMenu } = useContext(
+    NestedMenuContext
+  )
 
   const wrappedCloseParentMenu = useCallback(() => {
     // Close the grandparent menu, if there is one

--- a/packages/components/src/Menu/NestedMenuProvider.tsx
+++ b/packages/components/src/Menu/NestedMenuProvider.tsx
@@ -25,7 +25,7 @@
  */
 
 import type { FC } from 'react'
-import React, { createContext } from 'react'
+import React, { createContext, useCallback, useContext } from 'react'
 import type { UseDelayedStateReturn } from '../utils'
 import { useDelayedState } from '../utils'
 
@@ -52,9 +52,16 @@ export const NestedMenuProvider: FC<CloseParentMenuProps> = ({
   closeParentMenu,
 }) => {
   const delayedStateProps = useDelayedState<string>('')
+  const { closeParentMenu: closeGrandparent } = useContext(NestedMenuContext)
+
+  const wrappedClose = useCallback(() => {
+    closeGrandparent?.()
+    closeParentMenu?.()
+  }, [closeGrandparent, closeParentMenu])
+
   return (
     <NestedMenuContext.Provider
-      value={{ ...delayedStateProps, closeParentMenu }}
+      value={{ ...delayedStateProps, closeParentMenu: wrappedClose }}
     >
       {children}
     </NestedMenuContext.Provider>

--- a/packages/components/src/Menu/NestedMenuProvider.tsx
+++ b/packages/components/src/Menu/NestedMenuProvider.tsx
@@ -52,16 +52,18 @@ export const NestedMenuProvider: FC<CloseParentMenuProps> = ({
   closeParentMenu,
 }) => {
   const delayedStateProps = useDelayedState<string>('')
-  const { closeParentMenu: closeGrandparent } = useContext(NestedMenuContext)
+  const { closeParentMenu: closeGrandparentMenu } =
+    useContext(NestedMenuContext)
 
-  const wrappedClose = useCallback(() => {
-    closeGrandparent?.()
+  const wrappedCloseParentMenu = useCallback(() => {
+    // Close the grandparent menu, if there is one
+    closeGrandparentMenu?.()
     closeParentMenu?.()
-  }, [closeGrandparent, closeParentMenu])
+  }, [closeGrandparentMenu, closeParentMenu])
 
   return (
     <NestedMenuContext.Provider
-      value={{ ...delayedStateProps, closeParentMenu: wrappedClose }}
+      value={{ ...delayedStateProps, closeParentMenu: wrappedCloseParentMenu }}
     >
       {children}
     </NestedMenuContext.Provider>

--- a/packages/components/src/Menu/useNestedMenu.tsx
+++ b/packages/components/src/Menu/useNestedMenu.tsx
@@ -28,7 +28,7 @@ import type { CompatibleHTMLProps } from '@looker/design-tokens'
 import { transitions } from '@looker/design-tokens'
 import type { Placement } from '@popperjs/core'
 import omit from 'lodash/omit'
-import type { FocusEvent, KeyboardEvent, MouseEvent, ReactNode } from 'react'
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
 import React, { useContext, useEffect, useRef } from 'react'
 import { DialogContext } from '../Dialog'
 import { usePopover } from '../Popover'
@@ -187,14 +187,6 @@ export const useNestedMenu = ({
       }
     : {}
 
-  // React artificially bubbles events up through Portal
-  // We don't want that here because it causes the useArrowKeyNav logic
-  // to think focus is still inside the parent menu(s),
-  // resulting in a focus trap error when closing a 3rd level nested menu
-  const stopFocusBubbling = (e: FocusEvent) => {
-    e.stopPropagation()
-  }
-
   const { popover, popperInstanceRef, domProps } = usePopover({
     content: (
       <MenuList
@@ -202,7 +194,6 @@ export const useNestedMenu = ({
         density={density}
         {...listHandlers}
         closeParentMenu={closeModal}
-        onFocus={stopFocusBubbling}
       >
         {nestedMenu}
       </MenuList>

--- a/packages/components/src/Menu/useNestedMenu.tsx
+++ b/packages/components/src/Menu/useNestedMenu.tsx
@@ -95,8 +95,9 @@ export const useNestedMenu = ({
 }: UseNestedMenuProps) => {
   const mousePosition = useRef<MousePosition>()
   const focusRef = useRef<Element | null>(null)
-  const { value, change, delayChange, waitChange } =
-    useContext(NestedMenuContext)
+  const { value, change, delayChange, waitChange } = useContext(
+    NestedMenuContext
+  )
 
   const { closeModal } = useContext(DialogContext)
   const { density } = useContext(ListItemContext)

--- a/packages/components/src/Menu/useNestedMenu.tsx
+++ b/packages/components/src/Menu/useNestedMenu.tsx
@@ -28,7 +28,7 @@ import type { CompatibleHTMLProps } from '@looker/design-tokens'
 import { transitions } from '@looker/design-tokens'
 import type { Placement } from '@popperjs/core'
 import omit from 'lodash/omit'
-import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
+import type { FocusEvent, KeyboardEvent, MouseEvent, ReactNode } from 'react'
 import React, { useContext, useEffect, useRef } from 'react'
 import { DialogContext } from '../Dialog'
 import { usePopover } from '../Popover'
@@ -187,6 +187,14 @@ export const useNestedMenu = ({
       }
     : {}
 
+  // React artificially bubbles events up through Portal
+  // We don't want that here because it causes the useArrowKeyNav logic
+  // to think focus is still inside the parent menu(s),
+  // resulting in a focus trap error when closing a 3rd level nested menu
+  const stopFocusBubbling = (e: FocusEvent) => {
+    e.stopPropagation()
+  }
+
   const { popover, popperInstanceRef, domProps } = usePopover({
     content: (
       <MenuList
@@ -194,7 +202,7 @@ export const useNestedMenu = ({
         density={density}
         {...listHandlers}
         closeParentMenu={closeModal}
-        onFocus={e => e.stopPropagation()}
+        onFocus={stopFocusBubbling}
       >
         {nestedMenu}
       </MenuList>

--- a/packages/components/src/Menu/useNestedMenu.tsx
+++ b/packages/components/src/Menu/useNestedMenu.tsx
@@ -95,9 +95,8 @@ export const useNestedMenu = ({
 }: UseNestedMenuProps) => {
   const mousePosition = useRef<MousePosition>()
   const focusRef = useRef<Element | null>(null)
-  const { value, change, delayChange, waitChange } = useContext(
-    NestedMenuContext
-  )
+  const { value, change, delayChange, waitChange } =
+    useContext(NestedMenuContext)
 
   const { closeModal } = useContext(DialogContext)
   const { density } = useContext(ListItemContext)
@@ -195,6 +194,7 @@ export const useNestedMenu = ({
         density={density}
         {...listHandlers}
         closeParentMenu={closeModal}
+        onFocus={e => e.stopPropagation()}
       >
         {nestedMenu}
       </MenuList>


### PR DESCRIPTION
Though it wasn't specifically designed for it, nesting menus 3 levels deep mostly works, except for these issues when clicking on an item in the 3rd level menu:

1. There's an error from focus trap
2. Only the 2nd and 3rd menus close, not the 1st

This PR addresses both by addressing issue 2. 

Issue 1 is due to a complicated collision between how React bubbles events up through a portal, how we handle focus & blur events in `useArrowKeyNav`, and focus trap. Calling `stopPropagation` could fix this but might also have unforeseen consequences. So closing all the menus is the simpler solution.
