### PR TITLE
fix(components-data): ensure all IDs are strings instead of numbers

### DIFF
--- a/packages/components-data/src/hooks/useDataState.ts
+++ b/packages/components-data/src/hooks/useDataState.ts
@@ -54,20 +54,20 @@ export type DataStore = {
 type UpdateByDashboardID = {
   type: 'update_by_dashboard_id';
   payload: {
-    dashboardId: number;
-    id: number;
+    dashboardId: string;
+    id: string;
     queryInfo: Partial<QueryAttributes>;
   };
 };
 
 type UpdateBySlug = {
   type: 'update_by_slug';
-  payload: { slug: string; id: number; queryInfo: Partial<QueryAttributes> };
+  payload: { slug: string; id: string; queryInfo: Partial<QueryAttributes> };
 };
 
 type UpdateByID = {
   type: 'update_by_id';
-  payload: { id: number; queryInfo: Partial<QueryAttributes> };
+  payload: { id: string; queryInfo: Partial<QueryAttributes> };
 };
 
 type UpdateModelView = {
@@ -164,28 +164,28 @@ const useDataState = (initialState = defaultInitialState) => {
   const [{ dashboardIdMap, slugIdMap, byId, modelExplore }, dispatch] =
     useReducer(reducer, initialState);
 
-  const getIdFromDashboard = (dashboardId?: number) =>
+  const getIdFromDashboard = (dashboardId?: string) =>
     dashboardId && dashboardIdMap[dashboardId];
 
   const getIdFromSlug = (slug: string) => slugIdMap[slug];
 
   const getById = <K extends keyof QueryAttributes>(
-    id: number,
+    id: string,
     key: K
   ): Partial<QueryAttributes>[K] => byId[id]?.[key];
 
-  const setById = (id: number, queryInfo: Partial<QueryAttributes>) =>
+  const setById = (id: string, queryInfo: Partial<QueryAttributes>) =>
     dispatch({ payload: { id, queryInfo }, type: 'update_by_id' });
 
   const setBySlug = (
     slug: string,
-    id: number,
+    id: string,
     queryInfo: Partial<QueryAttributes>
   ) => dispatch({ payload: { id, queryInfo, slug }, type: 'update_by_slug' });
 
   const setByDashboardId = (
-    dashboardId: number,
-    queryId: number,
+    dashboardId: string,
+    queryId: string,
     queryInfo: Partial<QueryAttributes>
   ) => {
     dispatch({

--- a/packages/components-data/src/hooks/useExplore.spec.tsx
+++ b/packages/components-data/src/hooks/useExplore.spec.tsx
@@ -39,7 +39,7 @@ type TestComponentProps = {
   id?: string;
 };
 
-const TestComponent = ({ id = 1 }: TestComponentProps) => {
+const TestComponent = ({ id = '1' }: TestComponentProps) => {
   const response = useExplore(id);
   dataContainerListener(response);
   return null;

--- a/packages/components-data/src/hooks/useExplore.spec.tsx
+++ b/packages/components-data/src/hooks/useExplore.spec.tsx
@@ -36,7 +36,7 @@ import { useExplore } from './useExplore';
 const dataContainerListener = jest.fn();
 
 type TestComponentProps = {
-  id?: number;
+  id?: string;
 };
 
 const TestComponent = ({ id = 1 }: TestComponentProps) => {
@@ -83,7 +83,7 @@ describe('useExplore', () => {
           slugIdMap: {},
         }}
       >
-        <TestComponent id={456} />
+        <TestComponent id={'456'} />
       </ContextWrapper>
     );
 

--- a/packages/components-data/src/hooks/useExplore.ts
+++ b/packages/components-data/src/hooks/useExplore.ts
@@ -41,7 +41,7 @@ import { useSDK, useQueryMetadata, DataState } from '.';
  * @returns field groups and api state
  */
 
-export const useExplore = (id: number) => {
+export const useExplore = (id: string) => {
   const sdk = useSDK();
   const { setModelExplore, getModelExplore } = DataState.useContainer();
 
@@ -60,7 +60,7 @@ export const useExplore = (id: number) => {
    */
 
   const fetcher = async () => {
-    if (id > 0 && model && view && isEmpty(explore)) {
+    if (id && model && view && isEmpty(explore)) {
       return await sdk.lookml_model_explore(model, view);
     }
 

--- a/packages/components-data/src/hooks/useFieldGroups.spec.tsx
+++ b/packages/components-data/src/hooks/useFieldGroups.spec.tsx
@@ -36,7 +36,7 @@ import { useFieldGroups } from './useFieldGroups';
 const dataContainerListener = jest.fn();
 
 type TestComponentProps = {
-  id?: number;
+  id?: string;
 };
 
 const TestComponent = ({ id = 1 }: TestComponentProps) => {
@@ -83,7 +83,7 @@ describe('useFieldGroups', () => {
           slugIdMap: {},
         }}
       >
-        <TestComponent id={456} />
+        <TestComponent id={'456'} />
       </ContextWrapper>
     );
 

--- a/packages/components-data/src/hooks/useQueryData.spec.tsx
+++ b/packages/components-data/src/hooks/useQueryData.spec.tsx
@@ -33,10 +33,10 @@ import { useQueryData } from './useQueryData';
 const dataContainerListener = jest.fn();
 
 type TestComponentProps = {
-  queryId?: number;
+  queryId?: string;
 };
 
-const TestComponent = ({ queryId = 1 }: TestComponentProps) => {
+const TestComponent = ({ queryId = '1' }: TestComponentProps) => {
   const response = useQueryData(queryId);
   dataContainerListener(response);
   return null;
@@ -67,7 +67,7 @@ describe('useQueryData', () => {
   it('does not dispatch request if data query id is out of range', async () => {
     render(
       <ContextWrapper>
-        <TestComponent queryId={-1} />
+        <TestComponent queryId={''} />
       </ContextWrapper>
     );
 
@@ -96,10 +96,10 @@ describe('useQueryData', () => {
           },
           dashboardIdMap: {},
           modelExplore: {},
-          slugIdMap: { '123': 123 },
+          slugIdMap: { '123': '123' },
         }}
       >
-        <TestComponent queryId={123} />
+        <TestComponent queryId={'123'} />
       </ContextWrapper>
     );
 

--- a/packages/components-data/src/hooks/useQueryData.ts
+++ b/packages/components-data/src/hooks/useQueryData.ts
@@ -63,7 +63,7 @@ type RunQueryReturnType = SDKResponse<IQueryExtended, IError>;
  * @returns normalized data, fields, totals, and async request state
  */
 
-export const useQueryData = (id: number, agentTag?: string) => {
+export const useQueryData = (id: string, agentTag?: string) => {
   const sdk = useSDK();
   const { getById, setById } = DataState.useContainer();
 

--- a/packages/components-data/src/hooks/useQueryId.spec.tsx
+++ b/packages/components-data/src/hooks/useQueryId.spec.tsx
@@ -39,7 +39,7 @@ describe('useQueryId', () => {
 
     expect(dataContainerListener).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryId: 126,
+        queryId: '126',
       })
     );
   });
@@ -51,7 +51,7 @@ describe('useQueryId', () => {
           byId: {},
           dashboardIdMap: {},
           modelExplore: {},
-          slugIdMap: { qz123: 456 },
+          slugIdMap: { qz123: '456' },
         }}
       >
         <TestComponent slug={'qz123'} />
@@ -62,7 +62,7 @@ describe('useQueryId', () => {
       expect(dataContainerListener).toHaveBeenCalledWith({
         isOK: true,
         isPending: false,
-        queryId: 456,
+        queryId: '456',
       })
     );
 

--- a/packages/components-data/src/hooks/useQueryId.ts
+++ b/packages/components-data/src/hooks/useQueryId.ts
@@ -92,8 +92,8 @@ export const useQueryId = (slugOrId: string | number = '') => {
 
     const draftQuery = { ...cachedQuery, ...SWRValue };
 
-    if (id && Number(id) !== queryId) {
-      setBySlug(querySlug, Number(id), { metadata: draftQuery });
+    if (id && id !== queryId) {
+      setBySlug(querySlug, id, { metadata: draftQuery });
     }
   }, [SWRData, queryId, querySlug, setBySlug, cachedQuery]);
 

--- a/packages/components-data/src/hooks/useQueryIdFromDashboard.spec.tsx
+++ b/packages/components-data/src/hooks/useQueryIdFromDashboard.spec.tsx
@@ -12,10 +12,10 @@ import { useQueryIdFromDashboard } from './useQueryIdFromDashboard';
 const dataContainerListener = jest.fn();
 
 type TestComponentProps = {
-  dashboardId?: number;
+  dashboardId?: string;
 };
 
-const TestComponent = ({ dashboardId = 1 }: TestComponentProps) => {
+const TestComponent = ({ dashboardId = '1' }: TestComponentProps) => {
   const response = useQueryIdFromDashboard(dashboardId);
   dataContainerListener(response);
   return null;
@@ -35,7 +35,7 @@ describe('useQueryIdFromDashboard', () => {
     await waitFor(() =>
       expect(dataContainerListener).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryId: 126,
+          queryId: '126',
         })
       )
     );
@@ -47,12 +47,12 @@ describe('useQueryIdFromDashboard', () => {
       <ContextWrapper
         initialState={{
           byId: {},
-          dashboardIdMap: { 456: 789 },
+          dashboardIdMap: { '456': '789' },
           modelExplore: {},
           slugIdMap: {},
         }}
       >
-        <TestComponent dashboardId={456} />
+        <TestComponent dashboardId={'456'} />
       </ContextWrapper>
     );
 
@@ -60,7 +60,7 @@ describe('useQueryIdFromDashboard', () => {
       expect(dataContainerListener).toHaveBeenCalledWith({
         isOK: true,
         isPending: false,
-        queryId: 789,
+        queryId: '789',
       })
     );
 

--- a/packages/components-data/src/hooks/useQueryIdFromDashboard.ts
+++ b/packages/components-data/src/hooks/useQueryIdFromDashboard.ts
@@ -19,7 +19,7 @@ import { useSDK } from './useSDK';
  * @returns the query ID associated with the first dashboard tile, and api state
  */
 
-export const useQueryIdFromDashboard = (dashboardId?: number) => {
+export const useQueryIdFromDashboard = (dashboardId?: string) => {
   const sdk = useSDK();
   const { getIdFromDashboard, setByDashboardId } = DataState.useContainer();
 
@@ -64,8 +64,8 @@ export const useQueryIdFromDashboard = (dashboardId?: number) => {
 
     const { id, ...query } = firstTile || ({} as IQuery);
 
-    if (dashboardId && id && Number(id) !== queryId) {
-      setByDashboardId(dashboardId, Number(id), { metadata: query });
+    if (dashboardId && id && id !== queryId) {
+      setByDashboardId(dashboardId, id, { metadata: query });
     }
   }, [SWRData, dashboardId, setByDashboardId, queryId]);
 

--- a/packages/components-data/src/hooks/useQueryMetadata.spec.tsx
+++ b/packages/components-data/src/hooks/useQueryMetadata.spec.tsx
@@ -34,10 +34,10 @@ import { useQueryMetadata } from './useQueryMetadata';
 const dataContainerListener = jest.fn();
 
 type TestComponentProps = {
-  queryId?: number;
+  queryId?: string;
 };
 
-const TestComponent = ({ queryId = 1 }: TestComponentProps) => {
+const TestComponent = ({ queryId = '1' }: TestComponentProps) => {
   const response = useQueryMetadata(queryId);
   dataContainerListener(response);
   return null;
@@ -89,7 +89,7 @@ describe('useQueryMetadata', () => {
           slugIdMap: {},
         }}
       >
-        <TestComponent queryId={456} />
+        <TestComponent queryId={'456'} />
       </ContextWrapper>
     );
     await waitFor(() =>

--- a/packages/components-data/src/hooks/useQueryMetadata.ts
+++ b/packages/components-data/src/hooks/useQueryMetadata.ts
@@ -44,7 +44,7 @@ import { DataState } from './useDataState';
  * @returns metadata object and api state
  */
 
-export const useQueryMetadata = (id: number) => {
+export const useQueryMetadata = (id: string) => {
   const sdk = useSDK();
   const { getById, setById } = DataState.useContainer();
 
@@ -65,7 +65,7 @@ export const useQueryMetadata = (id: number) => {
 
   const fetcher = async () => {
     if (
-      id > 0 &&
+      id &&
       (isEmpty(metadata.vis_config) || !metadata.model || !metadata.view)
     ) {
       return await sdk.query(String(id));

--- a/packages/components-data/src/hooks/useVisConfig.spec.tsx
+++ b/packages/components-data/src/hooks/useVisConfig.spec.tsx
@@ -36,7 +36,7 @@ type TestComponentProps = {
   queryId?: string;
 };
 
-const TestComponent = ({ queryId = 1 }: TestComponentProps) => {
+const TestComponent = ({ queryId = '1' }: TestComponentProps) => {
   const response = useVisConfig(queryId);
   dataContainerListener(response);
   return null;

--- a/packages/components-data/src/hooks/useVisConfig.spec.tsx
+++ b/packages/components-data/src/hooks/useVisConfig.spec.tsx
@@ -33,7 +33,7 @@ import { useVisConfig } from './useVisConfig';
 const dataContainerListener = jest.fn();
 
 type TestComponentProps = {
-  queryId?: number;
+  queryId?: string;
 };
 
 const TestComponent = ({ queryId = 1 }: TestComponentProps) => {
@@ -71,7 +71,7 @@ describe('useVisConfig', () => {
       <ContextWrapper
         initialState={{
           byId: {
-            456: {
+            '456': {
               metadata: {
                 model: 'thelook',
                 view: 'orders',
@@ -84,7 +84,7 @@ describe('useVisConfig', () => {
           slugIdMap: {},
         }}
       >
-        <TestComponent queryId={456} />
+        <TestComponent queryId={'456'} />
       </ContextWrapper>
     );
 

--- a/packages/components-data/src/hooks/useVisConfig.ts
+++ b/packages/components-data/src/hooks/useVisConfig.ts
@@ -43,7 +43,7 @@ import { useQueryData, useQueryMetadata } from '.';
  * @returns final visConfig object and api state
  */
 
-export const useVisConfig = (id: number, configOverrides?: Partial<CAll>) => {
+export const useVisConfig = (id: string, configOverrides?: Partial<CAll>) => {
   /*
    * Check for stored values
    * -----------------------------------------------------------


### PR DESCRIPTION
Since all IDs in API 4.0 are strings and query IDs now cannot be numeric, this change removes any number casting for IDs and sets the type for all dashboard and query IDs to `string` from `number`.

Fixes #2997