### PR TITLE
chore: Update postbuild script to copy readme

### DIFF
--- a/bin/publish-package-json.js
+++ b/bin/publish-package-json.js
@@ -40,7 +40,7 @@ const removeKeys = [
   'main',
   'scripts',
 ]
-removeKeys.map((key) => {
+removeKeys.map(key => {
   delete draft[key]
 })
 
@@ -66,3 +66,11 @@ fs.writeFile(
     console.log('complete')
   }
 )
+
+// Copy the README, if it exists, into the lib folders
+fs.copyFile('README.md', 'lib/README.md', err => {
+  if (err) {
+    console.error(err)
+  }
+  console.log('complete')
+})


### PR DESCRIPTION
Copy the README into the lib folder after building so that it appears on the NPM page.