### PR TITLE
fix: Export type for SpecifiableTextColors

### DIFF
--- a/packages/design-tokens/src/color/types/index.ts
+++ b/packages/design-tokens/src/color/types/index.ts
@@ -39,7 +39,12 @@ export type TextColors = TextColor
 export { coreColors, intentColors, specifiableColors } from './specifiable'
 
 export type { DerivativeColors } from './derivative'
-export type { CoreColors, IntentColors, SpecifiableColors } from './specifiable'
+export type {
+  CoreColors,
+  IntentColors,
+  SpecifiableColors,
+  SpecifiableTextColors,
+} from './specifiable'
 export type { BlendColors } from './blends'
 export type {
   ExtendedStatefulColor,


### PR DESCRIPTION
Core product uses deep-import to pull in `SpecifiableTextColors` type currently. This will be problematic once code is shifted to core monorepo (and there's not really a good argument _not_ to go ahead and export it anyway) :)