### PR TITLE
Adding future React.FC Provider support for typescript and react-18 users.

### DIFF
--- a/packages/components-providers/src/ComponentsProvider.tsx
+++ b/packages/components-providers/src/ComponentsProvider.tsx
@@ -30,7 +30,7 @@ import {
   theme as defaultTheme,
 } from '@looker/design-tokens'
 import type { FC } from 'react'
-import React, { Fragment, useMemo } from 'react'
+import React, { Fragment, PropsWithChildren, useMemo } from 'react'
 import { HelmetProvider } from 'react-helmet-async'
 import { FocusTrapProvider } from './FocusTrap'
 import { ScrollLockProvider } from './ScrollLock'
@@ -41,34 +41,35 @@ import { ThemeProvider } from './ThemeProvider'
 import type { ExtendComponentsTheme } from './ExtendComponentsProvider'
 import { FontFaceLoader } from './FontFaceLoader'
 import { StyleDefender } from './StyleDefender'
-export interface ComponentsProviderProps
-  extends ThemeProviderProps,
-    ExtendComponentsTheme,
-    UseI18nProps,
-    React.PropsWithChildren<{}> {
-  /**
-   * Load any font faces specified on theme.fontSources
-   * @default true
-   */
-  loadFontSources?: boolean
-  /**
-   * Load fonts from the Google Fonts CDN if not already available
-   * @default false
-   */
-  loadGoogleFonts?: boolean
+export type ComponentsProviderProps = PropsWithChildren<
+  ThemeProviderProps &
+  ExtendComponentsTheme &
+  UseI18nProps &
+  {
+    /**
+     * Load any font faces specified on theme.fontSources
+     * @default true
+     */
+    loadFontSources?: boolean
+    /**
+     * Load fonts from the Google Fonts CDN if not already available
+     * @default false
+     */
+    loadGoogleFonts?: boolean
 
-  /**
-   * Disables the "StyleDefender"
-   *
-   * StyledDefender is a utility component that attempts to ensure that a few common
-   * styles are injected at any point where @looker/components are injected into the DOM.
-   * When taking code-snapshots (a pattern we generally discourage) the `StyleDefender`
-   * may be visible in output so we generally recommend disabling it for those use-cases.
-   *
-   * @default false
-   */
-  disableStyleDefender?: boolean
-}
+    /**
+     * Disables the "StyleDefender"
+     *
+     * StyledDefender is a utility component that attempts to ensure that a few common
+     * styles are injected at any point where @looker/components are injected into the DOM.
+     * When taking code-snapshots (a pattern we generally discourage) the `StyleDefender`
+     * may be visible in output so we generally recommend disabling it for those use-cases.
+     *
+     * @default false
+     */
+    disableStyleDefender?: boolean
+  }
+>
 
 /**
  * ComponentsProvider registers fundamental infrastructure for @looker/components to

--- a/packages/components-providers/src/ComponentsProvider.tsx
+++ b/packages/components-providers/src/ComponentsProvider.tsx
@@ -29,8 +29,8 @@ import {
   googleFontUrl,
   theme as defaultTheme,
 } from '@looker/design-tokens'
-import type { FC } from 'react'
-import React, { Fragment, PropsWithChildren, useMemo } from 'react'
+import type { FC, PropsWithChildren } from 'react'
+import React, { Fragment, useMemo } from 'react'
 import { HelmetProvider } from 'react-helmet-async'
 import { FocusTrapProvider } from './FocusTrap'
 import { ScrollLockProvider } from './ScrollLock'

--- a/packages/components-providers/src/ComponentsProvider.tsx
+++ b/packages/components-providers/src/ComponentsProvider.tsx
@@ -44,7 +44,8 @@ import { StyleDefender } from './StyleDefender'
 export interface ComponentsProviderProps
   extends ThemeProviderProps,
     ExtendComponentsTheme,
-    UseI18nProps {
+    UseI18nProps,
+    React.PropsWithChildren<{}> {
   /**
    * Load any font faces specified on theme.fontSources
    * @default true

--- a/packages/components-providers/src/ExtendComponentsProvider.tsx
+++ b/packages/components-providers/src/ExtendComponentsProvider.tsx
@@ -30,7 +30,7 @@ import { ThemeProvider, useTheme } from 'styled-components'
 import type { FC } from 'react'
 import React, { useMemo } from 'react'
 
-export interface ExtendComponentsTheme {
+export interface ExtendComponentsTheme extends React.PropsWithChildren<{}> {
   themeCustomizations?: ThemeCustomizations
 }
 

--- a/packages/components-providers/src/ExtendComponentsProvider.tsx
+++ b/packages/components-providers/src/ExtendComponentsProvider.tsx
@@ -27,14 +27,12 @@
 import type { ThemeCustomizations } from '@looker/design-tokens'
 import { generateTheme } from '@looker/design-tokens'
 import { ThemeProvider, useTheme } from 'styled-components'
-import type { FC } from 'react'
+import type { FC, PropsWithChildren } from 'react'
 import React, { useMemo } from 'react'
 
-export type ExtendComponentsTheme = React.PropsWithChildren<{
+export type ExtendComponentsTheme = PropsWithChildren<{
   themeCustomizations?: ThemeCustomizations
 }>
-  themeCustomizations?: ThemeCustomizations
-}
 
 /**
  * This component is designed for making adjustments to the Theme without

--- a/packages/components-providers/src/ThemeProvider.tsx
+++ b/packages/components-providers/src/ThemeProvider.tsx
@@ -23,15 +23,15 @@
  SOFTWARE.
 
  */
-import type { FC } from 'react'
+import type { FC, PropsWithChildren } from 'react'
 import React from 'react'
 import type { Theme } from '@looker/design-tokens'
 import { theme as builtIn } from '@looker/design-tokens'
 import { ThemeProvider as ActualThemeProvider } from 'styled-components'
 
-export interface ThemeProviderProps extends React.PropsWithChildren<{}> {
+export type ThemeProviderProps = PropsWithChildren<{
   theme?: Theme
-}
+}>
 
 export const ThemeProvider: FC<ThemeProviderProps> = ({
   children,

--- a/packages/components-providers/src/ThemeProvider.tsx
+++ b/packages/components-providers/src/ThemeProvider.tsx
@@ -29,7 +29,7 @@ import type { Theme } from '@looker/design-tokens'
 import { theme as builtIn } from '@looker/design-tokens'
 import { ThemeProvider as ActualThemeProvider } from 'styled-components'
 
-export interface ThemeProviderProps {
+export interface ThemeProviderProps extends React.PropsWithChildren<{}> {
   theme?: Theme
 }
 


### PR DESCRIPTION
# What changed?

React 18 `React.FC` no longer supports implicit children. Developers using React 18 and typescript will get type errors when using the `ComponentsProviders`. This PR adds `React.PropsWithChildren<{}>` to the providers' props to add future support for React 18 users.

**Issue** https://github.com/looker-open-source/components/issues/2975