### PR TITLE
chore: Jest mock consistency

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -44,6 +44,9 @@ globalAny.IntersectionObserver = observeMock
 // js-dom doesn't do scrollIntoView
 Element.prototype.scrollIntoView = jest.fn()
 
+// js-dom doesn't do requestAnimationFrame
+globalAny.requestAnimationFrame = cb => setTimeout(() => cb(), 0)
+
 /**
  * Throw a hard-error if an underlying library (e.g.: React) is throwing console.error
  * Inspired by: https://github.com/facebook/jest/issues/6121#issuecomment-529591574

--- a/packages/components/src/Button/IconButton.spec.tsx
+++ b/packages/components/src/Button/IconButton.spec.tsx
@@ -30,12 +30,7 @@ import ReactDOMServer from 'react-dom/server'
 import { ComponentsProvider } from '@looker/components-providers'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { Favorite } from '@styled-icons/material'
-import {
-  act,
-  fireEvent,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 import { Tooltip } from '../Tooltip'
 import { IconButton } from './IconButton'
 
@@ -75,7 +70,6 @@ describe('IconButton', () => {
   test('accepts events', async () => {
     const fauxMouseEnter = jest.fn()
     const fauxClick = jest.fn()
-    const label = 'Test'
 
     renderWithTheme(
       <IconButton
@@ -92,7 +86,6 @@ describe('IconButton', () => {
     expect(fauxMouseEnter).toHaveBeenCalledTimes(1)
     fireEvent.mouseOut(button)
     runTimers()
-    await waitForElementToBeRemoved(() => screen.getAllByText(label)[1])
 
     fireEvent.click(button)
     expect(fauxClick).toHaveBeenCalledTimes(1)
@@ -114,7 +107,7 @@ describe('IconButton', () => {
     expect(tooltip[1]).toBeVisible()
 
     fireEvent.mouseOut(icon)
-    await waitForElementToBeRemoved(() => screen.getAllByText(label)[1])
+    runTimers()
   })
 
   test('tooltipDisabled actually disables tooltip', () => {
@@ -158,7 +151,7 @@ describe('IconButton', () => {
     expect(tooltipContents).toBeVisible()
 
     fireEvent.mouseOut(button)
-    await waitForElementToBeRemoved(() => screen.getByText(tooltip))
+    runTimers()
   })
 
   test('built-in tooltip respects text-align, width props', async () => {
@@ -182,7 +175,7 @@ describe('IconButton', () => {
     expect(tooltip[0]).toHaveStyleRule('text-align', 'right')
 
     fireEvent.mouseOut(trigger)
-    await waitForElementToBeRemoved(() => screen.getAllByText(label)[1])
+    runTimers()
   })
 
   test('toggleBackground renders a background', () => {

--- a/packages/components/src/DataTable/DataTable.spec.tsx
+++ b/packages/components/src/DataTable/DataTable.spec.tsx
@@ -276,16 +276,13 @@ const dataTableWithSelectedItems = (
 )
 
 describe('DataTable', () => {
-  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>
-
   beforeEach(() => {
-    rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation((cb: any) => cb())
+    jest.useFakeTimers()
   })
 
   afterEach(() => {
-    rafSpy.mockRestore()
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
     handleActionClick.mockClear()
     handleListItemClick.mockClear()
     onSelect.mockClear()

--- a/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
+++ b/packages/components/src/Form/Inputs/InputChips/InputChips.spec.tsx
@@ -301,9 +301,7 @@ tag2`
   })
 
   test('mousedown on a chip does not focus the inner input', () => {
-    const rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation((cb: any) => cb())
+    jest.useFakeTimers()
 
     renderWithTheme(
       <InputChips
@@ -324,13 +322,12 @@ tag2`
     fireEvent.click(deleteButton)
     expect(input).toHaveFocus()
 
-    rafSpy.mockRestore()
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
   })
 
   test('mousedown on clear button does not focus the inner input', () => {
-    const rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation((cb: any) => cb())
+    jest.useFakeTimers()
 
     renderWithTheme(
       <InputChips
@@ -350,7 +347,8 @@ tag2`
     fireEvent.click(clear)
     expect(input).toHaveFocus()
 
-    rafSpy.mockRestore()
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
   })
 
   describe('Selecting chips', () => {

--- a/packages/components/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/components/src/Tooltip/Tooltip.spec.tsx
@@ -33,18 +33,12 @@ import { Popover } from '../Popover'
 import { Tooltip } from './Tooltip'
 
 describe('Tooltip', () => {
-  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>
-
   beforeEach(() => {
     jest.useFakeTimers()
-    rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation((cb: any) => cb())
   })
 
   afterEach(() => {
     jest.useRealTimers()
-    rafSpy.mockRestore()
   })
 
   const runTimers = () =>
@@ -70,6 +64,7 @@ describe('Tooltip', () => {
     expect(tooltip).toBeVisible()
 
     fireEvent.mouseOut(tooltip)
+    runTimers()
     expect(tooltip).not.toBeInTheDocument()
   })
 
@@ -87,6 +82,7 @@ describe('Tooltip', () => {
     expect(tooltip).toBeVisible()
 
     fireEvent.mouseOut(tooltip)
+    runTimers()
     expect(tooltip).not.toBeInTheDocument()
   })
 
@@ -108,7 +104,7 @@ describe('Tooltip', () => {
     expect(tooltip).toBeInTheDocument()
 
     fireEvent.mouseOut(tooltip)
-
+    runTimers()
     expect(tooltip).not.toBeInTheDocument()
   })
 
@@ -125,6 +121,7 @@ describe('Tooltip', () => {
     expect(tooltip).toBeVisible()
 
     fireEvent.mouseOut(trigger)
+    runTimers()
     expect(tooltip).not.toBeInTheDocument()
   })
 
@@ -206,6 +203,7 @@ describe('Tooltip', () => {
     expect(mockHandlers.onMouseOut).toHaveBeenCalled()
     fireEvent.mouseOver(button)
     expect(mockHandlers.onMouseOver).toHaveBeenCalled()
+    runTimers()
     expect(screen.queryByText('Some tooltip')).not.toBeInTheDocument()
 
     fireEvent.blur(button)

--- a/packages/components/src/Truncate/Truncate.spec.tsx
+++ b/packages/components/src/Truncate/Truncate.spec.tsx
@@ -33,18 +33,12 @@ import { Truncate } from './Truncate'
 const longLabel = 'This is a long label that should trigger truncation'
 
 describe('Truncate', () => {
-  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>
-
   beforeEach(() => {
     jest.useFakeTimers()
-    rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation((cb: any) => cb())
   })
 
   afterEach(() => {
     jest.useRealTimers()
-    rafSpy.mockRestore()
   })
 
   const runTimers = () =>
@@ -84,6 +78,7 @@ describe('Truncate', () => {
     expect(tooltip).toBeVisible()
 
     fireEvent.mouseOut(tooltip)
+    runTimers()
     expect(tooltip).not.toBeInTheDocument()
   })
 
@@ -100,6 +95,7 @@ describe('Truncate', () => {
     expect(tooltip).toBeVisible()
 
     fireEvent.mouseOut(tooltip)
+    runTimers()
     expect(tooltip).not.toBeInTheDocument()
   })
 })

--- a/packages/components/src/utils/useHovered.spec.tsx
+++ b/packages/components/src/utils/useHovered.spec.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React, { useRef } from 'react'
 import { useHovered } from './useHovered'
@@ -41,15 +41,18 @@ const HoveredComponent = () => {
 }
 
 describe('useHovered', () => {
-  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>
   beforeEach(() => {
-    rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation((cb: any) => cb())
+    jest.useFakeTimers()
   })
+
   afterEach(() => {
-    rafSpy.mockRestore()
+    jest.useRealTimers()
   })
+
+  const runTimers = () =>
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
 
   it('toggles on hover', () => {
     render(<HoveredComponent />)
@@ -59,6 +62,7 @@ describe('useHovered', () => {
     userEvent.hover(hoverMe)
     expect(screen.getByText('button')).toBeVisible()
     userEvent.unhover(hoverMe)
+    runTimers()
     expect(screen.queryByText('button')).not.toBeInTheDocument()
   })
 
@@ -79,6 +83,7 @@ describe('useHovered', () => {
     expect(button).toBeVisible()
 
     userEvent.tab()
+    runTimers()
     expect(screen.queryByText('button')).not.toBeInTheDocument()
   })
 })

--- a/packages/components/src/utils/useScrollLock.spec.tsx
+++ b/packages/components/src/utils/useScrollLock.spec.tsx
@@ -31,9 +31,10 @@ import { useScrollLock, useToggle } from './'
 
 const globalConsole = global.console
 const warnMock = jest.fn()
-const paddingSpy = jest.spyOn(document.body.style, 'paddingRight', 'set')
+let paddingSpy: jest.SpyInstance<void, string[]>
 
 beforeEach(() => {
+  paddingSpy = jest.spyOn(document.body.style, 'paddingRight', 'set')
   global.console = ({
     ...globalConsole,
     warn: warnMock,


### PR DESCRIPTION
1. Match the `requestAnimationFrame` mock in jest setup with that in the core product.
2. Fix `paddingSpy` in `useScrollLock.spec.tsx` – not sure why it was working before but the core product wasn't having it.

I removed all existing instances of `jest.spyOn(window, 'requestAnimationFrame')`, since they are now redundant, except for two in `Combobox.spec` and `Select.spec`. Those will take some time to unwind so I want to save them for a follow-up (I created a ticket). In most cases an additional `runTimers()` call was necessary since the `requestAnimationFrame` mock uses a `setTimeout`.