### PR TITLE
Potential changes to Query

### DIFF
--- a/apps/vis-filter-demo/src/VisFilterDemo.tsx
+++ b/apps/vis-filter-demo/src/VisFilterDemo.tsx
@@ -134,9 +134,11 @@ const VisFilterDemoInternal: FC = () => {
         </Paragraph>
       )}
       {queryId && <Divider my="medium" />}
-      <Query query={queryId} sdk={core40SDK}>
-        <Visualization />
-      </Query>
+      {queryDetails && (
+        <Query query={queryId} queryResult={queryDetails} sdk={core40SDK}>
+          <Visualization />
+        </Query>
+      )}
     </Page>
   )
 }


### PR DESCRIPTION
Exploring a possible way to avoid duplicate calls to get query metadata in the Vis/Filter Demo app.

(There's currently a bug with this approach where if you try to re-submit the original query ID after filtering it, you still just get the filtered one.)